### PR TITLE
Remove deployment group names from log streams

### DIFF
--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
@@ -6,10 +6,7 @@
 package com.aws.greengrass.logmanager;
 
 import com.aws.greengrass.config.Topic;
-import com.aws.greengrass.deployment.DeploymentService;
 import com.aws.greengrass.deployment.DeviceConfiguration;
-import com.aws.greengrass.lifecyclemanager.Kernel;
-import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.logmanager.model.CloudWatchAttempt;
 import com.aws.greengrass.logmanager.model.CloudWatchAttemptLogInformation;
 import com.aws.greengrass.logmanager.model.ComponentLogFileInformation;
@@ -44,37 +41,27 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_AWS_REGION;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
-import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 import static com.aws.greengrass.logmanager.CloudWatchAttemptLogsProcessor.DEFAULT_LOG_GROUP_NAME;
-import static com.aws.greengrass.logmanager.CloudWatchAttemptLogsProcessor.MAX_LOG_STREAM_NAME_LENGTH;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
+
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     private static final SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy/MM/dd", Locale.ENGLISH);
     @Mock
     private DeviceConfiguration mockDeviceConfiguration;
-    @Mock
-    private DeploymentService mockDeploymentService;
-    @Mock
-    private Kernel mockKernel;
     @TempDir
     static Path directoryPath;
 
@@ -88,19 +75,10 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         lenient().when(mockDeviceConfiguration.getAWSRegion()).thenReturn(regionTopic);
     }
 
-    private void mockDefaultGetGroups() throws ServiceLoadException {
-        lenient().when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
-        lenient().when(mockDeploymentService.getGroupNamesForUserComponent(anyString()))
-                .thenReturn(new HashSet<>(Collections.singletonList("testGroup2")));
-        lenient().when(mockDeploymentService.getAllGroupNames())
-                .thenReturn(new HashSet<>(Collections.singletonList("testGroup1")));
-    }
-
     @Test
     void GIVEN_one_system_component_one_file_less_than_max_WHEN_merge_THEN_reads_entire_file(ExtensionContext ec)
-            throws URISyntaxException, ServiceLoadException {
+            throws URISyntaxException {
         ignoreExceptionOfType(ec, DateTimeParseException.class);
-        mockDefaultGetGroups();
         File file1 = new File(getClass().getResource("testlogs2.log").toURI());
         List<LogFileInformation> logFileInformationSet = new ArrayList<>();
         logFileInformationSet.add(LogFileInformation.builder().startPosition(0).file(file1).build());
@@ -111,7 +89,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
                 .componentType(ComponentType.GreengrassSystemComponent)
                 .logFileInformationList(logFileInformationSet)
                 .build();
-        logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration, mockKernel);
+        logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration);
         CloudWatchAttempt attempt = logsProcessor.processLogFiles(componentLogFileInformation);
         assertNotNull(attempt);
 
@@ -119,7 +97,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         assertThat(attempt.getLogStreamsToLogEventsMap().entrySet(), IsNot.not(IsEmptyCollection.empty()));
         String logGroup = calculateLogGroupName(ComponentType.GreengrassSystemComponent, "testRegion", "TestComponent");
         assertEquals(attempt.getLogGroupName(), logGroup);
-        String logStream = calculateLogStreamName("testThing", "testGroup1");
+        String logStream = calculateLogStreamName("testThing");
         assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream));
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
         assertNotNull(logEventsForStream1.getLogEvents());
@@ -140,9 +118,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_one_user_component_one_file_less_than_max_WHEN_merge_THEN_reads_entire_file(ExtensionContext ec)
-            throws URISyntaxException, ServiceLoadException {
+            throws URISyntaxException {
         ignoreExceptionOfType(ec, DateTimeParseException.class);
-        mockDefaultGetGroups();
+
         File file1 = new File(getClass().getResource("testlogs2.log").toURI());
         List<LogFileInformation> logFileInformationSet = new ArrayList<>();
         logFileInformationSet.add(LogFileInformation.builder().startPosition(0).file(file1).build());
@@ -153,7 +131,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
                 .componentType(ComponentType.UserComponent)
                 .logFileInformationList(logFileInformationSet)
                 .build();
-        logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration, mockKernel);
+        logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration);
         CloudWatchAttempt attempt = logsProcessor.processLogFiles(componentLogFileInformation);
         assertNotNull(attempt);
 
