### PR TITLE
feat: enable logFileGroup update with latest directory

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -530,9 +530,13 @@ public class LogManagerService extends PluginService {
                 fileName = file.getAbsolutePath();
                 // TODO: the following logic is only for passing this small PR while not changing the current context.
                 //  We will grab the fileHash in the future.
-                isActiveFile = logFileGroup.isActiveFile(fileHash);
+                Optional<LogFile> activeFile = logFileGroup.getActiveFile();
+                if (activeFile.isPresent()) {
+                    isActiveFile = activeFile.get().fileEquals(file);
+                }
             } catch (InvalidLogGroupException e) {
                 logger.atDebug().cause(e).log();
+                return;
             }
         }
         // If we have completely read the file, then we need add it to the completed files list and remove it
@@ -638,7 +642,8 @@ public class LogManagerService extends PluginService {
                             //TODO: setting this flag is only to develop incrementally without having to changed all
                             // tests yet, so that we can avoid a massive PR. This will be removed in the end.
                             if (ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.get()) {
-                                if (logFileGroup.isActiveFile(fileHash) && startPosition == file.length()) {
+                                if (file.fileEquals(logFileGroup.getActiveFile().get())
+                                        && startPosition == file.length()) {
                                     isActiveFileCompleted.set(true);
                                 }
                             }

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -518,11 +518,17 @@ public class LogManagerService extends PluginService {
         //TODO: setting this flag is only to develop incrementally without having to changed all tests yet, so that
         // we can avoid a massive PR. This will be removed in the end.
         if (ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.get()) {
-            String fileHash = cloudWatchAttemptLogFileInformation.getFileHash();
-            LogFileGroup logFileGroup = attemptLogInformation.getLogFileGroup();
-            // TODO: the following logic is only for passing this small PR while not changing the current context.
-            //  We will grab the fileHash in the future.
-            isActiveFile = logFileGroup.isActiveFile(fileHash);
+            try {
+                String fileHash = cloudWatchAttemptLogFileInformation.getFileHash();
+                LogFileGroup logFileGroup = attemptLogInformation.getLogFileGroup().update();
+                file = logFileGroup.getFile(fileHash);
+                fileName = file.getAbsolutePath();
+                // TODO: the following logic is only for passing this small PR while not changing the current context.
+                //  We will grab the fileHash in the future.
+                isActiveFile = logFileGroup.isActiveFile(fileHash);
+            } catch (InvalidLogGroupException e) {
+                logger.atDebug().cause(e).log();
+            }
         }
         // If we have completely read the file, then we need add it to the completed files list and remove it
         // it (if necessary) for the current processing list.

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
@@ -101,12 +101,15 @@ public class LogFile extends File {
         }  catch (NoSuchAlgorithmException e) {
             logger.atError().cause(e).log("The digest algorithm is invalid");
         }
-
         return fileHash;
     }
 
     public boolean isEmpty() {
         return Utils.isEmpty(this.hashString());
+    }
+
+    public boolean fileEquals(LogFile logFile) {
+        return this.hashString().equals(logFile.hashString());
     }
 
 }

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
@@ -109,7 +109,4 @@ public class LogFile extends File {
         return Utils.isEmpty(this.hashString());
     }
 
-    public boolean isEmpty(String hash) {
-        return Utils.isEmpty(hash);
-    }
 }

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
@@ -108,4 +108,8 @@ public class LogFile extends File {
     public boolean isEmpty() {
         return Utils.isEmpty(this.hashString());
     }
+
+    public boolean isEmpty(String hash) {
+        return Utils.isEmpty(hash);
+    }
 }

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -77,16 +77,14 @@ public final class LogFileGroup {
     }
 
     /**
-     * Given a fileHash of a file, using the sorted log files to detect if the file is the active file.
-     * @param fileHash the fileHash of the target file.
-     * @return boolean if this is the active file.
+     * Using the sorted log files to get the active file.
+     * @return the active logFile.
      */
