### PR TITLE
fix: Send the correct timestamp to CloudWatch when uploading logs.

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/logmanager/LogManagerTest.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -123,6 +124,7 @@ class LogManagerTest extends BaseITCase {
     void beforeEach(ExtensionContext context) {
         ignoreExceptionOfType(context, TLSAuthException.class);
         ignoreExceptionOfType(context, InterruptedException.class);
+        ignoreExceptionOfType(context, DateTimeParseException.class);
     }
 
     @AfterEach

--- a/src/integrationtests/java/com/aws/greengrass/logmanager/SpaceManagementTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/logmanager/SpaceManagementTest.java
@@ -34,6 +34,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,6 +66,7 @@ class SpaceManagementTest extends BaseITCase {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, TLSAuthException.class);
         ignoreExceptionOfType(context, NoSuchFileException.class);
+        ignoreExceptionOfType(context, DateTimeParseException.class);
         LogManager.getRootLogConfiguration().setLevel(Level.DEBUG);
     }
 

--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.event.Level;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,6 +38,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -60,7 +65,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
+class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     private static final SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy/MM/dd", Locale.ENGLISH);
     @Mock
     private DeviceConfiguration mockDeviceConfiguration;
@@ -90,7 +95,7 @@ public class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     }
 
     @Test
-    public void GIVEN_one_system_component_one_file_less_than_max_WHEN_merge_THEN_reads_entire_file()
+    void GIVEN_one_system_component_one_file_less_than_max_WHEN_merge_THEN_reads_entire_file()
             throws URISyntaxException, ServiceLoadException {
         mockDefaultGetGroups();
         File file1 = new File(getClass().getResource("testlogs2.log").toURI());
@@ -115,15 +120,23 @@ public class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream));
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
         assertNotNull(logEventsForStream1.getLogEvents());
-        assertEquals(7, logEventsForStream1.getLogEvents().size());
+        assertEquals(13, logEventsForStream1.getLogEvents().size());
         assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file1.getAbsolutePath()));
         assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getStartPosition());
-        assertEquals(13, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
+        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
         assertEquals("TestComponent", logEventsForStream1.getComponentName());
+        for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
+            Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
+            assertTrue(logTimestamp.isBefore(Instant.now()));
+            LocalDateTime localDate = LocalDateTime.ofInstant(logTimestamp, ZoneOffset.UTC);
+            assertEquals(2020, localDate.getYear());
+            assertEquals(12, localDate.getMonth().getValue());
+            assertEquals(17, localDate.getDayOfMonth());
+        }
     }
 
     @Test
-    public void GIVEN_one_user_component_one_file_less_than_max_WHEN_merge_THEN_reads_entire_file()
+    void GIVEN_one_user_component_one_file_less_than_max_WHEN_merge_THEN_reads_entire_file()
             throws URISyntaxException, ServiceLoadException {
         mockDefaultGetGroups();
         File file1 = new File(getClass().getResource("testlogs2.log").toURI());
@@ -148,15 +161,23 @@ public class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream));
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
         assertNotNull(logEventsForStream1.getLogEvents());
-        assertEquals(7, logEventsForStream1.getLogEvents().size());
+        assertEquals(13, logEventsForStream1.getLogEvents().size());
         assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file1.getAbsolutePath()));
         assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getStartPosition());
-        assertEquals(13, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
+        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
         assertEquals("TestComponent", logEventsForStream1.getComponentName());
+        for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
+            Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
+            assertTrue(logTimestamp.isBefore(Instant.now()));
+            LocalDateTime localDate = LocalDateTime.ofInstant(logTimestamp, ZoneOffset.UTC);
+            assertEquals(2020, localDate.getYear());
+            assertEquals(12, localDate.getMonth().getValue());
+            assertEquals(17, localDate.getDayOfMonth());
+        }
     }
 
     @Test
-    public void GIVEN_one_component_one_file_less_than_max_WHEN_no_group_THEN_reads_entire_file_and_sets_group_correctly()
+    void GIVEN_one_component_one_file_less_than_max_WHEN_no_group_THEN_reads_entire_file_and_sets_group_correctly()
             throws URISyntaxException, ServiceLoadException {
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
         lenient().when(mockDeploymentService.getGroupNamesForUserComponent(anyString()))
@@ -186,15 +207,23 @@ public class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream));
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
         assertNotNull(logEventsForStream1.getLogEvents());
-        assertEquals(7, logEventsForStream1.getLogEvents().size());
+        assertEquals(13, logEventsForStream1.getLogEvents().size());
         assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file1.getAbsolutePath()));
         assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getStartPosition());
-        assertEquals(13, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
+        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
         assertEquals("TestComponent", logEventsForStream1.getComponentName());
+        for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
+            Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
+            assertTrue(logTimestamp.isBefore(Instant.now()));
+            LocalDateTime localDate = LocalDateTime.ofInstant(logTimestamp, ZoneOffset.UTC);
+            assertEquals(2020, localDate.getYear());
+            assertEquals(12, localDate.getMonth().getValue());
+            assertEquals(17, localDate.getDayOfMonth());
+        }
     }
 
     @Test
