### PR TITLE
fix: sort log events by timestamp for CloudWatch 400 error

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/CloudWatchLogsUploader.java
+++ b/src/main/java/com/aws/greengrass/logmanager/CloudWatchLogsUploader.java
@@ -58,7 +58,7 @@ public class CloudWatchLogsUploader {
         try {
             attempt.getLogStreamsToLogEventsMap().forEach((streamName, attemptLogInformation) -> {
                 boolean success = uploadLogs(attempt.getLogGroupName(), streamName,
-                        attemptLogInformation.getLogEvents(), tryCount);
+                        attemptLogInformation.getSortedLogEvents(), tryCount);
                 if (success) {
                     attempt.getLogStreamUploadedSet().add(streamName);
                 }

--- a/src/main/java/com/aws/greengrass/logmanager/model/CloudWatchAttemptLogInformation.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/CloudWatchAttemptLogInformation.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,9 +22,21 @@ import java.util.Map;
 @Getter
 @Setter
 public class CloudWatchAttemptLogInformation {
+    protected static final Comparator<InputLogEvent> EVENT_COMPARATOR = Comparator.comparing(InputLogEvent::timestamp);
     @Builder.Default
     private List<InputLogEvent> logEvents = new ArrayList<>();
     @Builder.Default
     private Map<String, CloudWatchAttemptLogFileInformation> attemptLogFileInformationMap = new HashMap<>();
     private String componentName;
+
+    /**
+     * Get the log events in chronological order.
+     *
+     * @return sorted events
+     */
+    public List<InputLogEvent> getSortedLogEvents() {
+        // Sort by timestamp because CloudWatch requires that the logs are in chronological order
+        logEvents.sort(EVENT_COMPARATOR);
+        return logEvents;
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Sorts log events by timestamp because CloudWatch requires that they are in chronological order.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
