### PR TITLE
Don't set store path. Set store directory.

### DIFF
--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -106,7 +106,7 @@ public class LogManagerServiceTest extends GGServiceTestUtil {
     static void setupBefore() throws IOException, InterruptedException {
         LogConfig.getInstance().setLevel(Level.TRACE);
         LogConfig.getInstance().setStoreType(LogStore.FILE);
-        LogConfig.getInstance().setStorePath(directoryPath.resolve("greengrass.log"));
+        LogConfig.getInstance().setStoreDirectory(directoryPath);
         for (int i = 0; i < 5; i++) {
             File file = new File(directoryPath.resolve("greengrass_test_" + i + ".log").toUri());
             assertTrue(file.createNewFile());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Changes to logging framework to set the store directory instead of the store name.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
