### PR TITLE
feat: add log file factory with hash generation

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
+++ b/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.logmanager.model.CloudWatchAttempt;
 import com.aws.greengrass.logmanager.model.CloudWatchAttemptLogFileInformation;
 import com.aws.greengrass.logmanager.model.CloudWatchAttemptLogInformation;
 import com.aws.greengrass.logmanager.model.ComponentLogFileInformation;
+import com.aws.greengrass.logmanager.model.LogFile;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Pair;
 import com.aws.greengrass.util.Utils;
@@ -126,14 +127,15 @@ public class CloudWatchAttemptLogsProcessor {
         // Run the loop until all the log files from the component have been read or the max message
         // size has been reached.
         while (!componentLogFileInformation.getLogFileInformationList().isEmpty() && !reachedMaxSize.get()) {
-            File file = componentLogFileInformation.getLogFileInformationList().get(0).getFile();
+            LogFile logFile = componentLogFileInformation.getLogFileInformationList().get(0).getLogFile();
             long startPosition = componentLogFileInformation.getLogFileInformationList().get(0).getStartPosition();
-            String fileName = file.getAbsolutePath();
-            long lastModified = file.lastModified();
+            Optional<String> fileHash = componentLogFileInformation.getLogFileInformationList().get(0).getFileHash();
+            String fileName = logFile.getAbsolutePath();
+            long lastModified = logFile.lastModified();
 
             // If we have read the file already, we are at the correct offset in the file to start reading from
             // Let's get that file handle to read the new log line.
-            try (SeekableByteChannel chan = Files.newByteChannel(file.toPath(), StandardOpenOption.READ);
+            try (SeekableByteChannel chan = Files.newByteChannel(logFile.toPath(), StandardOpenOption.READ);
                  PositionTrackingBufferedReader r =
                          new PositionTrackingBufferedReader(new InputStreamReader(Channels.newInputStream(chan),
                          StandardCharsets.UTF_8))) {
@@ -174,14 +176,14 @@ public class CloudWatchAttemptLogsProcessor {
                         // Need to read more lines until we get a complete log line. Let's add this to the SB.
                         data.append(partialLogLine);
                     } catch (IOException e) {
-                        logger.atError().cause(e).log("Unable to read file {}", file.getAbsolutePath());
+                        logger.atError().cause(e).log("Unable to read file {}", logFile.getAbsolutePath());
                         componentLogFileInformation.getLogFileInformationList().remove(0);
                         break;
                     }
                 }
             } catch (IOException e) {
                 // File probably does not exist.
-                logger.atError().cause(e).log("Unable to read file {}", file.getAbsolutePath());
+                logger.atError().cause(e).log("Unable to read file {}", logFile.getAbsolutePath());
                 componentLogFileInformation.getLogFileInformationList().remove(0);
             }
         }
@@ -222,6 +224,9 @@ public class CloudWatchAttemptLogsProcessor {
         CloudWatchAttemptLogInformation attemptLogInformation;
         Optional<GreengrassLogMessage> logMessage = tryGetStructuredLogMessage(dataStr);
         Pair<Boolean, AtomicInteger> addEventResult;
+        // if the message is in JSON format, directly grab the message timestamp as logStreamName
+        // otherwise, try to find if any timestamp matched in text. If not, set the local (where LM is) time as the
+        // logStreamName
         if (logMessage.isPresent()) {
             logStreamName = logStreamName.replace("{date}",
                     DATE_FORMATTER.get().format(new Date(logMessage.get().getTimestamp())));

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
@@ -1,0 +1,89 @@
+package com.aws.greengrass.logmanager.model;
+
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.logmanager.LogManagerService;
+
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.aws.greengrass.util.Digest.calculate;
+
+public class LogFile extends File {
+    private static final Logger logger = LogManager.getLogger(LogManagerService.class);
+    private static final String EMPTY_STRING = "";
+    private static final int linesNeededNum = 1;
+
+    public LogFile(String pathname) {
+        super(pathname);
+    }
+
+    public static LogFile of(File file) {
+        return new LogFile(file.getAbsolutePath());
+    }
+
+    public static LogFile[] of(File[] files) {
+        if (files == null) return new LogFile[] {};
+        return Arrays.stream(files).map(LogFile::of).toArray(LogFile[]::new);
+    }
+
+    @Override
+    public boolean isFile() {
+        return super.isFile();
+    }
+
+    /**
+     * Read target lines from the file.
+     * The file must contain (minLine + 1) lines. One extra line is needed to prevent incomplete line when hashing.
+     * @return an ArrayList of lines or empty ArrayList
+     */
+    private String getLines() {
+        ArrayList<String> linesReaded = new ArrayList<>();
+        String oneLine;
+        try (BufferedReader r = Files.newBufferedReader(this.toPath(), StandardCharsets.UTF_8)) {
+            int linesReadForDigest = 0;
+            // read target number of lines
+            while (linesReadForDigest < linesNeededNum) {
+                oneLine = r.readLine();
+                if (oneLine == null) break;
+                linesReadForDigest ++;
+                linesReaded.add(oneLine);
+            }
+            // read one more line to prevent incomplete last line
+            // if lines in file less than minLines + 1, then return empty
+            if (r.readLine() == null || linesReadForDigest < linesNeededNum) {
+                logger.atTrace().log("Not enough lines to digest file {} ", this.getAbsolutePath());
+                return EMPTY_STRING;
+            }
+        } catch (IOException e) {
+            // File may not exist
+            logger.atError().cause(e).log("Unable to read file {}", this.getAbsolutePath());
+        }
+        return String.join("", linesReaded);
+    }
+
+    /**
+     * Get the hash of the logfile with target lines.
+     * @return the calculated hash value of the logfile
+     */
+    public Optional<String> hashString() {
+        if (!this.exists()) return Optional.ofNullable(null);
+        String lines = getLines();
+        if (!lines.isEmpty()) {
+            try {
+                return Optional.ofNullable(calculate(lines));
+            } catch (NoSuchAlgorithmException e) {
+                logger.atError().cause(e).log("The Digest Algorithm is invalid.");
+            }
+        }
+        return Optional.ofNullable(null);
+    }
+}

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileInformation.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileInformation.java
@@ -10,11 +10,13 @@ import lombok.Getter;
 import lombok.Value;
 
 import java.io.File;
+import java.util.Optional;
 
 @Builder
 @Value
 @Getter
 public class LogFileInformation {
-    private File file;
+    private LogFile logFile;
     private long startPosition;
+    private Optional fileHash;
 }

--- a/src/test/java/com/aws/greengrass/logmanager/model/LogFileTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/model/LogFileTest.java
@@ -1,0 +1,73 @@
+package com.aws.greengrass.logmanager.model;
+
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static com.aws.greengrass.util.Digest.calculate;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class LogFileTest {
+
+    @TempDir
+    static Path directoryPath;
+    private final int DEFAULT_LINES_FOR_DIGEST_NUM = 1;
+
+    @Test
+    void GIVEN_empty_file_WHEN_calculate_file_hash_THEN_we_get_null() throws IOException {
+        File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
+        LogFile logFile = LogFile.of(file);
+        Optional<String> fileHash = logFile.hashString();
+        assertFalse(fileHash.isPresent());
+    }
+
+    private void writeFiles(File file, int linesNeeded) throws IOException {
+        try (OutputStream fileOutputStream = Files.newOutputStream(file.toPath())) {
+            for (int i = 0; i < linesNeeded; i++) {
+                fileOutputStream.write("line".getBytes(StandardCharsets.UTF_8));
+                fileOutputStream.write(String.valueOf(i + 1).getBytes(StandardCharsets.UTF_8));
+                fileOutputStream.write("\n".getBytes(StandardCharsets.UTF_8));
+            }
+        }
+    }
+
+
+    @Test
+    void GIVEN_log_file_with_equal_to_target_lines_WHEN_calculate_file_hash_THEN_we_get_null() throws IOException {
+        File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
+        writeFiles(file, DEFAULT_LINES_FOR_DIGEST_NUM);
+        LogFile logFile = LogFile.of(file);
+        Optional<String> fileHash = logFile.hashString();
+        assertFalse(fileHash.isPresent());
+        file.delete();
+    }
+
+    @Test
+    void GIVEN_log_file_with_more_than_target_lines_WHEN_calculate_file_hash_THEN_we_get_hash()
+            throws IOException, NoSuchAlgorithmException {
+        File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
+        writeFiles(file, DEFAULT_LINES_FOR_DIGEST_NUM + 1);
+        StringBuilder msg = new StringBuilder();
+        for (int i = 0; i < DEFAULT_LINES_FOR_DIGEST_NUM; i++) msg.append("line").append(i + 1);
+
+        LogFile logFile = LogFile.of(file);
+        Optional<String> fileHash = logFile.hashString();
+        assertEquals(fileHash.get(), calculate(msg.toString()));
+        file.delete();
+
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**
#51 

**Description of changes:**
Add a LogFile class, which has the hash generation function. Change corresponding logic to transfer file to LogFile. 

**Why is this change necessary:**
One step for upload active log file, and creating a separate class is easy for maintain our own business logic.

**How was this change tested:**
Unit testing

**Any additional information or context required to review the change:**
Do not merge, this is not completed for #51 

**Checklist:**
 - [ ] Updated the README if applicable
 - [ x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