-    public void GIVEN_one_component_one_file_less_than_max_WHEN_locate_throws_ServiceLoadException_THEN_reads_entire_file_and_sets_group_correctly(
+    void GIVEN_one_component_one_file_less_than_max_WHEN_locate_throws_ServiceLoadException_THEN_reads_entire_file_and_sets_group_correctly(
             ExtensionContext context1) throws URISyntaxException, ServiceLoadException {
         ignoreExceptionOfType(context1, ServiceLoadException.class);
         when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenThrow(ServiceLoadException.class);
@@ -221,17 +250,26 @@ public class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream));
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
         assertNotNull(logEventsForStream1.getLogEvents());
-        assertEquals(7, logEventsForStream1.getLogEvents().size());
+        assertEquals(13, logEventsForStream1.getLogEvents().size());
         assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file1.getAbsolutePath()));
         assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getStartPosition());
-        assertEquals(13, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
+        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
         assertEquals("TestComponent", logEventsForStream1.getComponentName());
+        for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
+            Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
+            assertTrue(logTimestamp.isBefore(Instant.now()));
+            LocalDateTime localDate = LocalDateTime.ofInstant(logTimestamp, ZoneOffset.UTC);
+            assertEquals(2020, localDate.getYear());
+            assertEquals(12, localDate.getMonth().getValue());
+            assertEquals(17, localDate.getDayOfMonth());
+        }
     }
 
     @Test
-    public void GIVEN_one_component_one_file_more_than_max_WHEN_merge_THEN_reads_partial_file()
+    void GIVEN_one_component_one_file_more_than_max_WHEN_merge_THEN_reads_partial_file(ExtensionContext context1)
             throws IOException, ServiceLoadException {
         mockDefaultGetGroups();
+        ignoreExceptionOfType(context1, DateTimeParseException.class);
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
         assertTrue(file.createNewFile());
         assertTrue(file.setReadable(true));
@@ -275,13 +313,22 @@ public class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath()).getStartPosition());
             assertEquals(1016766, logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath()).getBytesRead());
             assertEquals("TestComponent", logEventsForStream1.getComponentName());
+            LocalDateTime localDateTimeNow = LocalDateTime.now();
+            for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
+                Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
+                assertTrue(logTimestamp.isBefore(Instant.now()));
+                LocalDateTime localDate = LocalDateTime.ofInstant(logTimestamp, ZoneOffset.UTC);
+                assertEquals(localDateTimeNow.getYear(), localDate.getYear());
+                assertEquals(localDateTimeNow.getMonth().getValue(), localDate.getMonth().getValue());
+                assertEquals(localDateTimeNow.getDayOfMonth(), localDate.getDayOfMonth());
+            }
         } finally {
             assertTrue(file.delete());
         }
     }
 
     @Test
-    public void GIVEN_one_components_two_file_less_than_max_WHEN_merge_THEN_reads_and_merges_both_files()
+    void GIVEN_one_components_two_file_less_than_max_WHEN_merge_THEN_reads_and_merges_both_files()
             throws URISyntaxException, ServiceLoadException {
         mockDefaultGetGroups();
         File file1 = new File(getClass().getResource("testlogs2.log").toURI());
@@ -312,11 +359,19 @@ public class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
         CloudWatchAttemptLogInformation logEventsForStream2 = attempt.getLogStreamsToLogEventsMap().get(logStream2);
         assertNotNull(logEventsForStream1.getLogEvents());
-        assertEquals(7, logEventsForStream1.getLogEvents().size());
+        assertEquals(13, logEventsForStream1.getLogEvents().size());
         assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file1.getAbsolutePath()));
         assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getStartPosition());
-        assertEquals(13, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
+        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
         assertEquals("TestComponent", logEventsForStream1.getComponentName());
+        for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
+            Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
+            assertTrue(logTimestamp.isBefore(Instant.now()));
+            LocalDateTime localDate = LocalDateTime.ofInstant(logTimestamp, ZoneOffset.UTC);
+            assertEquals(2020, localDate.getYear());
+            assertEquals(12, localDate.getMonth().getValue());
+            assertEquals(17, localDate.getDayOfMonth());
+        }
 
         assertNotNull(logEventsForStream2.getLogEvents());
         assertEquals(4, logEventsForStream2.getLogEvents().size());

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -367,6 +367,13 @@ class LogManagerServiceTest extends GGServiceTestUtil {
 
         Topics componentTopics3 = mock(Topics.class);
         doNothing().when(componentTopics3).replaceAndWait(replaceAndWaitCaptor.capture());
+        Topics runtimeConfig = mock(Topics.class);
+        when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC))
+                .thenReturn(runtimeConfig);
+        when(runtimeConfig.lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION, "TestComponent2"))
+                .thenReturn(componentTopics3);
+        when(runtimeConfig.lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, "TestComponent"))
+                .thenReturn(componentTopics2);
 
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logStreamsToLogInformationMap = new HashMap<>();
@@ -375,7 +382,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         Map<String, CloudWatchAttemptLogFileInformation> attemptLogFileInformationMap1 = new HashMap<>();
         attemptLogFileInformationMap1.put(file1.getAbsolutePath(), CloudWatchAttemptLogFileInformation.builder()
                 .startPosition(0)
-                .bytesRead(13)
+                .bytesRead(2943)
                 .lastModifiedTime(file1.lastModified())
                 .build());
         Map<String, CloudWatchAttemptLogFileInformation> attemptLogFileInformationMap2 = new HashMap<>();
