### PR TITLE
improvement: Add logic to use logger config if available for component configuration

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/logmanager/util/LogFileHelper.java
+++ b/src/integrationtests/java/com/aws/greengrass/logmanager/util/LogFileHelper.java
@@ -53,4 +53,17 @@ public final class LogFileHelper {
             addDataToFile(messageBytes, file.toPath());
         }
     }
+
+    public static void createFileAndWriteData(Path tempDirectoryPath, String fileName)
+            throws IOException {
+        Path filePath = tempDirectoryPath.resolve(fileName + ".log");
+        if (!Files.exists(filePath)) {
+            Files.createFile(filePath);
+        }
+        File file = filePath.toFile();
+        List<String> randomMessages = generateRandomMessages();
+        for (String messageBytes : randomMessages) {
+            addDataToFile(messageBytes, file.toPath());
+        }
+    }
 }

--- a/src/integrationtests/resources/com/aws/greengrass/logmanager/smallPeriodicIntervalOnlyReqUserComponentConfig.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/logmanager/smallPeriodicIntervalOnlyReqUserComponentConfig.yaml
@@ -1,0 +1,18 @@
+---
+services:
+  aws.greengrass.LogManager:
+    configuration:
+      periodicUploadIntervalSec: 10
+      logsUploaderConfiguration:
+        componentLogsConfiguration:
+          - componentName: 'UserComponentB'
+            minimumLogLevel: 'INFO'
+            diskSpaceLimit: '25'
+            diskSpaceLimitUnit: 'MB'
+            deleteLogFileAfterCloudUpload: 'true'
+  main:
+    lifecycle:
+      install:
+        all: echo All installed
+    dependencies:
+      - aws.greengrass.LogManager

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -231,6 +231,13 @@ public class LogManagerService extends PluginService {
             }
 
         });
+        if (fileNameRegex.get() == null) {
+            LogManager.getLogConfigurations().computeIfPresent(componentLogConfiguration.getName(), (s, logConfig) -> {
+                fileNameRegex.set(Pattern.compile(String.format(DEFAULT_FILE_REGEX,
+                        logConfig.getFileName())));
+                return logConfig;
+            });
+        }
         componentLogConfiguration.setFileNameRegex(fileNameRegex.get());
         if (directoryPath.get() == null) {
             LogManager.getLogConfigurations().computeIfPresent(componentLogConfiguration.getName(), (s, logConfig) -> {

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -265,7 +265,58 @@ class LogManagerServiceTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_user_component_log_files_to_be_uploaded_WHEN_merger_merges_THEN_we_get_all_log_files()
+    void GIVEN_user_component_log_files_to_be_uploaded_with_required_config_WHEN_merger_merges_THEN_we_get_all_log_files()
+            throws InterruptedException, UnsupportedInputTypeException {
+        mockDefaultPersistedState();
+        Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
+                .thenReturn(periodicUpdateIntervalMsTopic);
+        when(mockMerger.processLogFiles(componentLogsInformationCaptor.capture())).thenReturn(new CloudWatchAttempt());
+
+        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+
+        List<Map<String, Object>> componentLogsInformationList = new ArrayList<>();
+        Map<String, Object> componentAConfig = new HashMap<>();
+        componentAConfig.put(COMPONENT_NAME_CONFIG_TOPIC_NAME, "UserComponentA");
+        componentAConfig.put(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME, "DEBUG");
+        componentAConfig.put(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME, "10");
+        componentAConfig.put(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME, "GB");
+        componentAConfig.put(DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME, "false");
+        componentLogsInformationList.add(componentAConfig);
+        configTopics.createLeafChild(COMPONENT_LOGS_CONFIG_TOPIC_NAME).withValueChecked(componentLogsInformationList);
+
+        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("false");
+        systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
+        systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
+        systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
+                .thenReturn(configTopics);
+
+        doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
+
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor);
+        startServiceOnAnotherThread();
+
+        TimeUnit.SECONDS.sleep(5);
+
+        assertThat(logsUploaderService.componentLogConfigurations.entrySet(), IsNot.not(IsEmptyCollection.empty()));
+        assertEquals(1, logsUploaderService.componentLogConfigurations.size());
+        assertTrue(logsUploaderService.componentLogConfigurations.containsKey("UserComponentA"));
+
+        assertNotNull(componentLogsInformationCaptor.getValue());
+        ComponentLogFileInformation componentLogFileInformation = componentLogsInformationCaptor.getValue();
+        assertNotNull(componentLogFileInformation);
+        assertEquals(ComponentType.UserComponent, componentLogFileInformation.getComponentType());
+        assertEquals(Level.DEBUG, componentLogFileInformation.getDesiredLogLevel());
+        assertNotNull(componentLogFileInformation.getLogFileInformationList());
+        assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
+        assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 5);
+        verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
+    }
+
+    @Test
+    void GIVEN_user_component_log_files_to_be_uploaded_with_all_config_WHEN_merger_merges_THEN_we_get_all_log_files()
             throws InterruptedException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-log-manager/issues/41

**Description of changes:**
Currently, the customers need to provide the location of the log files for an installed component in GGV2. This change will help the customer to just specify the name of the component if the component is using the logging framework provided by the Nucleus.

**Why is this change necessary:**
This would help the customer to just specify the component name in the Log Manager configuration and then the Log Manager component will use the logger config to get the file name that the component is logging to along with the location of those log files.

**How was this change tested:**
Added unit and integration tests.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
