### PR TITLE
fix: do not pass null into stringbuilder

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
+++ b/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
@@ -141,7 +141,12 @@ public class CloudWatchAttemptLogsProcessor {
                          StandardCharsets.UTF_8))) {
                 r.setInitialPosition(startPosition);
                 chan.position(startPosition);
-                StringBuilder data = new StringBuilder(r.readLine());
+                String line = r.readLine();
+                // Initialize string builder with empty string when the file is empty
+                if (line == null) {
+                    line = "";
+                }
+                StringBuilder data = new StringBuilder(line);
 
                 // Run the loop until we detect that the log file is completely read, or that we have reached the max
                 // message size or if we detect any IOException while reading from the file.


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Do not allow null to be passed into the stringbuilder, and instead initialize it with an empty string.

**Why is this change necessary:**
Fixes NPE when we read from an empty file and `readline` returns us `null`.

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
