### PR TITLE
feat: add LogFileGroup to find the active file

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/model/CloudWatchAttemptLogInformation.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/CloudWatchAttemptLogInformation.java
@@ -28,6 +28,7 @@ public class CloudWatchAttemptLogInformation {
     @Builder.Default
     private Map<String, CloudWatchAttemptLogFileInformation> attemptLogFileInformationMap = new HashMap<>();
     private String componentName;
+    private LogFileGroup logFileGroup;
 
     /**
      * Get the log events in chronological order.

--- a/src/main/java/com/aws/greengrass/logmanager/model/ComponentLogFileInformation.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/ComponentLogFileInformation.java
@@ -24,4 +24,5 @@ public class ComponentLogFileInformation {
     private Pattern multiLineStartPattern;
     private Level desiredLogLevel;
     private ComponentType componentType;
+    private LogFileGroup logFileGroup;
 }

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -1,0 +1,58 @@
+package com.aws.greengrass.logmanager.model;
+
+import com.aws.greengrass.util.Utils;
+import lombok.Getter;
+
+import java.io.File;
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class LogFileGroup {
+    @Getter
+    List<LogFile> logFiles;
+
+    private LogFileGroup(List<LogFile> files) {
+        this.logFiles = files;
+    }
+
+    public static LogFileGroup create(Pattern filePattern, URI path, Instant lastUpdated) {
+        File folder = new File(path);
+
+        List<LogFile> allFiles = new ArrayList<>();
+
+        if (!folder.isDirectory()) {
+            throw new RuntimeException("Must be a folder.");
+        }
+
+        LogFile[] files = LogFile.of(folder.listFiles());
+        if (files.length != 0) {
+            for (LogFile file: files) {
+                if (file.isFile()
+                        && lastUpdated.isBefore(Instant.ofEpochMilli(file.lastModified()))
+                        && filePattern.matcher(file.getName()).find()
+                        && file.length() > 0) {
+                    allFiles.add(file);
+                }
+            }
+        }
+        allFiles.sort(Comparator.comparingLong(LogFile::lastModified));
+        //TODO: the following logic is only for ignoring the active file and keeping the PR small
+        if (allFiles.size() - 1 <= 0) {
+            return new LogFileGroup(new ArrayList<>());
+        }
+        allFiles = allFiles.subList(0, allFiles.size() - 1);
+        return new LogFileGroup(allFiles);
+    }
+
+    public boolean isActiveFile(String fileHash) {
+        if (Utils.isEmpty(fileHash)) {
+            return false;
+        }
+        LogFile activeFile = logFiles.get(logFiles.size() - 1);
+        return activeFile.hashString().equals(fileHash);
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**
#51
**Description of changes:**
Introduce the LogFileGroup to grab the list of logFiles and can use lastModifiedTime to get the active file
**Why is this change necessary:**
THis is an approach to totally get rid of filenames.
**How was this change tested:**
Not yet
**Any additional information or context required to review the change:**
This PR is using enabledFlag to make current logic not changed and pass the Tests. 
**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