@@ -161,7 +139,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         assertThat(attempt.getLogStreamsToLogEventsMap().entrySet(), IsNot.not(IsEmptyCollection.empty()));
         String logGroup = calculateLogGroupName(ComponentType.UserComponent, "testRegion", "TestComponent");
         assertEquals(attempt.getLogGroupName(), logGroup);
-        String logStream = calculateLogStreamName("testThing", "testGroup2");
+        String logStream = calculateLogStreamName("testThing");
         assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream));
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
         assertNotNull(logEventsForStream1.getLogEvents());
@@ -181,14 +159,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_one_component_one_file_less_than_max_WHEN_no_group_THEN_reads_entire_file_and_sets_group_correctly(
-            ExtensionContext ec) throws URISyntaxException, ServiceLoadException {
+    void GIVEN_one_component_WHEN_one_file_less_than_max_THEN_reads_entire_file(
+            ExtensionContext ec) throws URISyntaxException {
         ignoreExceptionOfType(ec, DateTimeParseException.class);
-        when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenReturn(mockDeploymentService);
-        lenient().when(mockDeploymentService.getGroupNamesForUserComponent(anyString()))
-                .thenReturn(new HashSet<>(Collections.emptyList()));
-        lenient().when(mockDeploymentService.getAllGroupNames())
-                .thenReturn(new HashSet<>(Collections.emptyList()));
 
         File file1 = new File(getClass().getResource("testlogs2.log").toURI());
         List<LogFileInformation> logFileInformationSet = new ArrayList<>();
@@ -200,7 +173,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
                 .componentType(ComponentType.GreengrassSystemComponent)
                 .logFileInformationList(logFileInformationSet)
                 .build();
-        logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration, mockKernel);
+        logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration);
         CloudWatchAttempt attempt = logsProcessor.processLogFiles(componentLogFileInformation);
         assertNotNull(attempt);
 
@@ -208,51 +181,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         assertThat(attempt.getLogStreamsToLogEventsMap().entrySet(), IsNot.not(IsEmptyCollection.empty()));
         String logGroup = calculateLogGroupName(ComponentType.GreengrassSystemComponent, "testRegion", "TestComponent");
         assertEquals(attempt.getLogGroupName(), logGroup);
-        String logStream = calculateLogStreamName("testThing", LOCAL_DEPLOYMENT_GROUP_NAME);
-        assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream));
-        CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
-        assertNotNull(logEventsForStream1.getLogEvents());
-        assertEquals(13, logEventsForStream1.getLogEvents().size());
-        assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file1.getAbsolutePath()));
-        assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getStartPosition());
-        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
-        assertEquals("TestComponent", logEventsForStream1.getComponentName());
-        for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
-            Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
-            assertTrue(logTimestamp.isBefore(Instant.now()));
-            LocalDateTime localDate = LocalDateTime.ofInstant(logTimestamp, ZoneOffset.UTC);
-            assertEquals(2020, localDate.getYear());
-            assertEquals(12, localDate.getMonth().getValue());
-            assertEquals(17, localDate.getDayOfMonth());
-        }
-    }
-
-    @Test
-    void GIVEN_one_component_one_file_less_than_max_WHEN_locate_throws_ServiceLoadException_THEN_reads_entire_file_and_sets_group_correctly(
-            ExtensionContext context1) throws URISyntaxException, ServiceLoadException {
-        ignoreExceptionOfType(context1, ServiceLoadException.class);
-        ignoreExceptionOfType(context1, DateTimeParseException.class);
-        when(mockKernel.locate(DeploymentService.DEPLOYMENT_SERVICE_TOPICS)).thenThrow(ServiceLoadException.class);
-
-        File file1 = new File(getClass().getResource("testlogs2.log").toURI());
-        List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).file(file1).build());
-        ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
-                .name("TestComponent")
-                .multiLineStartPattern(Pattern.compile("^[^\\s]+(\\s+[^\\s]+)*$"))
-                .desiredLogLevel(Level.INFO)
-                .componentType(ComponentType.GreengrassSystemComponent)
-                .logFileInformationList(logFileInformationSet)
-                .build();
-        logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration, mockKernel);
-        CloudWatchAttempt attempt = logsProcessor.processLogFiles(componentLogFileInformation);
-        assertNotNull(attempt);
-
-        assertNotNull(attempt.getLogStreamsToLogEventsMap());
-        assertThat(attempt.getLogStreamsToLogEventsMap().entrySet(), IsNot.not(IsEmptyCollection.empty()));
-        String logGroup = calculateLogGroupName(ComponentType.GreengrassSystemComponent, "testRegion", "TestComponent");
-        assertEquals(attempt.getLogGroupName(), logGroup);
-        String logStream = calculateLogStreamName("testThing", LOCAL_DEPLOYMENT_GROUP_NAME);
+        String logStream = calculateLogStreamName("testThing");
         assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream));
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
         assertNotNull(logEventsForStream1.getLogEvents());
