### PR TITLE
fix: reset isCurrentlyUploading flag on shutdown to avoid log manager…

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -615,7 +615,6 @@ public class LogManagerService extends PluginService {
 
     @Override
     public void startup() throws InterruptedException {
-        // Need to override the function for tests.
         super.startup();
         processLogsAndUpload();
     }
@@ -762,8 +761,8 @@ public class LogManagerService extends PluginService {
     @Override
     @SuppressWarnings("PMD.UselessOverridingMethod")
     public void shutdown() throws InterruptedException {
-        // Need to override the function for tests.
         super.shutdown();
+        isCurrentlyUploading.set(false);
     }
 
     @Builder


### PR DESCRIPTION
… upload getting stuck on restart

**Issue #, if available:**

**Description of changes:**
periodic log processing and upload is only attempted when isCurrentlyUploading is false, when log manager shuts down and this flag is true, when log manager restarts it will keep thinking there's an ongoing update

**Why is this change necessary:**

**How was this change tested:**
Integ test added, verified that without the fix once log manager is restarted due to an error it keeps waiting for the upload attempt to finish but there is no upload attempt ongoing because it failed and caused the error. The test verifies the ideal fixed behavior where log manager attempts uploading after restart correctly

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
