### PR TITLE
Update DeploymentService function names to get groups

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
+++ b/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
@@ -326,7 +326,7 @@ public class CloudWatchAttemptLogsProcessor {
      * @param data                  The log line read from the file.
      * @return whether or not the maximum message size has reached or not.
      * @implNote We need to add extra bytes size for every input message as well as the timestamp byte size alongwith
-     * the log line data size to get the exact size of the input log events.
+     *     the log line data size to get the exact size of the input log events.
      */
     private boolean addNewLogEvent(AtomicInteger totalBytesRead, CloudWatchAttemptLogInformation attemptLogInformation,
                                    String data) {

--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
@@ -84,9 +84,9 @@ public class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     private void mockDefaultGetGroups() throws ServiceLoadException {
         lenient().when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
         lenient().when(mockDeploymentService.getGroupNamesForUserComponent(anyString()))
-                .thenReturn(new HashSet<>(Collections.singletonList("arn:aws:greengrass:testRegion:12345:configuration:testGroup2:12")));
+                .thenReturn(new HashSet<>(Collections.singletonList("testGroup2")));
         lenient().when(mockDeploymentService.getAllGroupNames())
-                .thenReturn(new HashSet<>(Collections.singletonList("arn:aws:greengrass:testRegion:12345:configuration:testGroup1:12")));
+                .thenReturn(new HashSet<>(Collections.singletonList("testGroup1")));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Get the group name from the fleet config arn and use it to generate the log stream names.

**Why is this change necessary:**

Log stream name should contain thing group names only, not the entire config arn.

**How was this change tested:**

Unit tests.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
