### PR TITLE
fix: bug when config values are replaced after a reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Manifests:
          "diskSpaceLimitUnit":"MB",
          "deleteLogFileAfterCloudUpload":true
       },
-      "componentLogsConfigurationMap" {
+      "componentLogsConfigurationMap": {
          "<ComponentName>": {
             "minimumLogLevel":"INFO",
             "logFileDirectoryPath":"/path/to/logs/directory/",

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -67,6 +67,7 @@ import static com.aws.greengrass.logmanager.LogManagerService.COMPONENT_LOGS_CON
 import static com.aws.greengrass.logmanager.LogManagerService.DEFAULT_FILE_REGEX;
 import static com.aws.greengrass.logmanager.LogManagerService.DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME;
 import static com.aws.greengrass.logmanager.LogManagerService.DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME;
+import static com.aws.greengrass.logmanager.LogManagerService.DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME;
 import static com.aws.greengrass.logmanager.LogManagerService.FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME;
 import static com.aws.greengrass.logmanager.LogManagerService.FILE_REGEX_CONFIG_TOPIC_NAME;
 import static com.aws.greengrass.logmanager.LogManagerService.LOGS_UPLOADER_CONFIGURATION_TOPIC;
@@ -299,38 +300,54 @@ class LogManagerTest extends BaseITCase {
     }
 
     @Test
-    void GIVEN_component_configs_WHEN_individual_configs_are_reset_THEN_correct_default_values_are_used()
+    void GIVEN_system_and_component_configs_WHEN_individual_configs_are_reset_and_replaced_THEN_correct_values_are_used()
             throws Exception {
         String componentName = "UserComponentA";
 
         tempDirectoryPath = Files.createTempDirectory(tempRootDir, "IntegrationTestsTemporaryLogFiles");
         setupKernel(tempDirectoryPath, "configsDifferentFromDefaults.yaml");
 
-        // Verify correct reset for periodicUploadIntervalSec
-        assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(), eventuallyEval(is(10), Duration.ofSeconds(30)));
+        // Verify correct reset and replacement for periodicUploadIntervalSec
+        assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(), eventuallyEval(is(60),
+                Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC).remove();
         assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(),
                 eventuallyEval(is(LogManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
+        logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC).withValue(600);
+        assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(), eventuallyEval(is(600),
+                Duration.ofSeconds(30)));
 
-        // Verify correct reset for fileNameRegex
+        // Verify correct reset and replacement for fileNameRegex
         String fileNameRegexDefault = "^\\QUserComponentA\\E\\w*.log";
+        String fileNameRegexNew = "RandomLogFileName\\w*.log";
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
                 eventuallyEval(is("^integTestRandomLogFiles.log\\w*"), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_REGEX_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
                 eventuallyEval(is(fileNameRegexDefault), Duration.ofSeconds(30)));
+        logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_REGEX_CONFIG_TOPIC_NAME).withValue(fileNameRegexNew);
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
+                eventuallyEval(is(fileNameRegexNew), Duration.ofSeconds(30)));
 
-        // Verify correct reset for directoryPath
+        // Verify correct reset and replacement for directoryPath
         Path logFileDirectoryPathDefault = tempRootDir.resolve("logs");
+        Path logFileDirectoryPathNew = tempRootDir.resolve("newLogDir");
+        Files.createDirectory(logFileDirectoryPathNew);
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
                 eventuallyEval(is(tempDirectoryPath), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
                 eventuallyEval(is(logFileDirectoryPathDefault), Duration.ofSeconds(30)));
+        logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME)
+                .withValue(logFileDirectoryPathNew.toString());
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
+                eventuallyEval(is(logFileDirectoryPathNew), Duration.ofSeconds(30)));
 
-        // Verify correct reset for minimumLogLevel
+        // Verify correct reset and replacement for minimumLogLevel
         Level minimumLogLevelDefault =  Level.INFO;
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
                 eventuallyEval(is(Level.TRACE), Duration.ofSeconds(30)));
@@ -338,8 +355,12 @@ class LogManagerTest extends BaseITCase {
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
                 eventuallyEval(is(minimumLogLevelDefault), Duration.ofSeconds(30)));
