### PR TITLE
test: Use the correct IoT endpoints and region in tests after adding validation in Nucleus

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/logmanager/LogManagerTest.java
@@ -109,8 +109,8 @@ class LogManagerTest extends BaseITCase {
                 logManagerService = (LogManagerService) service;
             }
         });
-        deviceConfiguration = new DeviceConfiguration(kernel, THING_NAME, "dataEndpoint", "credEndpoint",
-                "privKeyFilePath", "certFilePath", "caFilePath", AWS_REGION, "roleAlias");
+        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com", "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath",
+                "certFilePath", "caFilePath", "us-east-1", "roleAliasName");
 
         kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
         // set required instances from context

--- a/src/integrationtests/java/com/aws/greengrass/logmanager/SpaceManagementTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/logmanager/SpaceManagementTest.java
@@ -51,8 +51,6 @@ import static org.mockito.Mockito.lenient;
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
 class SpaceManagementTest extends BaseITCase {
-    private static final String THING_NAME = "ThingName";
-    private static final String AWS_REGION = "us-east-1";
     private static Kernel kernel;
     private static DeviceConfiguration deviceConfiguration;
     private LogManagerService logManagerService;
@@ -103,8 +101,8 @@ class SpaceManagementTest extends BaseITCase {
                 logManagerService = (LogManagerService) service;
             }
         });
-        deviceConfiguration = new DeviceConfiguration(kernel, THING_NAME, "dataEndpoint", "credEndpoint",
-                "privKeyFilePath", "certFilePath", "caFilePath", AWS_REGION, "roleAlias");
+        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com", "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath",
+                "certFilePath", "caFilePath", "us-east-1", "roleAliasName");
         kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
         // set required instances from context
         kernel.launch();

--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
@@ -313,7 +313,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath()).getStartPosition());
             assertEquals(1016766, logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath()).getBytesRead());
             assertEquals("TestComponent", logEventsForStream1.getComponentName());
-            LocalDateTime localDateTimeNow = LocalDateTime.now();
+            LocalDateTime localDateTimeNow = LocalDateTime.now(ZoneOffset.UTC);
             for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
                 Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
                 assertTrue(logTimestamp.isBefore(Instant.now()));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The integration tests were broken after this [change](https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/813) in the Nucleus. Also fix flaky unit test by using the correct time zone.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [X] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