-    public boolean isActiveFile(String fileHash) {
-        if (fileHash.isEmpty() || logFiles.isEmpty()) {
-            return false;
+    public Optional<LogFile> getActiveFile() {
+        if (logFiles.isEmpty()) {
+            return Optional.empty();
         }
-        LogFile activeFile = logFiles.get(logFiles.size() - 1);
-        return activeFile.hashString().equals(fileHash);
+        return Optional.of(logFiles.get(logFiles.size() - 1));
     }
 
     public void forEach(Consumer<LogFile> callback) {
@@ -104,9 +102,9 @@ public final class LogFileGroup {
      */
     public Optional<LogFile> getFile(String fileHash) {
         if (!fileHashToLogFile.containsKey(fileHash)) {
-            return Optional.ofNullable(null);
+            return Optional.empty();
         }
-        return Optional.ofNullable(fileHashToLogFile.get(fileHash));
+        return Optional.of(fileHashToLogFile.get(fileHash));
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -88,8 +88,8 @@ import static com.aws.greengrass.logmanager.LogManagerService.SYSTEM_LOGS_COMPON
 import static com.aws.greengrass.logmanager.LogManagerService.SYSTEM_LOGS_CONFIG_TOPIC_NAME;
 import static com.aws.greengrass.logmanager.LogManagerService.UPLOAD_TO_CW_CONFIG_TOPIC_NAME;
 import static com.aws.greengrass.logmanager.model.LogFile.bytesNeeded;
+import static com.aws.greengrass.logmanager.util.TestUtils.createLogFileWithSize;
 import static com.aws.greengrass.logmanager.util.TestUtils.givenAStringOfSize;
-import static com.aws.greengrass.logmanager.util.TestUtils.writeFile;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -594,20 +594,14 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logStreamsToLogInformationMap = new HashMap<>();
 
-        LogFile lastProcessedFile = new LogFile(directoryPath.resolve("testlogs2.log").toUri());
-        byte[] bytesArray = givenAStringOfSize(2943).getBytes(StandardCharsets.UTF_8);
-        writeFile(lastProcessedFile, bytesArray);
+        LogFile lastProcessedFile = createLogFileWithSize(directoryPath.resolve("testlogs2.log").toUri(), 2943);
         Pattern pattern1 = Pattern.compile("^testlogs2.log\\w*$");
         Instant instant1 = Instant.EPOCH;
-        // Create an active file intentionally, so that the lastProcessedFile will be processed.
-        LogFile lastProcessedActiveFile = new LogFile(directoryPath.resolve("testlogs2.log_active").toUri());
-        byte[] bytesArray0 = givenAStringOfSize(2943).getBytes(StandardCharsets.UTF_8);
-        writeFile(lastProcessedActiveFile, bytesArray0);
+        // Create another file intentionally, so that the lastProcessedFile will be processed.
+        createLogFileWithSize(directoryPath.resolve("testlogs2.log_active").toUri(), 2943);
         LogFileGroup LastProcessedLogFileGroup = LogFileGroup.create(pattern1, lastProcessedFile.getParentFile().toURI(), instant1);
 
-        LogFile processingFile = new LogFile(directoryPath.resolve("testlogs1.log").toUri());
-        byte[] bytesArray2 = givenAStringOfSize(1061).getBytes(StandardCharsets.UTF_8);
-        writeFile(processingFile, bytesArray2);
+        LogFile processingFile = createLogFileWithSize(directoryPath.resolve("testlogs1.log").toUri(), 1061);
         Pattern pattern2 = Pattern.compile("^testlogs1.log$");
         Instant instant2 = Instant.EPOCH;
         LogFileGroup processingLogFileGroup = LogFileGroup.create(pattern2, processingFile.getParentFile().toURI(), instant2);

--- a/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
@@ -46,8 +46,8 @@ public class LogFileGroupTest {
         LogFileGroup logFileGroup = LogFileGroup.create(pattern, file.getParentFile().toURI(), instant);
 
         assertEquals(2, logFileGroup.getLogFiles().size());
-        assertFalse(logFileGroup.isActiveFile(file.hashString()));
-        assertTrue(logFileGroup.isActiveFile(file2.hashString()));
+        assertFalse(logFileGroup.getActiveFile().get().fileEquals(file));
+        assertTrue(logFileGroup.getActiveFile().get().fileEquals(file2));
         ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 }

--- a/src/test/java/com/aws/greengrass/logmanager/util/TestUtils.java
+++ b/src/test/java/com/aws/greengrass/logmanager/util/TestUtils.java
@@ -4,6 +4,8 @@ import com.aws.greengrass.logmanager.model.LogFile;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Random;
 
@@ -25,5 +27,12 @@ public final class TestUtils {
         try (OutputStream fileOutputStream = Files.newOutputStream(file.toPath())) {
             fileOutputStream.write(byteArray);
         }
+    }
+
+    public static LogFile createLogFileWithSize(URI uri, int bytesNeeded) throws IOException {
+        LogFile file = new LogFile(uri);
+        byte[] bytesArray = givenAStringOfSize(bytesNeeded).getBytes(StandardCharsets.UTF_8);
+        writeFile(file, bytesArray);
+        return file;
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
#51 
**Description of changes:**
Add the logFileGroup update to the latest directory, thus grab information even log rotation happens during uploading.
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