+        logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("WARN");
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
+                eventuallyEval(is(Level.WARN), Duration.ofSeconds(30)));
 
-        // Verify correct reset for deleteLogFileAfterCloudUpload
+        // Verify correct reset and replacement for deleteLogFileAfterCloudUpload
         boolean deleteLogFileAfterCloudUploadDefault = false;
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
@@ -347,13 +368,23 @@ class LogManagerTest extends BaseITCase {
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(deleteLogFileAfterCloudUploadDefault), Duration.ofSeconds(30)));
+        logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue(true);
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
+                eventuallyEval(is(true), Duration.ofSeconds(30)));
 
-        // Verify correct reset for diskSpaceLimit (expected to be null)
+        // Verify correct reset and replacement for diskSpaceLimit (expected to be null)
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit(),
                 eventuallyEval(is(20480L), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit() == null,
                 eventuallyEval(equalTo(true), Duration.ofSeconds(30)));
+        logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue(5);
+        logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit(),
+                eventuallyEval(is(5242880L), Duration.ofSeconds(30)));
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -66,6 +66,7 @@ import static com.aws.greengrass.logmanager.LogManagerService.DEFAULT_FILE_REGEX
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -331,5 +332,14 @@ class LogManagerTest extends BaseITCase {
                 "componentLogsConfigurationMap", "UserComponentA", "deleteLogFileAfterCloudUpload").remove();
         assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(DELETE_LOG_FILE_AFTER_CLOUD_UPLOAD_DEFAULT), Duration.ofSeconds(30)));