@@ -398,12 +405,6 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         attempt.setLogStreamsToLogEventsMap(logStreamsToLogInformationMap);
         attempt.setLogStreamUploadedSet(new HashSet<>(Arrays.asList("testStream", "testStream2")));
         doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
-        when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
-                .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION, "TestComponent2"))
-                .thenReturn(componentTopics3);
-        when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
-                .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, "TestComponent"))
-                .thenReturn(componentTopics2);
 
         logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor);
         startServiceOnAnotherThread();

--- a/src/test/resources/com/aws/greengrass/logmanager/testlogs2.log
+++ b/src/test/resources/com/aws/greengrass/logmanager/testlogs2.log
@@ -1,7 +1,13 @@
-1
-2
-3
-4
-5
-6
-7
+2020-12-17T22:58:52.686Z [INFO] (pool-2-thread-13) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-awaiting-start. waiting for dependencies to start. {serviceName=main, currentState=INSTALLED}
+2020-12-17T22:58:52.688Z [INFO] (ComponentWithManyChildProcesses-lifecycle) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-report-state. {serviceName=ComponentWithManyChildProcesses, currentState=NEW, newState=INSTALLED}
+2020-12-17T22:58:52.688Z [INFO] (ComponentWithManyChildProcesses-lifecycle) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-set-state. {serviceName=ComponentWithManyChildProcesses, currentState=NEW, newState=INSTALLED}
+2020-12-17T22:58:52.689Z [INFO] (pool-2-thread-9) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-awaiting-start. waiting for dependencies to start. {serviceName=ComponentWithManyChildProcesses, currentState=INSTALLED}
+2020-12-17T22:58:52.690Z [INFO] (pool-2-thread-9) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-starting. {serviceName=ComponentWithManyChildProcesses, currentState=INSTALLED}
+2020-12-17T22:58:52.690Z [INFO] (pool-2-thread-9) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-report-state. {serviceName=ComponentWithManyChildProcesses, currentState=INSTALLED, newState=STARTING}
+2020-12-17T22:58:52.691Z [INFO] (ComponentWithManyChildProcesses-lifecycle) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-set-state. {serviceName=ComponentWithManyChildProcesses, currentState=INSTALLED, newState=STARTING}
+2020-12-17T14:58:52.692+08:00 [INFO] (pool-2-thread-9) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-report-state. {serviceName=ComponentWithManyChildProcesses, currentState=STARTING, newState=FINISHED}
+2020-12-17T22:58:52.693Z [INFO] (pool-2-thread-9) com.aws.greengrass.lifecyclemanager.GenericExternalService: generic-service-finished. Nothing done. {serviceName=ComponentWithManyChildProcesses, currentState=STARTING}
+2020-12-17T22:58:52.693Z [INFO] (ComponentWithManyChildProcesses-lifecycle) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-report-state. {serviceName=ComponentWithManyChildProcesses, currentState=STARTING, newState=STOPPING}
+2020-12-17T22:58:52.694Z [INFO] (ComponentWithManyChildProcesses-lifecycle) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-set-state. {serviceName=ComponentWithManyChildProcesses, currentState=STARTING, newState=FINISHED}
+2020-12-17T22:58:52.695Z [INFO] (ComponentWithManyChildProcesses-lifecycle) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-set-state. {serviceName=ComponentWithManyChildProcesses, currentState=FINISHED, newState=STOPPING}
+2020-12-17T22:58:52.695Z [INFO] (pool-2-thread-13) com.aws.greengrass.lifecyclemanager.GenericExternalService: service-starting. {serviceName=main, currentState=INSTALLED}


### PR DESCRIPTION

**Issue #, if available:**

**Description of changes:**
If the log message is in JSON format, then use the timestamp from the the JSON object.
If the log message is in TEXT format, then get the timestamp using a regex. The timestamp should be at the very beginning of the log line.

**Why is this change necessary:**
Currently we are sending the timestamp of the CW log events as the time of the upload which is different from the logs timestamp.

**How was this change tested:**
Added unit tests.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
