### PR TITLE
Do not upload if there are not input log events to upload.

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/CloudWatchLogsUploader.java
+++ b/src/main/java/com/aws/greengrass/logmanager/CloudWatchLogsUploader.java
@@ -101,6 +101,12 @@ public class CloudWatchLogsUploader {
                     logEvents.size(), logGroupName, logStreamName, MAX_RETRIES);
             return false;
         }
+        // If there are no logs available to upload, then return true so that we don't read those files again.
+        // This can occur if the log files read have logs below the desired log level.
+        // By returning true, we will ensure that we won't read those log files again.
+        if (logEvents.isEmpty()) {
+            return true;
+        }
         logger.atTrace().log("Uploading {} logs to {}-{}", logEvents.size(), logGroupName, logStreamName);
         AtomicReference<String> sequenceToken = new AtomicReference<>();
         logGroupsToSequenceTokensMap.computeIfPresent(logGroupName, (groupName, streamToSequenceTokenMap) -> {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Return before trying to upload to Cloud Watch if there are not logs to upload. 

**Why is this change necessary:**
This will cause no logs to be uploaded since it causes a 400 when we call `putlogevents`. We do not need to upload if there are no logs, also we don't need to reread the log files again.

Also should fix the flaky UAT.

**How was this change tested:**
Added unit tests.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
