### PR TITLE
fix: skip empty log messages that fail CW validation

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
+++ b/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
@@ -15,6 +15,7 @@ import com.aws.greengrass.logmanager.model.CloudWatchAttemptLogInformation;
 import com.aws.greengrass.logmanager.model.ComponentLogFileInformation;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Pair;
+import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -391,9 +392,12 @@ public class CloudWatchAttemptLogsProcessor {
             totalBytesRead.addAndGet(currChunkSize + TIMESTAMP_BYTES + EVENT_STORAGE_OVERHEAD);
             currBytesRead.addAndGet(currChunkSize);
 
-            InputLogEvent inputLogEvent =
-                    InputLogEvent.builder().message(partialData).timestamp(timestamp.toEpochMilli()).build();
-            attemptLogInformation.getLogEvents().add(inputLogEvent);
+            // Leave out empty messages since CloudWatch doesn't accept them
+            if (Utils.isNotEmpty(partialData)) {
+                InputLogEvent inputLogEvent =
+                        InputLogEvent.builder().message(partialData).timestamp(timestamp.toEpochMilli()).build();
+                attemptLogInformation.getLogEvents().add(inputLogEvent);
+            }
 
             currChunk++;
         }

--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
@@ -537,6 +537,65 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     }
 
     @Test
+    void GIVEN_empty_log_message_WHEN_upload_attempted_THEN_empty_message_skipped(ExtensionContext ec) throws IOException {
+
+        ignoreExceptionOfType(ec, DateTimeParseException.class);
+        File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
+        assertTrue(file.createNewFile());
+        assertTrue(file.setReadable(true));
+        assertTrue(file.setWritable(true));
+        try (OutputStream fileOutputStream = Files.newOutputStream(file.toPath())) {
+            // Large line with an empty chunk in the middle, empty chunk should be filtered out and only two log
+            // events should be uploaded
+            StringBuilder largeLineWithEmptyChunk =
+                    new StringBuilder(RandomStringUtils.random(MAX_EVENT_LENGTH, true, true))
+                            .append(StringUtils.repeat(" ", MAX_EVENT_LENGTH))
+                            .append(RandomStringUtils.random(MAX_EVENT_LENGTH, true, true))
+                            .append("\r\n");
+            fileOutputStream.write(largeLineWithEmptyChunk.toString().getBytes(StandardCharsets.UTF_8));
+        }
+
+        try {
+            List<LogFileInformation> logFileInformationSet = new ArrayList<>();
+            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).file(file).build());
+            ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
+                    .name("TestComponent")
+                    .desiredLogLevel(Level.INFO)
+                    .componentType(ComponentType.GreengrassSystemComponent)
+                    .logFileInformationList(logFileInformationSet)
+                    .build();
+
+            logsProcessor = new CloudWatchAttemptLogsProcessor(mockDeviceConfiguration, defaultClock);
+            CloudWatchAttempt attempt = logsProcessor.processLogFiles(componentLogFileInformation);
+            assertNotNull(attempt);
+
+            assertNotNull(attempt.getLogStreamsToLogEventsMap());
+            assertThat(attempt.getLogStreamsToLogEventsMap().entrySet(), IsNot.not(IsEmptyCollection.empty()));
+            String logGroup = calculateLogGroupName(ComponentType.GreengrassSystemComponent, "testRegion", "TestComponent");
+            assertEquals(attempt.getLogGroupName(), logGroup);
+            String logStream = calculateLogStreamName("testThing");
+            assertTrue(attempt.getLogStreamsToLogEventsMap().containsKey(logStream));
+            CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
+            assertNotNull(logEventsForStream1.getLogEvents());
+            assertEquals(2, logEventsForStream1.getLogEvents().size());
+            assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file.getAbsolutePath()));
+            assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath()).getStartPosition());
+            assertEquals("TestComponent", logEventsForStream1.getComponentName());
+            LocalDateTime localDateTimeNow = LocalDateTime.now(ZoneOffset.UTC);
+            for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
+                Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
+                assertTrue(logTimestamp.isBefore(Instant.now()));
+                LocalDateTime localDate = LocalDateTime.ofInstant(logTimestamp, ZoneOffset.UTC);
+                assertEquals(localDateTimeNow.getYear(), localDate.getYear());
+                assertEquals(localDateTimeNow.getMonth().getValue(), localDate.getMonth().getValue());
+                assertEquals(localDateTimeNow.getDayOfMonth(), localDate.getDayOfMonth());
+            }
+        } finally {
+            assertTrue(file.delete());
+        }
+    }
+
+    @Test
     void GIVEN_component_multiline_pattern_default_WHEN_logs_start_with_whitespace_THEN_append_to_previous_log() throws IOException{
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
         assertTrue(file.createNewFile());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
CloudWatch PutLogEvents API fails validation when a log event has an empty message, this change skips any empty messages so other logs in the batch can be uploaded

**Why is this change necessary:**
This causes the batch upload to fail while empty messages are of no value to users

**How was this change tested:**
New unit test

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