@@ -273,8 +202,8 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_one_component_one_file_more_than_max_WHEN_merge_THEN_reads_partial_file(ExtensionContext context1)
-            throws IOException, ServiceLoadException {
-        mockDefaultGetGroups();
+            throws IOException {
+
         ignoreExceptionOfType(context1, DateTimeParseException.class);
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
         assertTrue(file.createNewFile());
@@ -302,7 +231,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
                     .logFileInformationList(logFileInformationSet)
                     .build();
 
-            logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration, mockKernel);
+            logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration);
             CloudWatchAttempt attempt = logsProcessor.processLogFiles(componentLogFileInformation);
             assertNotNull(attempt);
 
@@ -310,7 +239,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             assertThat(attempt.getLogStreamsToLogEventsMap().entrySet(), IsNot.not(IsEmptyCollection.empty()));
             String logGroup = calculateLogGroupName(ComponentType.GreengrassSystemComponent, "testRegion", "TestComponent");
             assertEquals(attempt.getLogGroupName(), logGroup);
-            String logStream = calculateLogStreamName("testThing", "testGroup1");
+            String logStream = calculateLogStreamName("testThing");
             assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream));
             CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
             assertNotNull(logEventsForStream1.getLogEvents());
@@ -335,9 +264,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_one_components_two_file_less_than_max_WHEN_merge_THEN_reads_and_merges_both_files(ExtensionContext ec)
-            throws URISyntaxException, ServiceLoadException {
+            throws URISyntaxException {
         ignoreExceptionOfType(ec, DateTimeParseException.class);
-        mockDefaultGetGroups();
+
         File file1 = new File(getClass().getResource("testlogs2.log").toURI());
         File file2 = new File(getClass().getResource("testlogs1.log").toURI());
         List<LogFileInformation> logFileInformationSet = new ArrayList<>();
@@ -350,7 +279,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
                 .componentType(ComponentType.GreengrassSystemComponent)
                 .logFileInformationList(logFileInformationSet)
                 .build();
-        logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration, mockKernel);
+        logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration);
         CloudWatchAttempt attempt = logsProcessor.processLogFiles(componentLogFileInformation);
 
         assertNotNull(attempt);
@@ -359,8 +288,8 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         assertThat(attempt.getLogStreamsToLogEventsMap().entrySet(), IsNot.not(IsEmptyCollection.empty()));
         String logGroup = calculateLogGroupName(ComponentType.GreengrassSystemComponent, "testRegion", "TestComponent");
         assertEquals(attempt.getLogGroupName(), logGroup);
