### PR TITLE
fix: respect 24 hour time span limits for CW upload

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -50,6 +50,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -70,6 +71,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("PMD.UnsynchronizedStaticFormatter")
 @ExtendWith({GGExtension.class, MockitoExtension.class})
 class LogManagerTest extends BaseITCase {
     private static final String THING_NAME = "ThingName";
@@ -80,6 +82,10 @@ class LogManagerTest extends BaseITCase {
     private LogManagerService logManagerService;
     private Path tempDirectoryPath;
     private final static ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    static {
+        DATE_FORMATTER.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
 
     @Mock
     private CloudWatchLogsClient cloudWatchLogsClient;
@@ -103,7 +109,7 @@ class LogManagerTest extends BaseITCase {
         System.setProperty("root", tempRootDir.toAbsolutePath().toString());
         CountDownLatch logManagerRunning = new CountDownLatch(1);
 
-        CompletableFuture cf = new CompletableFuture();
+        CompletableFuture<Void> cf = new CompletableFuture<>();
         cf.complete(null);
         kernel = new Kernel();
 

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -539,7 +539,7 @@ public class LogManagerService extends PluginService {
                                     .build()));
                     allFiles.forEach(file -> {
                         long startPosition = 0;
-                        // If the file was paritially read in the previous run, then get the starting position for
+                        // If the file was partially read in the previous run, then get the starting position for
                         // new log lines.
                         if (componentCurrentProcessingLogFile.containsKey(componentName)) {
                             CurrentProcessingFileInformation processingFileInformation =

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -212,6 +212,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         logsUploaderService.componentCurrentProcessingLogFile.clear();
         logsUploaderService.lastComponentUploadedLogFileInstantMap.clear();
         logsUploaderService.shutdown();
+        executor.shutdownNow();
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Cloudwatch requires that any batch upload does not exceed a time span of 24 hours. This change splits out each 24 hour batch in order to respect that requirement.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
