### PR TITLE
Update for Log SDK change

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,12 +16,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          # Only restore maven cache for this exact commit. If we start incrementing the version
-          # of our Java SDK, then we can relax this to just the "hashFiles" and exclude "sha"
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
       - run: rm -rf /tmp/*
         continue-on-error: true
       - run: rm -rf ~/.m2/repository/com/aws/iot/evergreen-kernel

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -183,9 +183,10 @@ public class LogManagerService extends PluginService {
 
     private void addSystemLogsConfiguration(Map<String, ComponentLogConfiguration> newComponentLogConfigurations,
                                             SystemLogsConfiguration systemLogsConfiguration) {
-        Path logsDirectoryPath = Paths.get(LogManager.getConfig().getStoreName()).getParent();
+        Path logsDirectoryPath = Paths.get(LogManager.getRootLogConfiguration().getStoreName()).getParent();
         ComponentLogConfiguration systemConfiguration = ComponentLogConfiguration.builder()
-                .fileNameRegex(Pattern.compile(String.format(DEFAULT_FILE_REGEX, LogManager.getConfig().getFileName())))
+                .fileNameRegex(Pattern.compile(String.format(DEFAULT_FILE_REGEX,
+                        LogManager.getRootLogConfiguration().getFileName())))
                 .directoryPath(logsDirectoryPath)
                 .name(SYSTEM_LOGS_COMPONENT_NAME)
                 .componentType(ComponentType.GreengrassSystemComponent)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Update for changed logging SDK interface which caused a runtime error due to mismatched interfaces.

Removes cache because it doesn't buy us anything since we run on our own hosts which keep all the maven artifacts anyway. Caching only slows us down


**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
