### PR TITLE
fix: use correct matcher in space management, remove useless logs

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
+++ b/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
@@ -218,7 +218,7 @@ public class CloudWatchAttemptLogsProcessor {
         String dataStr = data.toString();
         int dataSize = dataStr.getBytes(StandardCharsets.UTF_8).length;
         CloudWatchAttemptLogInformation attemptLogInformation;
-        Optional<GreengrassLogMessage> logMessage = tryGetstructuredLogMessage(data);
+        Optional<GreengrassLogMessage> logMessage = tryGetStructuredLogMessage(dataStr);
         Pair<Boolean, AtomicInteger> addEventResult;
         if (logMessage.isPresent()) {
             logStreamName = logStreamName.replace("{date}",
@@ -292,9 +292,9 @@ public class CloudWatchAttemptLogsProcessor {
      * @param data The log line read from the file.
      * @return a structuredLogMessage if the deserialization is successful, else an empty optional object.
      */
-    private Optional<GreengrassLogMessage> tryGetstructuredLogMessage(StringBuilder data) {
+    private Optional<GreengrassLogMessage> tryGetStructuredLogMessage(String data) {
         try {
-            return Optional.of(DESERIALIZER.readValue(data.toString(), GreengrassLogMessage.class));
+            return Optional.of(DESERIALIZER.readValue(data, GreengrassLogMessage.class));
         } catch (JsonProcessingException ignored) {
             // If unable to deserialize, then we treat it as a normal log line and do not need to smartly upload.
             return Optional.empty();

--- a/src/main/java/com/aws/greengrass/logmanager/CloudWatchLogsUploader.java
+++ b/src/main/java/com/aws/greengrass/logmanager/CloudWatchLogsUploader.java
@@ -144,7 +144,7 @@ public class CloudWatchLogsUploader {
             return true;
         } catch (InvalidSequenceTokenException e) {
             // Get correct token using describe
-            logger.atError().cause(e)
+            logger.atError()
                     .log("Invalid token while uploading logs to {}-{}. Getting the correct sequence token.",
                             logGroupName,
                     logStreamName);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Some small fixes including quoting the filenames before inserting them into our predefined regex. Also fixes which regex is used in the space management thread; it was using the multiline regex instead of the filename regex.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
