### PR TITLE
feat: add cw emf logging support - WIP

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/CloudWatchLogsUploader.java
+++ b/src/main/java/com/aws/greengrass/logmanager/CloudWatchLogsUploader.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsResponse
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceAlreadyExistsException;
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -119,11 +120,18 @@ public class CloudWatchLogsUploader {
             return streamToSequenceTokenMap;
         });
         PutLogEventsRequest request = PutLogEventsRequest.builder()
-                .logEvents(logEvents)
-                .logGroupName(logGroupName)
-                .logStreamName(logStreamName)
-                .sequenceToken(sequenceToken.get())
-                .build();
+            .overrideConfiguration(builder ->
+                // provide the log-format header of json/emf
+                builder.headers(
+                    Collections.singletonMap("x-amzn-logs-format",  Collections.singletonList("json/emf"))
+                )
+            )
+            .logEvents(logEvents)
+            .logGroupName(logGroupName)
+            .logStreamName(logStreamName)
+            .sequenceToken(sequenceToken.get())
+            .build();
+
         try {
             PutLogEventsResponse putLogEventsResponse = this.cloudWatchLogsClient.putLogEvents(request);
             addNextSequenceToken(logGroupName, logStreamName, putLogEventsResponse.nextSequenceToken());

--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchLogsUploaderTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchLogsUploaderTest.java
@@ -21,6 +21,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.CreateLogGroupRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.CreateLogStreamRequest;
@@ -138,6 +139,11 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
 
         PutLogEventsRequest request = putLogEventsRequests.get(1);
         assertTrue(request.hasLogEvents());
+        assertTrue(request.overrideConfiguration().isPresent());
+        RequestOverrideConfiguration requestOverrideConfiguration = request.overrideConfiguration().get();
+        List<String> amznLogFormatHeader = requestOverrideConfiguration.headers().get("x-amzn-logs-format");
+        assertNotNull(amznLogFormatHeader);
+        assertTrue(amznLogFormatHeader.contains("json/emf"));
         assertEquals(mockGroupName, request.logGroupName());
         assertEquals(mockStreamNameForGroup, request.logStreamName());
         assertEquals(mockSequenceToken, request.sequenceToken());


### PR DESCRIPTION
**Issue #, if available:**

When sending emf formatted JSON logs the log-manager does not apply the `x-amzn-logs-format: json/emf` header for cloud watch to process the emf logs [ref](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html)

**Description of changes:**

Adds the emf header based on new isEmf field in the `ComponentLogConfiguration`.  

**Why is this change necessary:**

see issue

**How was this change tested:**

unit tests - still WIP

**Any additional information or context required to review the change:**


**Checklist:**
 - [x] Updated the README if applicable - not applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests - integ tests build with `mvn -U verify`
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
