### PR TITLE
fix: component config reset bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Manifests:
          "diskSpaceLimitUnit":"MB",
          "deleteLogFileAfterCloudUpload":true
       },
-      "componentLogsConfigurationMap" {
+      "componentLogsConfigurationMap": {
          "<ComponentName>": {
             "minimumLogLevel":"INFO",
             "logFileDirectoryPath":"/path/to/logs/directory/",

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -66,6 +66,7 @@ import static com.aws.greengrass.logmanager.LogManagerService.DEFAULT_FILE_REGEX
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -331,5 +332,14 @@ class LogManagerTest extends BaseITCase {
                 "componentLogsConfigurationMap", "UserComponentA", "deleteLogFileAfterCloudUpload").remove();
         assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(DELETE_LOG_FILE_AFTER_CLOUD_UPLOAD_DEFAULT), Duration.ofSeconds(30)));
+
+        // Verify correct reset for diskSpaceLimit (expected to be null)
+        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDiskSpaceLimit(),
+                eventuallyEval(is(20480L), Duration.ofSeconds(30)));
+        logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
+                "componentLogsConfigurationMap", "UserComponentA", "diskSpaceLimit").remove();
+        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDiskSpaceLimit() == null,
+                eventuallyEval(equalTo(true), Duration.ofSeconds(30)));
+
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -301,6 +301,12 @@ class LogManagerTest extends BaseITCase {
         setupKernel(tempDirectoryPath, "configsDifferentFromDefaults.yaml");
         TimeUnit.SECONDS.sleep(30);
 
+        // Verify correct reset for periodicUploadIntervalSec
+        assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(), eventuallyEval(is(10), Duration.ofSeconds(30)));
+        logManagerService.getConfig().find("configuration", "periodicUploadIntervalSec").remove();
+        assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(),
+                eventuallyEval(is(logManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
+
         // Verify correct reset for fileNameRegex
         assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getFileNameRegex().pattern(),
                 eventuallyEval(is("^integTestRandomLogFiles.log\\w*"), Duration.ofSeconds(30)));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -302,44 +302,43 @@ class LogManagerTest extends BaseITCase {
         TimeUnit.SECONDS.sleep(30);
 
         // Verify correct reset for fileNameRegex
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getFileNameRegex().pattern(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getFileNameRegex().pattern(),
                 eventuallyEval(is("^integTestRandomLogFiles.log\\w*"), Duration.ofSeconds(30)));
         logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
                 "componentLogsConfigurationMap", "UserComponentA", "logFileRegex").remove();
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getFileNameRegex().pattern(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getFileNameRegex().pattern(),
                 eventuallyEval(is(FILE_NAME_REGEX_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for directoryPath
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDirectoryPath(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getDirectoryPath(),
                 eventuallyEval(is(tempDirectoryPath), Duration.ofSeconds(30)));
         logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
                 "componentLogsConfigurationMap", "UserComponentA", "logFileDirectoryPath").remove();
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDirectoryPath(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getDirectoryPath(),
                 eventuallyEval(is(LOG_FILE_DIRECTORY_PATH_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for minimumLogLevel
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getMinimumLogLevel(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getMinimumLogLevel(),
                 eventuallyEval(is(Level.TRACE), Duration.ofSeconds(30)));
         logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
                 "componentLogsConfigurationMap", "UserComponentA", "minimumLogLevel").remove();
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getMinimumLogLevel(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getMinimumLogLevel(),
                 eventuallyEval(is(MINIMUM_LOG_LEVEL_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for deleteLogFileAfterCloudUpload
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").isDeleteLogFileAfterCloudUpload(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
         logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
                 "componentLogsConfigurationMap", "UserComponentA", "deleteLogFileAfterCloudUpload").remove();
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").isDeleteLogFileAfterCloudUpload(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(DELETE_LOG_FILE_AFTER_CLOUD_UPLOAD_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for diskSpaceLimit (expected to be null)
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDiskSpaceLimit(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getDiskSpaceLimit(),
                 eventuallyEval(is(20480L), Duration.ofSeconds(30)));
         logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
                 "componentLogsConfigurationMap", "UserComponentA", "diskSpaceLimit").remove();
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDiskSpaceLimit() == null,
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getDiskSpaceLimit() == null,
                 eventuallyEval(equalTo(true), Duration.ofSeconds(30)));
-
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -97,9 +97,6 @@ class LogManagerTest extends BaseITCase {
     private Path tempDirectoryPath;
     private final static ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
 
-    private static final Level MINIMUM_LOG_LEVEL_DEFAULT =  Level.INFO;
-    private static final boolean DELETE_LOG_FILE_AFTER_CLOUD_UPLOAD_DEFAULT = false;
-    private static final String FILE_NAME_REGEX_DEFAULT = "^\\QUserComponentA\\E\\w*.log";
     static {
         DATE_FORMATTER.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
@@ -316,38 +313,40 @@ class LogManagerTest extends BaseITCase {
                 eventuallyEval(is(logManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
 
         // Verify correct reset for fileNameRegex
+        String fileNameRegexDefault = "^\\QUserComponentA\\E\\w*.log";
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
                 eventuallyEval(is("^integTestRandomLogFiles.log\\w*"), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_REGEX_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
-                eventuallyEval(is(FILE_NAME_REGEX_DEFAULT), Duration.ofSeconds(30)));
+                eventuallyEval(is(fileNameRegexDefault), Duration.ofSeconds(30)));
 
         // Verify correct reset for directoryPath
-        Path defaultLogFileDirectoryPath = tempRootDir.resolve("logs");
-
+        Path logFileDirectoryPathDefault = tempRootDir.resolve("logs");
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
                 eventuallyEval(is(tempDirectoryPath), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
-                eventuallyEval(is(defaultLogFileDirectoryPath), Duration.ofSeconds(30)));
+                eventuallyEval(is(logFileDirectoryPathDefault), Duration.ofSeconds(30)));
 
         // Verify correct reset for minimumLogLevel
+        Level minimumLogLevelDefault =  Level.INFO;
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
                 eventuallyEval(is(Level.TRACE), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
-                eventuallyEval(is(MINIMUM_LOG_LEVEL_DEFAULT), Duration.ofSeconds(30)));
+                eventuallyEval(is(minimumLogLevelDefault), Duration.ofSeconds(30)));
 
         // Verify correct reset for deleteLogFileAfterCloudUpload
+        boolean deleteLogFileAfterCloudUploadDefault = false;
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
-                eventuallyEval(is(DELETE_LOG_FILE_AFTER_CLOUD_UPLOAD_DEFAULT), Duration.ofSeconds(30)));
+                eventuallyEval(is(deleteLogFileAfterCloudUploadDefault), Duration.ofSeconds(30)));
 
         // Verify correct reset for diskSpaceLimit (expected to be null)
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit(),

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -304,8 +304,7 @@ class LogManagerTest extends BaseITCase {
     @Test
     void GIVEN_component_configs_WHEN_individual_configs_are_reset_THEN_correct_default_values_are_used()
             throws Exception {
-        Path LOG_FILE_DIRECTORY_PATH_DEFAULT = tempRootDir.resolve("logs");
-        String COMPONENT_NAME = "UserComponentA";
+        String componentName = "UserComponentA";
 
         tempDirectoryPath = Files.createTempDirectory(tempRootDir, "IntegrationTestsTemporaryLogFiles");
         setupKernel(tempDirectoryPath, "configsDifferentFromDefaults.yaml");
@@ -317,43 +316,45 @@ class LogManagerTest extends BaseITCase {
                 eventuallyEval(is(logManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
 
         // Verify correct reset for fileNameRegex
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getFileNameRegex().pattern(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
                 eventuallyEval(is("^integTestRandomLogFiles.log\\w*"), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
-                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, COMPONENT_NAME, FILE_REGEX_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getFileNameRegex().pattern(),
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_REGEX_CONFIG_TOPIC_NAME).remove();
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
                 eventuallyEval(is(FILE_NAME_REGEX_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for directoryPath
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getDirectoryPath(),
+        Path defaultLogFileDirectoryPath = tempRootDir.resolve("logs");
+
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
                 eventuallyEval(is(tempDirectoryPath), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
-                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, COMPONENT_NAME, FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getDirectoryPath(),
-                eventuallyEval(is(LOG_FILE_DIRECTORY_PATH_DEFAULT), Duration.ofSeconds(30)));
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).remove();
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
+                eventuallyEval(is(defaultLogFileDirectoryPath), Duration.ofSeconds(30)));
 
         // Verify correct reset for minimumLogLevel
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getMinimumLogLevel(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
                 eventuallyEval(is(Level.TRACE), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
-                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, COMPONENT_NAME, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getMinimumLogLevel(),
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).remove();
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
                 eventuallyEval(is(MINIMUM_LOG_LEVEL_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for deleteLogFileAfterCloudUpload
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).isDeleteLogFileAfterCloudUpload(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
-                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, COMPONENT_NAME, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).isDeleteLogFileAfterCloudUpload(),
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).remove();
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(DELETE_LOG_FILE_AFTER_CLOUD_UPLOAD_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for diskSpaceLimit (expected to be null)
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getDiskSpaceLimit(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit(),
                 eventuallyEval(is(20480L), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
-                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, COMPONENT_NAME, DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getDiskSpaceLimit() == null,
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).remove();
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit() == null,
                 eventuallyEval(equalTo(true), Duration.ofSeconds(30)));
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -310,7 +310,7 @@ class LogManagerTest extends BaseITCase {
         assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(), eventuallyEval(is(10), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC).remove();
         assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(),
-                eventuallyEval(is(logManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
+                eventuallyEval(is(LogManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
 
         // Verify correct reset for fileNameRegex
         String fileNameRegexDefault = "^\\QUserComponentA\\E\\w*.log";

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/configsDifferentFromDefaults.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/configsDifferentFromDefaults.yaml
@@ -1,0 +1,26 @@
+---
+services:
+  aws.greengrass.LogManager:
+    configuration:
+      periodicUploadIntervalSec: 10
+      logsUploaderConfiguration:
+        componentLogsConfigurationMap:
+          UserComponentA:
+            logFileRegex: '^integTestRandomLogFiles.log\w*'
+            logFileDirectoryPath: '{{logFileDirectoryPath}}'
+            minimumLogLevel: 'TRACE'
+            diskSpaceLimit: '20'
+            diskSpaceLimitUnit: 'KB'
+            deleteLogFileAfterCloudUpload: 'true'
+        systemLogsConfiguration:
+          uploadToCloudWatch: true
+          minimumLogLevel: 'TRACE'
+          diskSpaceLimit: '25'
+          diskSpaceLimitUnit: 'MB'
+          deleteLogFileAfterCloudUpload: 'true'
+  main:
+    lifecycle:
+      install:
+        all: echo All installed
+    dependencies:
+      - aws.greengrass.LogManager

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -101,8 +101,8 @@ public class LogManagerService extends PluginService {
             Collections.synchronizedMap(new LinkedHashMap<>());
     final Map<String, CurrentProcessingFileInformation> componentCurrentProcessingLogFile =
             new ConcurrentHashMap<>();
-    // public only for integ tests
-    public Map<String, ComponentLogConfiguration> componentLogConfigurations = new ConcurrentHashMap<>();
+    @Getter
+    Map<String, ComponentLogConfiguration> componentLogConfigurations = new ConcurrentHashMap<>();
     @Getter
     private final CloudWatchLogsUploader uploader;
     private final CloudWatchAttemptLogsProcessor logsProcessor;

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -101,7 +101,8 @@ public class LogManagerService extends PluginService {
             Collections.synchronizedMap(new LinkedHashMap<>());
     final Map<String, CurrentProcessingFileInformation> componentCurrentProcessingLogFile =
             new ConcurrentHashMap<>();
-    Map<String, ComponentLogConfiguration> componentLogConfigurations = new ConcurrentHashMap<>();
+    // public only for integ tests
+    public Map<String, ComponentLogConfiguration> componentLogConfigurations = new ConcurrentHashMap<>();
     @Getter
     private final CloudWatchLogsUploader uploader;
     private final CloudWatchAttemptLogsProcessor logsProcessor;
@@ -230,8 +231,8 @@ public class LogManagerService extends PluginService {
                     if (Utils.isNotEmpty(logFileRegexString)) {
                         fileNameRegex.set(Pattern.compile(logFileRegexString));
                     } else {
-                        fileNameRegex.set(Pattern.compile(String.format(DEFAULT_FILE_REGEX,
-                                Pattern.quote(LogManager.getRootLogConfiguration().getFileName()))));
+                        fileNameRegex.set(Pattern.compile(String.format(DEFAULT_FILE_REGEX, Pattern.quote(
+                                Coerce.toString(componentConfigMap.get(COMPONENT_NAME_CONFIG_TOPIC_NAME))))));
                     }
                     break;
                 case FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME:

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -135,7 +135,14 @@ public class LogManagerService extends PluginService {
                     if (why == WhatHappened.removed) {
                         periodicUpdateIntervalSec = DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC;
                     } else {
-                        periodicUpdateIntervalSec = Coerce.toInt(newv);
+                        if (Coerce.toInt(newv) > 0) {
+                            periodicUpdateIntervalSec = Coerce.toInt(newv);
+                        } else {
+                            logger.atWarn().log("Invalid config value, {}, for periodicUploadIntervalSec. Must be an "
+                                    + "integer greater than 0. Using default value of 300 (5 minutes)",
+                                    Coerce.toInt(newv));
+                            periodicUpdateIntervalSec = DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC;
+                        }
                     }
                 });
         this.uploader.registerAttemptStatus(LOGS_UPLOADER_SERVICE_TOPICS, this::handleCloudWatchAttemptStatus);
@@ -238,9 +245,6 @@ public class LogManagerService extends PluginService {
                     String logFileRegexString = Coerce.toString(val);
                     if (Utils.isNotEmpty(logFileRegexString)) {
                         fileNameRegex.set(Pattern.compile(logFileRegexString));
-                    } else {
-                        fileNameRegex.set(Pattern.compile(String.format(DEFAULT_FILE_REGEX, Pattern.quote(
-                                Coerce.toString(componentConfigMap.get(COMPONENT_NAME_CONFIG_TOPIC_NAME))))));
                     }
                     break;
                 case FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME:


### PR DESCRIPTION
**Issue #, if available:**
 
**Description of changes:**
Fixing bugs so that when logFileRegex or periodicUploadIntervalSec config key is removed, the value is reset to the correct default.
Also adding testing for correct reset values for other component config keys

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
