### PR TITLE
fix: do not delete the active log file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>log-manager</artifactId>
     <name>greengrass-log-manager</name>
     <packaging>jar</packaging>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <licenses>
       <license>
@@ -44,13 +44,13 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -14,7 +14,7 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.logging.impl.config.LogStore;
-import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
+import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import com.aws.greengrass.logmanager.LogManagerService;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.exceptions.TLSAuthException;
@@ -58,6 +58,7 @@ import java.util.regex.Pattern;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 import static com.aws.greengrass.integrationtests.logmanager.util.LogFileHelper.createFileAndWriteData;
 import static com.aws.greengrass.integrationtests.logmanager.util.LogFileHelper.createTempFileAndWriteData;
+import static com.aws.greengrass.logging.impl.config.LogConfig.newLogConfigFromRootConfig;
 import static com.aws.greengrass.logmanager.CloudWatchAttemptLogsProcessor.DEFAULT_LOG_STREAM_NAME;
 import static com.aws.greengrass.logmanager.LogManagerService.DEFAULT_FILE_REGEX;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
@@ -191,10 +192,10 @@ class LogManagerTest extends BaseITCase {
     void GIVEN_user_component_config_with_small_periodic_interval_and_only_required_config_WHEN_interval_elapses_THEN_logs_are_uploaded_to_cloud()
             throws Exception {
         tempDirectoryPath = Files.createDirectory(tempRootDir.resolve("logs"));
-        LogConfig.getInstance().setLevel(Level.TRACE);
-        LogConfig.getInstance().setStore(LogStore.FILE);
+        LogConfig.getRootLogConfig().setLevel(Level.TRACE);
+        LogConfig.getRootLogConfig().setStore(LogStore.FILE);
         LogManager.getLogConfigurations().putIfAbsent("UserComponentB",
-                new LogConfig(LoggerConfiguration.builder().fileName("UserComponentB.log").build()));
+                newLogConfigFromRootConfig(LogConfigUpdate.builder().fileName("UserComponentB.log").build()));
 
         for (int i = 0; i < 5; i++) {
             createFileAndWriteData(tempDirectoryPath, "UserComponentB_" + i);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
@@ -137,7 +137,7 @@ class SpaceManagementTest extends BaseITCase {
             for (int i = 0; i < 14; i++) {
                 createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log_", "");
             }
-            cdl.await(60, TimeUnit.SECONDS);
+            assertTrue(cdl.await(60, TimeUnit.SECONDS), "5 files deleted");
         }
 
         File folder = tempDirectoryPath.toFile();

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -12,7 +12,7 @@ import com.aws.greengrass.config.UpdateBehaviorTree;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.logging.impl.config.LogStore;
-import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
+import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import com.aws.greengrass.logmanager.model.CloudWatchAttempt;
 import com.aws.greengrass.logmanager.model.CloudWatchAttemptLogFileInformation;
 import com.aws.greengrass.logmanager.model.CloudWatchAttemptLogInformation;
@@ -64,6 +64,7 @@ import java.util.function.Consumer;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
+import static com.aws.greengrass.logging.impl.config.LogConfig.newLogConfigFromRootConfig;
 import static com.aws.greengrass.logmanager.LogManagerService.COMPONENT_LOGS_CONFIG_TOPIC_NAME;
 import static com.aws.greengrass.logmanager.LogManagerService.COMPONENT_NAME_CONFIG_TOPIC_NAME;
 import static com.aws.greengrass.logmanager.LogManagerService.DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME;
@@ -118,11 +119,11 @@ class LogManagerServiceTest extends GGServiceTestUtil {
 
     @BeforeAll
     static void setupBefore() throws IOException, InterruptedException {
-        LogConfig.getInstance().setLevel(Level.TRACE);
-        LogConfig.getInstance().setStore(LogStore.FILE);
-        LogConfig.getInstance().setStoreDirectory(directoryPath);
+        LogConfig.getRootLogConfig().setLevel(Level.TRACE);
+        LogConfig.getRootLogConfig().setStore(LogStore.FILE);
+        LogConfig.getRootLogConfig().setStoreDirectory(directoryPath);
         LogManager.getLogConfigurations().putIfAbsent("UserComponentA",
-                new LogConfig(LoggerConfiguration.builder().fileName("UserComponentA.log").build()));
+                newLogConfigFromRootConfig(LogConfigUpdate.builder().fileName("UserComponentA.log").build()));
         for (int i = 0; i < 5; i++) {
             File file = new File(directoryPath.resolve("UserComponentA_" + i + ".log").toUri());
             assertTrue(file.createNewFile());
@@ -157,8 +158,8 @@ class LogManagerServiceTest extends GGServiceTestUtil {
 
     @AfterAll
     static void cleanUpAfter() {
-        LogConfig.getInstance().setLevel(Level.INFO);
-        LogConfig.getInstance().setStore(LogStore.CONSOLE);
+        LogConfig.getRootLogConfig().setLevel(Level.INFO);
+        LogConfig.getRootLogConfig().setStore(LogStore.CONSOLE);
         final File folder = new File(directoryPath.toUri());
         final File[] files = folder.listFiles();
         if (files != null) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When `diskLimit` option is set too low, LogManager was deleting the active log file. This change will prevent us from deleting the active log.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