-        String logStream = calculateLogStreamName("testThing", "testGroup1");
-        String logStream2 = "/2020/02/10/testGroup1/testThing";
+        String logStream = calculateLogStreamName("testThing");
+        String logStream2 = "/2020/02/10/thing/testThing";
         assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream));
         assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream2));
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
@@ -390,39 +319,19 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_componentsToGroups_WHEN_getLogStreamName_THEN_return_valid_log_stream_name() {
-        logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration, mockKernel);
-        Set<String> groups = new HashSet<>();
-        String groupName1 = "thing/" + StringUtils.repeat("a", 128);
-        String groupName2 = "thinggroup/" + StringUtils.repeat("b", 128);
-        String groupName3 = "thinggroup/" + StringUtils.repeat("c", 128);
-        groups.add(groupName1);
-        groups.add(groupName2);
-        groups.add(groupName3);
+        logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration);
 
         String thingName1 = StringUtils.repeat("1", 86);
-        String logStream1 = logsProcessor.getLogStreamName(thingName1, groups);
-        assertEquals(String.format("/{date}/%s/%s/%s", groupName1, groupName2, thingName1), logStream1);
-        String finalLogStream1;
-        synchronized (DATE_FORMATTER) {
-            finalLogStream1 = logStream1.replace("{date}", DATE_FORMATTER.format(new Date()));
-        }
-        assertTrue(finalLogStream1.length() < MAX_LOG_STREAM_NAME_LENGTH);
+        String logStream1 = logsProcessor.getLogStreamName(thingName1);
+        assertEquals(String.format("/{date}/thing/%s", thingName1), logStream1);
 
         String thingName2 = StringUtils.repeat("2", 85);
-        String logStream2 = logsProcessor.getLogStreamName(thingName2, groups);
-        assertEquals(String.format("/{date}/%s/%s/%s/%s", groupName1, groupName2, groupName3, thingName2), logStream2);
-        String finalLogStream2;
-        synchronized (DATE_FORMATTER) {
-            finalLogStream2 = logStream2.replace("{date}", DATE_FORMATTER.format(new Date()));
-        }
-        assertEquals(MAX_LOG_STREAM_NAME_LENGTH, finalLogStream2.length());
+        String logStream2 = logsProcessor.getLogStreamName(thingName2);
+        assertEquals(String.format("/{date}/thing/%s", thingName2), logStream2);
 
         String thingName3 = "a:zA_Z:0-9";
-        groups.clear();
-        groups.add("thinggroup/myns:mygroup:myfleet");
-        groups.add("thing/" + thingName3);
-        String logStream3 = logsProcessor.getLogStreamName(thingName3, groups);
-        assertEquals("/{date}/thinggroup/myns+mygroup+myfleet/thing/a+zA_Z+0-9/a+zA_Z+0-9", logStream3);
+        String logStream3 = logsProcessor.getLogStreamName(thingName3);
+        assertEquals("/{date}/thing/a+zA_Z+0-9", logStream3);
     }
 
     private String calculateLogGroupName(ComponentType componentType, String awsRegion, String componentName) {
@@ -432,11 +341,10 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
                 .replace("{componentName}", componentName);
     }
 
-    private String calculateLogStreamName(String thingName, String group) {
+    private String calculateLogStreamName(String thingName) {
         synchronized (DATE_FORMATTER) {
             return CloudWatchAttemptLogsProcessor.DEFAULT_LOG_STREAM_NAME
                     .replace("{thingName}", thingName)
-                    .replace("{ggFleetId}", group)
                     .replace("{date}", DATE_FORMATTER.format(new Date()));
         }
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Remove deployment group names from log streams.
The current log stream format is `/{date}/thing/thinggroup/{group1}/thinggroup/{group2}/thing/{thingname}` 
If there is no group present the local deployment group name hardcoded in Nucleus gets added.
The new log stream format will be /{date}/thing/{thingname}

**Why is this change necessary:**
Adding groups to log stream names has been causing us issues.
Recently we had to fix an issue about characters from group arns not being supported in log stream names by CW.
Currently we're dealing with an issue where we cannot properly predict what log stream name will be when multiple deployments happen to the device for a component one after the other from the cloud or from cli
If the list and names of deployment groups are too long then it doesn't fit in the stream name max size so has to be truncated anyway, so this is more unpredictable than being useful in getting information about where the log originates from. 

**How was this change tested:**
Modified tests

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
