### PR TITLE
Publish to beta GCS as well.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -83,11 +83,20 @@ jobs:
         run: mvn -ntp package
       - run: mkdir -p target/artifacts && cp target/LogManager.jar target/artifacts/aws.greengrass.LogManager.jar
       - uses: ./.github/actions/aws-greengrass-component-upload-action
-        name: Upload to GCS
+        name: Upload to GCS beta
         env:
           AWS_REGION: us-east-1
         with:
           recipePath: recipe.yaml
           artifactDirectoryPath: target/artifacts
-          endpoint: https://nztb5z87k6.execute-api.us-east-1.amazonaws.com/Gamma
+          endpoint: https://evergreen-beta.us-east-1.amazonaws.com
+          autoBumpVersion: true
+      - uses: ./.github/actions/aws-greengrass-component-upload-action
+        name: Upload to GCS gamma
+        env:
+          AWS_REGION: us-east-1
+        with:
+          recipePath: recipe.yaml
+          artifactDirectoryPath: target/artifacts
+          endpoint: https://evergreen-gamma.us-east-1.amazonaws.com
           autoBumpVersion: true


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Log Manager should be published to beta GCS registry since UATs are running in beta.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