+
+        // Verify correct reset for diskSpaceLimit (expected to be null)
+        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDiskSpaceLimit(),
+                eventuallyEval(is(20480L), Duration.ofSeconds(30)));
+        logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
+                "componentLogsConfigurationMap", "UserComponentA", "diskSpaceLimit").remove();
+        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDiskSpaceLimit() == null,
+                eventuallyEval(equalTo(true), Duration.ofSeconds(30)));
+
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -301,6 +301,12 @@ class LogManagerTest extends BaseITCase {
         setupKernel(tempDirectoryPath, "configsDifferentFromDefaults.yaml");
         TimeUnit.SECONDS.sleep(30);
 
+        // Verify correct reset for periodicUploadIntervalSec
+        assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(), eventuallyEval(is(10), Duration.ofSeconds(30)));
+        logManagerService.getConfig().find("configuration", "periodicUploadIntervalSec").remove();
+        assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(),
+                eventuallyEval(is(logManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
+
         // Verify correct reset for fileNameRegex
         assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getFileNameRegex().pattern(),
                 eventuallyEval(is("^integTestRandomLogFiles.log\\w*"), Duration.ofSeconds(30)));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -302,44 +302,43 @@ class LogManagerTest extends BaseITCase {
         TimeUnit.SECONDS.sleep(30);
 
         // Verify correct reset for fileNameRegex
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getFileNameRegex().pattern(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getFileNameRegex().pattern(),
                 eventuallyEval(is("^integTestRandomLogFiles.log\\w*"), Duration.ofSeconds(30)));
         logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
                 "componentLogsConfigurationMap", "UserComponentA", "logFileRegex").remove();
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getFileNameRegex().pattern(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getFileNameRegex().pattern(),
                 eventuallyEval(is(FILE_NAME_REGEX_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for directoryPath
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDirectoryPath(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getDirectoryPath(),
                 eventuallyEval(is(tempDirectoryPath), Duration.ofSeconds(30)));
         logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
                 "componentLogsConfigurationMap", "UserComponentA", "logFileDirectoryPath").remove();
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDirectoryPath(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getDirectoryPath(),
                 eventuallyEval(is(LOG_FILE_DIRECTORY_PATH_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for minimumLogLevel
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getMinimumLogLevel(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getMinimumLogLevel(),
                 eventuallyEval(is(Level.TRACE), Duration.ofSeconds(30)));
         logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
                 "componentLogsConfigurationMap", "UserComponentA", "minimumLogLevel").remove();
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getMinimumLogLevel(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getMinimumLogLevel(),
                 eventuallyEval(is(MINIMUM_LOG_LEVEL_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for deleteLogFileAfterCloudUpload
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").isDeleteLogFileAfterCloudUpload(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
         logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
                 "componentLogsConfigurationMap", "UserComponentA", "deleteLogFileAfterCloudUpload").remove();
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").isDeleteLogFileAfterCloudUpload(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(DELETE_LOG_FILE_AFTER_CLOUD_UPLOAD_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for diskSpaceLimit (expected to be null)
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDiskSpaceLimit(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getDiskSpaceLimit(),
                 eventuallyEval(is(20480L), Duration.ofSeconds(30)));
         logManagerService.getConfig().find("configuration", "logsUploaderConfiguration",
                 "componentLogsConfigurationMap", "UserComponentA", "diskSpaceLimit").remove();
-        assertThat(()-> logManagerService.componentLogConfigurations.get("UserComponentA").getDiskSpaceLimit() == null,
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get("UserComponentA").getDiskSpaceLimit() == null,
                 eventuallyEval(equalTo(true), Duration.ofSeconds(30)));
-
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -97,9 +97,6 @@ class LogManagerTest extends BaseITCase {
     private Path tempDirectoryPath;
     private final static ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
 
-    private static final Level MINIMUM_LOG_LEVEL_DEFAULT =  Level.INFO;
-    private static final boolean DELETE_LOG_FILE_AFTER_CLOUD_UPLOAD_DEFAULT = false;
-    private static final String FILE_NAME_REGEX_DEFAULT = "^\\QUserComponentA\\E\\w*.log";
     static {
         DATE_FORMATTER.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
@@ -316,38 +313,40 @@ class LogManagerTest extends BaseITCase {
                 eventuallyEval(is(logManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
 
         // Verify correct reset for fileNameRegex
+        String fileNameRegexDefault = "^\\QUserComponentA\\E\\w*.log";
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
                 eventuallyEval(is("^integTestRandomLogFiles.log\\w*"), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_REGEX_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
-                eventuallyEval(is(FILE_NAME_REGEX_DEFAULT), Duration.ofSeconds(30)));
+                eventuallyEval(is(fileNameRegexDefault), Duration.ofSeconds(30)));
 
         // Verify correct reset for directoryPath
-        Path defaultLogFileDirectoryPath = tempRootDir.resolve("logs");
-
+        Path logFileDirectoryPathDefault = tempRootDir.resolve("logs");
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
                 eventuallyEval(is(tempDirectoryPath), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
-                eventuallyEval(is(defaultLogFileDirectoryPath), Duration.ofSeconds(30)));
+                eventuallyEval(is(logFileDirectoryPathDefault), Duration.ofSeconds(30)));
 
         // Verify correct reset for minimumLogLevel
+        Level minimumLogLevelDefault =  Level.INFO;
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
                 eventuallyEval(is(Level.TRACE), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
-                eventuallyEval(is(MINIMUM_LOG_LEVEL_DEFAULT), Duration.ofSeconds(30)));
+                eventuallyEval(is(minimumLogLevelDefault), Duration.ofSeconds(30)));
 
         // Verify correct reset for deleteLogFileAfterCloudUpload
+        boolean deleteLogFileAfterCloudUploadDefault = false;
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).remove();
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
-                eventuallyEval(is(DELETE_LOG_FILE_AFTER_CLOUD_UPLOAD_DEFAULT), Duration.ofSeconds(30)));
+                eventuallyEval(is(deleteLogFileAfterCloudUploadDefault), Duration.ofSeconds(30)));
 
         // Verify correct reset for diskSpaceLimit (expected to be null)
         assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit(),

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -304,8 +304,7 @@ class LogManagerTest extends BaseITCase {
     @Test
     void GIVEN_component_configs_WHEN_individual_configs_are_reset_THEN_correct_default_values_are_used()
             throws Exception {
-        Path LOG_FILE_DIRECTORY_PATH_DEFAULT = tempRootDir.resolve("logs");
-        String COMPONENT_NAME = "UserComponentA";
+        String componentName = "UserComponentA";
 
         tempDirectoryPath = Files.createTempDirectory(tempRootDir, "IntegrationTestsTemporaryLogFiles");
         setupKernel(tempDirectoryPath, "configsDifferentFromDefaults.yaml");
@@ -317,43 +316,45 @@ class LogManagerTest extends BaseITCase {
                 eventuallyEval(is(logManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
 
         // Verify correct reset for fileNameRegex
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getFileNameRegex().pattern(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
                 eventuallyEval(is("^integTestRandomLogFiles.log\\w*"), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
-                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, COMPONENT_NAME, FILE_REGEX_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getFileNameRegex().pattern(),
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_REGEX_CONFIG_TOPIC_NAME).remove();
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
                 eventuallyEval(is(FILE_NAME_REGEX_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for directoryPath
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getDirectoryPath(),
+        Path defaultLogFileDirectoryPath = tempRootDir.resolve("logs");
+
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
                 eventuallyEval(is(tempDirectoryPath), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
-                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, COMPONENT_NAME, FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getDirectoryPath(),
-                eventuallyEval(is(LOG_FILE_DIRECTORY_PATH_DEFAULT), Duration.ofSeconds(30)));
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).remove();
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
+                eventuallyEval(is(defaultLogFileDirectoryPath), Duration.ofSeconds(30)));
 
         // Verify correct reset for minimumLogLevel
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getMinimumLogLevel(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
                 eventuallyEval(is(Level.TRACE), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
-                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, COMPONENT_NAME, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getMinimumLogLevel(),
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).remove();
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
                 eventuallyEval(is(MINIMUM_LOG_LEVEL_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for deleteLogFileAfterCloudUpload
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).isDeleteLogFileAfterCloudUpload(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
-                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, COMPONENT_NAME, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).isDeleteLogFileAfterCloudUpload(),
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).remove();
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(DELETE_LOG_FILE_AFTER_CLOUD_UPLOAD_DEFAULT), Duration.ofSeconds(30)));
 
         // Verify correct reset for diskSpaceLimit (expected to be null)
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getDiskSpaceLimit(),
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit(),
                 eventuallyEval(is(20480L), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
-                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, COMPONENT_NAME, DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(COMPONENT_NAME).getDiskSpaceLimit() == null,
+                COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).remove();
+        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit() == null,
                 eventuallyEval(equalTo(true), Duration.ofSeconds(30)));
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -310,7 +310,7 @@ class LogManagerTest extends BaseITCase {
         assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(), eventuallyEval(is(10), Duration.ofSeconds(30)));
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC).remove();
         assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(),
-                eventuallyEval(is(logManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
+                eventuallyEval(is(LogManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
 
         // Verify correct reset for fileNameRegex
         String fileNameRegexDefault = "^\\QUserComponentA\\E\\w*.log";

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/configsDifferentFromDefaults.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/configsDifferentFromDefaults.yaml
@@ -1,0 +1,26 @@
+---
+services:
+  aws.greengrass.LogManager:
+    configuration:
+      periodicUploadIntervalSec: 10
+      logsUploaderConfiguration:
+        componentLogsConfigurationMap:
+          UserComponentA:
+            logFileRegex: '^integTestRandomLogFiles.log\w*'
+            logFileDirectoryPath: '{{logFileDirectoryPath}}'
+            minimumLogLevel: 'TRACE'
+            diskSpaceLimit: '20'
+            diskSpaceLimitUnit: 'KB'
+            deleteLogFileAfterCloudUpload: 'true'
+        systemLogsConfiguration:
+          uploadToCloudWatch: true
+          minimumLogLevel: 'TRACE'
+          diskSpaceLimit: '25'
+          diskSpaceLimitUnit: 'MB'
+          deleteLogFileAfterCloudUpload: 'true'
+  main:
+    lifecycle:
+      install:
+        all: echo All installed
+    dependencies:
+      - aws.greengrass.LogManager

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/configsDifferentFromDefaults.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/configsDifferentFromDefaults.yaml
@@ -2,7 +2,7 @@
 services:
   aws.greengrass.LogManager:
     configuration:
-      periodicUploadIntervalSec: 10
+      periodicUploadIntervalSec: 60
       logsUploaderConfiguration:
         componentLogsConfigurationMap:
           UserComponentA:

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -101,8 +101,8 @@ public class LogManagerService extends PluginService {
             Collections.synchronizedMap(new LinkedHashMap<>());
     final Map<String, CurrentProcessingFileInformation> componentCurrentProcessingLogFile =
             new ConcurrentHashMap<>();
-    // public only for integ tests
-    public Map<String, ComponentLogConfiguration> componentLogConfigurations = new ConcurrentHashMap<>();
+    @Getter
+    Map<String, ComponentLogConfiguration> componentLogConfigurations = new ConcurrentHashMap<>();
     @Getter
     private final CloudWatchLogsUploader uploader;
     private final CloudWatchAttemptLogsProcessor logsProcessor;

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.logmanager;
 import ch.qos.logback.core.util.FileSize;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
-import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.logging.impl.LogManager;

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -101,7 +101,8 @@ public class LogManagerService extends PluginService {
             Collections.synchronizedMap(new LinkedHashMap<>());
     final Map<String, CurrentProcessingFileInformation> componentCurrentProcessingLogFile =
             new ConcurrentHashMap<>();
-    Map<String, ComponentLogConfiguration> componentLogConfigurations = new ConcurrentHashMap<>();
+    // public only for integ tests
+    public Map<String, ComponentLogConfiguration> componentLogConfigurations = new ConcurrentHashMap<>();
     @Getter
     private final CloudWatchLogsUploader uploader;
     private final CloudWatchAttemptLogsProcessor logsProcessor;
@@ -230,8 +231,8 @@ public class LogManagerService extends PluginService {
                     if (Utils.isNotEmpty(logFileRegexString)) {
                         fileNameRegex.set(Pattern.compile(logFileRegexString));
                     } else {
-                        fileNameRegex.set(Pattern.compile(String.format(DEFAULT_FILE_REGEX,
-                                Pattern.quote(LogManager.getRootLogConfiguration().getFileName()))));
+                        fileNameRegex.set(Pattern.compile(String.format(DEFAULT_FILE_REGEX, Pattern.quote(
+                                Coerce.toString(componentConfigMap.get(COMPONENT_NAME_CONFIG_TOPIC_NAME))))));
                     }
                     break;
                 case FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME:

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.logmanager;
 import ch.qos.logback.core.util.FileSize;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -129,7 +130,10 @@ public class LogManagerService extends PluginService {
         this.executorService = executorService;
 
         topics.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((why, newv) -> {
-            logger.atWarn().log("Log manager config change. Why: {}, Node: {}", why, newv);
+            if (why == WhatHappened.timestampUpdated) {
+                return;
+            }
+            logger.atDebug().log("Log manager config change. Why: {}, Node: {}", why, newv);
             handlePeriodicUploadIntervalSecConfig(topics);
             handleLogsUploaderConfig(topics);
         });

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.logmanager;
 import ch.qos.logback.core.util.FileSize;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
-import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -129,38 +128,44 @@ public class LogManagerService extends PluginService {
         this.logsProcessor = logProcessor;
         this.executorService = executorService;
 
-        topics.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC)
-                .dflt(DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC)
-                .subscribe((why, newv) -> {
-                    if (why == WhatHappened.removed) {
-                        periodicUpdateIntervalSec = DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC;
-                    } else {
-                        if (Coerce.toInt(newv) > 0) {
-                            periodicUpdateIntervalSec = Coerce.toInt(newv);
-                        } else {
-                            logger.atWarn().log("Invalid config value, {}, for periodicUploadIntervalSec. Must be an "
-                                    + "integer greater than 0. Using default value of 300 (5 minutes)",
-                                    Coerce.toInt(newv));
-                            periodicUpdateIntervalSec = DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC;
-                        }
-                    }
-                });
-        this.uploader.registerAttemptStatus(LOGS_UPLOADER_SERVICE_TOPICS, this::handleCloudWatchAttemptStatus);
-
-        Topics configTopics = topics.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC);
-        configTopics.subscribe((why, newv) -> {
-            Map<String, Object> configTopicsPojo = configTopics.toPOJO();
-            if (configTopicsPojo == null) {
-                //TODO: fail the deployment.
-                return;
-            }
-            processConfiguration(configTopicsPojo);
+        topics.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((why, newv) -> {
+            logger.atWarn().log("Log manager config change. Why: {}, Node: {}", why, newv);
+            handlePeriodicUploadIntervalSecConfig(topics);
+            handleLogsUploaderConfig(topics);
         });
+
+        this.uploader.registerAttemptStatus(LOGS_UPLOADER_SERVICE_TOPICS, this::handleCloudWatchAttemptStatus);
     }
 
-    private synchronized void processConfiguration(Map<String, Object> configTopicsPojo) {
+    private void handlePeriodicUploadIntervalSecConfig(Topics topics) {
+        int periodicUploadIntervalSecInput = Coerce.toInt(topics.lookup(CONFIGURATION_CONFIG_KEY,
+                        LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC)
+                .dflt(DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC)
+                .toPOJO());
+
+        if (periodicUploadIntervalSecInput > 0) {
+            periodicUpdateIntervalSec = periodicUploadIntervalSecInput;
+        } else {
+            logger.atWarn().log("Invalid config value, {}, for periodicUploadIntervalSec. Must be an "
+                            + "integer greater than 0. Using default value of 300 (5 minutes)",
+                    periodicUploadIntervalSecInput);
+            periodicUpdateIntervalSec = DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC;
+        }
+    }
+
+    private void handleLogsUploaderConfig(Topics topics) {
+        Topics logsUploaderTopics = topics.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC);
+        Map<String, Object> logsUploaderConfigTopicsPojo = logsUploaderTopics.toPOJO();
+        if (logsUploaderConfigTopicsPojo == null) {
+            //TODO: fail the deployment.
+            return;
+        }
+        processConfiguration(logsUploaderConfigTopicsPojo);
+    }
+
+    private synchronized void processConfiguration(Map<String, Object> logsUploaderConfigTopicsPojo) {
         Map<String, ComponentLogConfiguration> newComponentLogConfigurations = new ConcurrentHashMap<>();
-        configTopicsPojo.computeIfPresent(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, (s, o) -> {
+        logsUploaderConfigTopicsPojo.computeIfPresent(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, (s, o) -> {
             if (o instanceof Map) {
                 Map<String, Object> map = (Map) o;
                 map.forEach((componentName, componentConfigObject) -> {
@@ -173,7 +178,7 @@ public class LogManagerService extends PluginService {
             }
             return o;
         });
-        configTopicsPojo.computeIfPresent(COMPONENT_LOGS_CONFIG_TOPIC_NAME, (s, o) -> {
+        logsUploaderConfigTopicsPojo.computeIfPresent(COMPONENT_LOGS_CONFIG_TOPIC_NAME, (s, o) -> {
             if (o instanceof ArrayList) {
                 List<Object> list = (ArrayList) o;
                 list.forEach(componentConfigObject -> {
@@ -184,7 +189,7 @@ public class LogManagerService extends PluginService {
             }
             return o;
         });
-        configTopicsPojo.computeIfPresent(SYSTEM_LOGS_CONFIG_TOPIC_NAME, (s, o) -> {
+        logsUploaderConfigTopicsPojo.computeIfPresent(SYSTEM_LOGS_CONFIG_TOPIC_NAME, (s, o) -> {
             logger.atInfo().log("Process LogManager configuration for Greengrass system logs");
             Map<String, Object> systemConfigMap = (Map) o;
             AtomicBoolean isUploadToCloudWatch = new AtomicBoolean(false);

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -135,7 +135,14 @@ public class LogManagerService extends PluginService {
                     if (why == WhatHappened.removed) {
                         periodicUpdateIntervalSec = DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC;
                     } else {
-                        periodicUpdateIntervalSec = Coerce.toInt(newv);
+                        if (Coerce.toInt(newv) > 0) {
+                            periodicUpdateIntervalSec = Coerce.toInt(newv);
+                        } else {
+                            logger.atWarn().log("Invalid config value, {}, for periodicUploadIntervalSec. Must be an "
+                                    + "integer greater than 0. Using default value of 300 (5 minutes)",
+                                    Coerce.toInt(newv));
+                            periodicUpdateIntervalSec = DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC;
+                        }
                     }
                 });
         this.uploader.registerAttemptStatus(LOGS_UPLOADER_SERVICE_TOPICS, this::handleCloudWatchAttemptStatus);
@@ -238,9 +245,6 @@ public class LogManagerService extends PluginService {
                     String logFileRegexString = Coerce.toString(val);
                     if (Utils.isNotEmpty(logFileRegexString)) {
                         fileNameRegex.set(Pattern.compile(logFileRegexString));
-                    } else {
-                        fileNameRegex.set(Pattern.compile(String.format(DEFAULT_FILE_REGEX, Pattern.quote(
-                                Coerce.toString(componentConfigMap.get(COMPONENT_NAME_CONFIG_TOPIC_NAME))))));
                     }
                     break;
                 case FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME:

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -133,7 +133,7 @@ public class LogManagerService extends PluginService {
             if (why == WhatHappened.timestampUpdated) {
                 return;
             }
-            logger.atDebug().log("Log manager config change. Why: {}, Node: {}", why, newv);
+            logger.atDebug().kv("why", why).kv("node", newv).log();
             handlePeriodicUploadIntervalSecConfig(topics);
             handleLogsUploaderConfig(topics);
         });

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -255,9 +255,11 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(periodicUpdateIntervalMsTopic);
         when(mockMerger.processLogFiles(componentLogsInformationCaptor.capture())).thenReturn(new CloudWatchAttempt());
 
-        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
+        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
-        Topics componentConfigTopics = configTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^log.txt\\\\w*");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
@@ -266,13 +268,13 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         componentATopic.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("GB");
         componentATopic.createLeafChild(DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue("false");
 
-        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
         systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("true");
         systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopics);
+                .thenReturn(logsUploaderConfigTopics);
         doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
 
         logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor);
@@ -306,7 +308,9 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(periodicUpdateIntervalMsTopic);
         when(mockMerger.processLogFiles(componentLogsInformationCaptor.capture())).thenReturn(new CloudWatchAttempt());
 
-        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
+        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
         List<Map<String, Object>> componentLogsInformationList = new ArrayList<>();
         Map<String, Object> componentAConfig = new HashMap<>();
@@ -316,15 +320,15 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         componentAConfig.put(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME, "GB");
         componentAConfig.put(DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME, "false");
         componentLogsInformationList.add(componentAConfig);
-        configTopics.createLeafChild(COMPONENT_LOGS_CONFIG_TOPIC_NAME).withValueChecked(componentLogsInformationList);
+        logsUploaderConfigTopics.createLeafChild(COMPONENT_LOGS_CONFIG_TOPIC_NAME).withValueChecked(componentLogsInformationList);
 
-        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
         systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("false");
         systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopics);
+                .thenReturn(logsUploaderConfigTopics);
 
         doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
 
@@ -357,9 +361,11 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(periodicUpdateIntervalMsTopic);
         when(mockMerger.processLogFiles(componentLogsInformationCaptor.capture())).thenReturn(new CloudWatchAttempt());
 
-        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
+        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
-        Topics componentConfigTopics = configTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
         componentATopic.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("DEBUG");
@@ -367,13 +373,13 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         componentATopic.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("GB");
         componentATopic.createLeafChild(DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue("false");
 
-        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
         systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("false");
         systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopics);
+                .thenReturn(logsUploaderConfigTopics);
 
         doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
 
@@ -406,8 +412,11 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(periodicUpdateIntervalMsTopic);
         when(mockMerger.processLogFiles(componentLogsInformationCaptor.capture())).thenReturn(new CloudWatchAttempt());
 
-        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
-        Topics componentConfigTopics = configTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
+        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+
+        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^UserComponentA\\w*\\.log");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
@@ -416,13 +425,13 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         componentATopic.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("GB");
         componentATopic.createLeafChild(DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue("false");
 
-        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
         systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("false");
         systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopics);
+                .thenReturn(logsUploaderConfigTopics);
 
         doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
 
@@ -455,9 +464,11 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(periodicUpdateIntervalMsTopic);
         when(mockMerger.processLogFiles(componentLogsInformationCaptor.capture())).thenReturn(new CloudWatchAttempt());
 
-        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
-        Topics componentConfigTopics = configTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
+        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
+        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^log.txt\\\\w*");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
@@ -474,13 +485,13 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         componentBTopic.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("GB");
         componentBTopic.createLeafChild(DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue("false");
 
-        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
         systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("false");
         systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopics);
+                .thenReturn(logsUploaderConfigTopics);
 
         doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
 
@@ -517,12 +528,16 @@ class LogManagerServiceTest extends GGServiceTestUtil {
     void GIVEN_null_config_WHEN_config_is_processed_THEN_no_component_config_is_added(
             ExtensionContext context1) {
         ignoreExceptionOfType(context1, MismatchedInputException.class);
+
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
-        Topics configTopic = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+        Topics logsUploaderConfigTopic = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopic);
+                .thenReturn(logsUploaderConfigTopic);
+
 
         logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor);
         startServiceOnAnotherThread();
@@ -536,15 +551,16 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1000");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
-
-        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
-        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
+        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
         systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("false");
         systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopics);
+                .thenReturn(logsUploaderConfigTopics);
 
         Topics componentTopics2 = mock(Topics.class);
         Topic lastFileProcessedTimeStampTopics = mock(Topic.class);
@@ -633,14 +649,17 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(periodicUpdateIntervalMsTopic);
         when(mockMerger.processLogFiles(componentLogsInformationCaptor.capture())).thenReturn(new CloudWatchAttempt());
 
-        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
-        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
+        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+
+        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
         systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("true");
         systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopics);
+                .thenReturn(logsUploaderConfigTopics);
 
         logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor);
         File file = new File(directoryPath.resolve("greengrass_test_2.log").toUri());
@@ -684,9 +703,11 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
 
-        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
+        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
-        Topics componentConfigTopics = configTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^log.txt\\w*");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
@@ -695,13 +716,13 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         componentATopic.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("KB");
         componentATopic.createLeafChild(DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue("false");
 
-        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
         systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("true");
         systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("KB");
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopics);
+                .thenReturn(logsUploaderConfigTopics);
 
         logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor);
         startServiceOnAnotherThread();
@@ -742,9 +763,11 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
 
-        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
+        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
-        Topics componentConfigTopics = configTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^log2.txt\\w*");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
@@ -753,13 +776,13 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         componentATopic.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("KB");
         componentATopic.createLeafChild(DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue("true");
 
-        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
         systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("true");
         systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("KB");
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopics);
+                .thenReturn(logsUploaderConfigTopics);
 
         List<String> fileNames = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
@@ -835,14 +858,17 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(periodicUpdateIntervalMsTopic);
         when(mockMerger.processLogFiles(componentLogsInformationCaptor.capture())).thenReturn(new CloudWatchAttempt());
 
-        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
-        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
+        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+
+        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
         systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("true");
         systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopics);
+                .thenReturn(logsUploaderConfigTopics);
 
         logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor);
         startServiceOnAnotherThread();
@@ -879,9 +905,11 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
-        Topics configTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
+        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
+        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
-        Topics componentConfigTopics = configTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^log.txt\\w*");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
@@ -890,13 +918,13 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         componentATopic.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("GB");
         componentATopic.createLeafChild(DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue("false");
 
-        Topics systemConfigTopics = configTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
+        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
         systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("true");
         systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
         systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(configTopics);
+                .thenReturn(logsUploaderConfigTopics);
 
         Instant now = Instant.now();
         Instant tenSecondsAgo = Instant.now().minusSeconds(10);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixing bug, so that when periodicUploadIntervalSec or logsUploaderConfiguration config keys are removed via reset, and subsequently replaced, then the new values will be used.


**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
