### PR TITLE
feat: remove fileName and add randomly-named rotation tests

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -16,6 +16,7 @@ import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.logging.impl.config.LogStore;
 import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import com.aws.greengrass.logmanager.LogManagerService;
+import com.aws.greengrass.logmanager.model.LogFile;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.exceptions.TLSAuthException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -46,11 +47,13 @@ import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -59,14 +62,18 @@ import java.util.regex.Pattern;
 import static com.aws.greengrass.deployment.converter.DeploymentDocumentConverter.LOCAL_DEPLOYMENT_GROUP_NAME;
 import static com.aws.greengrass.integrationtests.logmanager.util.LogFileHelper.DEFAULT_FILE_SIZE;
 import static com.aws.greengrass.integrationtests.logmanager.util.LogFileHelper.DEFAULT_LOG_LINE_IN_FILE;
+import static com.aws.greengrass.integrationtests.logmanager.util.LogFileHelper.addDataToFile;
 import static com.aws.greengrass.integrationtests.logmanager.util.LogFileHelper.createFileAndWriteData;
 import static com.aws.greengrass.integrationtests.logmanager.util.LogFileHelper.createTempFileAndWriteData;
+import static com.aws.greengrass.integrationtests.logmanager.util.LogFileHelper.createTempFileAndWriteDataAndReturnFile;
+import static com.aws.greengrass.integrationtests.logmanager.util.LogFileHelper.generateRandomMessages;
 import static com.aws.greengrass.logging.impl.config.LogConfig.newLogConfigFromRootConfig;
 import static com.aws.greengrass.logmanager.CloudWatchAttemptLogsProcessor.DEFAULT_LOG_STREAM_NAME;
 import static com.aws.greengrass.logmanager.LogManagerService.DEFAULT_FILE_REGEX;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionWithMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -99,15 +106,13 @@ class LogManagerTest extends BaseITCase {
 
     private String calculateLogStreamName(String thingName, String group) {
         synchronized (DATE_FORMATTER) {
-            return DEFAULT_LOG_STREAM_NAME
-                    .replace("{thingName}", thingName)
-                    .replace("{ggFleetId}", group)
+            return DEFAULT_LOG_STREAM_NAME.replace("{thingName}", thingName).replace("{ggFleetId}", group)
                     .replace("{date}", DATE_FORMATTER.format(new Date()));
         }
     }
 
-    void setupKernel(Path storeDirectory, String configFileName) throws InterruptedException,
-            URISyntaxException, IOException, DeviceConfigurationException {
+    void setupKernel(Path storeDirectory, String configFileName)
+            throws InterruptedException, URISyntaxException, IOException, DeviceConfigurationException {
 
         System.setProperty("root", tempRootDir.toAbsolutePath().toString());
         CountDownLatch logManagerRunning = new CountDownLatch(1);
@@ -117,22 +122,21 @@ class LogManagerTest extends BaseITCase {
 
         Path testRecipePath = Paths.get(LogManagerTest.class.getResource(configFileName).toURI());
         String content = new String(Files.readAllBytes(testRecipePath), StandardCharsets.UTF_8);
-        content = content.replaceAll("\\{\\{logFileDirectoryPath}}",
-                storeDirectory.toAbsolutePath().toString());
+        content = content.replaceAll("\\{\\{logFileDirectoryPath}}", storeDirectory.toAbsolutePath().toString());
 
         Map<String, Object> objectMap = YAML_OBJECT_MAPPER.readValue(content, Map.class);
         kernel.parseArgs();
         kernel.getConfig().mergeMap(System.currentTimeMillis(), ConfigPlatformResolver.resolvePlatformMap(objectMap));
 
         kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
-            if (service.getName().equals(LogManagerService.LOGS_UPLOADER_SERVICE_TOPICS)
-                    && newState.equals(State.RUNNING)) {
+            if (service.getName().equals(LogManagerService.LOGS_UPLOADER_SERVICE_TOPICS) && newState.equals(State.RUNNING)) {
                 logManagerRunning.countDown();
                 logManagerService = (LogManagerService) service;
             }
         });
-        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com", "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath",
-                "certFilePath", "caFilePath", "us-east-1", "roleAliasName");
+        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
+                "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath", "certFilePath", "caFilePath",
+                "us-east-1", "roleAliasName");
 
         kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
         // set required instances from context
@@ -159,15 +163,15 @@ class LogManagerTest extends BaseITCase {
     @Test
     void GIVEN_user_component_config_with_small_periodic_interval_WHEN_interval_elapses_THEN_logs_are_uploaded_to_cloud()
             throws Exception {
-        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
-                .thenReturn(PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
+        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(
+                PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
 
         tempDirectoryPath = Files.createTempDirectory(tempRootDir, "IntegrationTestsTemporaryLogFiles");
 
         for (int i = 0; i < 5; i++) {
-            createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log_",  "");
+            createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log_", "");
         }
-        createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log",  "");
+        createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log", "");
 
         setupKernel(tempDirectoryPath, "smallPeriodicIntervalUserComponentConfig.yaml");
         TimeUnit.SECONDS.sleep(30);
@@ -177,12 +181,11 @@ class LogManagerTest extends BaseITCase {
         assertEquals(1, putLogEventsRequests.size());
         for (PutLogEventsRequest request : putLogEventsRequests) {
             assertEquals(calculateLogStreamName(THING_NAME, LOCAL_DEPLOYMENT_GROUP_NAME), request.logStreamName());
-            assertEquals("/aws/greengrass/UserComponent/" + AWS_REGION + "/UserComponentA",
-                    request.logGroupName());
+            assertEquals("/aws/greengrass/UserComponent/" + AWS_REGION + "/UserComponentA", request.logGroupName());
             assertNotNull(request.logEvents());
-            assertEquals(DEFAULT_LOG_LINE_IN_FILE*6, request.logEvents().size());
-            assertEquals(DEFAULT_FILE_SIZE*6, request.logEvents().stream().mapToLong(value -> value.message().length())
-                    .sum());
+            assertEquals(DEFAULT_LOG_LINE_IN_FILE * 6, request.logEvents().size());
+            assertEquals(DEFAULT_FILE_SIZE * 6,
+                    request.logEvents().stream().mapToLong(value -> value.message().length()).sum());
         }
         File folder = tempDirectoryPath.toFile();
         Pattern logFileNamePattern = Pattern.compile("^integTestRandomLogFiles.log\\w*");
@@ -190,9 +193,7 @@ class LogManagerTest extends BaseITCase {
         File[] files = folder.listFiles();
         if (files != null) {
             for (File file : files) {
-                if (file.isFile()
-                        && logFileNamePattern.matcher(file.getName()).find()
-                        && file.length() > 0) {
+                if (file.isFile() && logFileNamePattern.matcher(file.getName()).find() && file.length() > 0) {
                     allFiles.add(file);
                 }
             }
@@ -203,8 +204,8 @@ class LogManagerTest extends BaseITCase {
     @Test
     void GIVEN_user_component_config_with_small_periodic_interval_and_only_required_config_WHEN_interval_elapses_THEN_logs_are_uploaded_to_cloud()
             throws Exception {
-        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
-                .thenReturn(PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
+        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(
+                PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
 
         tempDirectoryPath = Files.createDirectory(tempRootDir.resolve("logs"));
         LogConfig.getRootLogConfig().setLevel(Level.TRACE);
@@ -225,12 +226,11 @@ class LogManagerTest extends BaseITCase {
         assertEquals(1, putLogEventsRequests.size());
         for (PutLogEventsRequest request : putLogEventsRequests) {
             assertEquals(calculateLogStreamName(THING_NAME, LOCAL_DEPLOYMENT_GROUP_NAME), request.logStreamName());
-            assertEquals("/aws/greengrass/UserComponent/" + AWS_REGION + "/UserComponentB",
-                    request.logGroupName());
+            assertEquals("/aws/greengrass/UserComponent/" + AWS_REGION + "/UserComponentB", request.logGroupName());
             assertNotNull(request.logEvents());
-            assertEquals(DEFAULT_LOG_LINE_IN_FILE*6, request.logEvents().size());
-            assertEquals(DEFAULT_FILE_SIZE*6, request.logEvents().stream().mapToLong(value -> value.message().length())
-                    .sum());
+            assertEquals(DEFAULT_LOG_LINE_IN_FILE * 6, request.logEvents().size());
+            assertEquals(DEFAULT_FILE_SIZE * 6,
+                    request.logEvents().stream().mapToLong(value -> value.message().length()).sum());
         }
         File folder = tempDirectoryPath.toFile();
         Pattern logFileNamePattern = Pattern.compile("^UserComponentB\\w*.log");
@@ -238,9 +238,7 @@ class LogManagerTest extends BaseITCase {
         File[] files = folder.listFiles();
         if (files != null) {
             for (File file : files) {
-                if (file.isFile()
-                        && logFileNamePattern.matcher(file.getName()).find()
-                        && file.length() > 0) {
+                if (file.isFile() && logFileNamePattern.matcher(file.getName()).find() && file.length() > 0) {
                     allFiles.add(file);
                 }
             }
@@ -251,8 +249,8 @@ class LogManagerTest extends BaseITCase {
     @Test
     void GIVEN_system_config_with_small_periodic_interval_WHEN_interval_elapses_THEN_logs_are_uploaded_to_cloud(
             ExtensionContext ec) throws Exception {
-        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
-                .thenReturn(PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
+        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(
+                PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
 
         ignoreExceptionOfType(ec, NoSuchFileException.class);
         LogManager.getRootLogConfiguration().setStoreDirectory(tempRootDir);
@@ -273,12 +271,11 @@ class LogManagerTest extends BaseITCase {
 
         for (PutLogEventsRequest request : putLogEventsRequests) {
             assertEquals(calculateLogStreamName(THING_NAME, LOCAL_DEPLOYMENT_GROUP_NAME), request.logStreamName());
-            assertEquals("/aws/greengrass/GreengrassSystemComponent/" + AWS_REGION + "/System",
-                    request.logGroupName());
+            assertEquals("/aws/greengrass/GreengrassSystemComponent/" + AWS_REGION + "/System", request.logGroupName());
             assertNotNull(request.logEvents());
-            assertTrue(request.logEvents().size() >= DEFAULT_LOG_LINE_IN_FILE*6);
+            assertTrue(request.logEvents().size() >= DEFAULT_LOG_LINE_IN_FILE * 6);
             assertTrue(request.logEvents().stream().mapToLong(value -> value.message().length()).sum()
-                    >= DEFAULT_FILE_SIZE*6);
+                    >= DEFAULT_FILE_SIZE * 6);
         }
         File folder = tempDirectoryPath.toFile();
         Pattern logFileNamePattern = Pattern.compile(String.format(DEFAULT_FILE_REGEX, fileName));
@@ -286,9 +283,7 @@ class LogManagerTest extends BaseITCase {
         File[] files = folder.listFiles();
         if (files != null) {
             for (File file : files) {
-                if (file.isFile()
-                        && logFileNamePattern.matcher(file.getName()).find()
-                        && file.length() > 0) {
+                if (file.isFile() && logFileNamePattern.matcher(file.getName()).find() && file.length() > 0) {
                     allFiles.add(file);
                 }
             }
@@ -301,8 +296,7 @@ class LogManagerTest extends BaseITCase {
             throws Exception {
         ignoreExceptionWithMessage(context, "Forcing error to trigger restart");
 
-        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
-                .thenThrow(new RuntimeException("Forcing error to trigger restart"))
+        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenThrow(new RuntimeException("Forcing error to trigger restart"))
                 .thenReturn(PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
 
         tempDirectoryPath = Files.createTempDirectory(tempRootDir, "IntegrationTestsTemporaryLogFiles");
@@ -337,8 +331,8 @@ class LogManagerTest extends BaseITCase {
             assertEquals(calculateLogStreamName(THING_NAME, LOCAL_DEPLOYMENT_GROUP_NAME), request.logStreamName());
             assertEquals("/aws/greengrass/UserComponent/" + AWS_REGION + "/UserComponentA", request.logGroupName());
             assertNotNull(request.logEvents());
-            assertEquals(DEFAULT_LOG_LINE_IN_FILE*6, request.logEvents().size());
-            assertEquals(DEFAULT_FILE_SIZE*6,
+            assertEquals(DEFAULT_LOG_LINE_IN_FILE * 6, request.logEvents().size());
+            assertEquals(DEFAULT_FILE_SIZE * 6,
                     request.logEvents().stream().mapToLong(value -> value.message().length()).sum());
         }
         File folder = tempDirectoryPath.toFile();
@@ -355,103 +349,155 @@ class LogManagerTest extends BaseITCase {
         assertEquals(1, allFiles.size());
     }
 
-    //TODO: this test is only for getting some certain level of knowledge of current change uploading active log file
-    // . It will be eventually removed.
     @Test
-    void GIVEN_user_component_config_with_small_periodic_interval_WHEN_active_logs_included_THEN_logs_are_uploaded_to_cloud()
+    void GIVEN_files_randomly_named_WHEN_all_files_renamed_randomly_THEN_all_files_only_send_once()
             throws Exception {
-        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
-                .thenReturn(PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
-        //logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
-        tempDirectoryPath = Files.createTempDirectory(tempRootDir, "IntegrationTestsTemporaryLogFiles");
+        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(
+                PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
 
-        for (int i = 0; i < 5; i++) {
-            createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log_",  "");
+        tempDirectoryPath = Files.createDirectory(tempRootDir.resolve("logs"));
+        LogConfig.getRootLogConfig().setLevel(Level.TRACE);
+        LogConfig.getRootLogConfig().setStore(LogStore.FILE);
+        LogManager.getLogConfigurations().putIfAbsent("UserComponentB",
+                newLogConfigFromRootConfig(LogConfigUpdate.builder().fileName("UserComponentB.log").build()));
+
+        List<LogFile> logFiles = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            String randomName1 = UUID.randomUUID().toString();
+            String randomName2 = UUID.randomUUID().toString();
+            LogFile logFile = createTempFileAndWriteDataAndReturnFile(tempDirectoryPath,
+                    randomName1 + "UserComponentB.", randomName2);
+            logFiles.add(logFile);
         }
-        createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log",  "");
 
-        setupKernel(tempDirectoryPath, "smallPeriodicIntervalUserComponentConfig.yaml");
-        //TODO: a better mechanism should be written. The lazy sleep should be replaced by some condition checks.
-        TimeUnit.SECONDS.sleep(30);
-        verify(cloudWatchLogsClient, atLeastOnce()).putLogEvents(captor.capture());
+        setupKernel(tempDirectoryPath, "randomlyNamedFilesWithoutComponentsConfig.yaml");
+        TimeUnit.SECONDS.sleep(15);
+
+        // randomly rename file and see if uploader trying to process more file.
+        for (LogFile logFile : logFiles) {
+            String randomName3 = UUID.randomUUID().toString();
+            String randomName4 = UUID.randomUUID().toString();
+            LogFile renameFile = new LogFile(Files.createTempFile(tempDirectoryPath,
+                    randomName3 + "UserComponentB.", randomName4).toUri());
+            String tempFileHash = logFile.hashString();
+            logFile.renameTo(renameFile);
+            assertEquals(renameFile.hashString(), tempFileHash);
+            assertFalse(logFile.exists());
+        }
+
+        TimeUnit.SECONDS.sleep(15);
+
+        // Even the file are all renamed, the cloudWatchClient should only try to upload events once, and the total
+        // size should be contents of 4 files.
+        verify(cloudWatchLogsClient, times(1)).putLogEvents(captor.capture());
 
         List<PutLogEventsRequest> putLogEventsRequests = captor.getAllValues();
         assertEquals(1, putLogEventsRequests.size());
         for (PutLogEventsRequest request : putLogEventsRequests) {
             assertEquals(calculateLogStreamName(THING_NAME, LOCAL_DEPLOYMENT_GROUP_NAME), request.logStreamName());
-            assertEquals("/aws/greengrass/UserComponent/" + AWS_REGION + "/UserComponentA",
-                    request.logGroupName());
+            assertEquals("/aws/greengrass/UserComponent/" + AWS_REGION + "/UserComponentB", request.logGroupName());
             assertNotNull(request.logEvents());
-            assertEquals(DEFAULT_LOG_LINE_IN_FILE * 6, request.logEvents().size());
-            assertEquals(DEFAULT_FILE_SIZE * 6,
-                    request.logEvents().stream().mapToLong(value -> value.message().length())
-                    .sum());
+            assertEquals(DEFAULT_LOG_LINE_IN_FILE*4, request.logEvents().size());
+            assertEquals(DEFAULT_FILE_SIZE*4,
+                    request.logEvents().stream().mapToLong(value -> value.message().length()).sum());
         }
         File folder = tempDirectoryPath.toFile();
-        Pattern logFileNamePattern = Pattern.compile("^integTestRandomLogFiles.log\\w*");
+        Pattern logFileNamePattern = Pattern.compile("\\w*UserComponentB\\w*.\\w*");
         List<File> allFiles = new ArrayList<>();
-        File[] filesInDirectory = folder.listFiles();
-        if (filesInDirectory != null) {
-            for (File file : filesInDirectory) {
-                if (file.isFile()
-                        && logFileNamePattern.matcher(file.getName()).find()
-                        && file.length() > 0) {
+        File[] files = folder.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file.isFile() && logFileNamePattern.matcher(file.getName()).find() && file.length() > 0) {
                     allFiles.add(file);
                 }
             }
         }
-        assertEquals(1, allFiles.size());
-        //logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
+        assertEquals(4, allFiles.size());
     }
 
-    //TODO: this test is only for getting some certain level of knowledge of current change uploading active log file
-    // . It will be eventually removed.
     @Test
-    void GIVEN_system_config_with_small_periodic_interval_WHEN_active_logs_included_THEN_logs_are_uploaded_to_cloud(
-            ExtensionContext ec) throws Exception {
-        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
-                .thenReturn(PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
-        //logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
-        LogManager.getRootLogConfiguration().setStoreDirectory(tempRootDir);
-        tempDirectoryPath = LogManager.getRootLogConfiguration().getStoreDirectory().resolve("logs");
-        String fileName = LogManager.getRootLogConfiguration().getFileName();
-        Files.createDirectory(tempDirectoryPath);
-        for (int i = 0; i < 5; i++) {
-            createTempFileAndWriteData(tempDirectoryPath, fileName, ".log");
-        }
-        createTempFileAndWriteData(tempDirectoryPath, fileName + ".log", "");
+    void GIVEN_files_randomly_named_WHEN_all_files_renamed_randomly_and_new_data_in_active_file_THEN_all_files_only_send_once()
+            throws Exception {
+        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenReturn(
+                PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
 
-        setupKernel(tempRootDir, "smallPeriodicIntervalSystemComponentConfig.yaml");
-        //TODO: a better mechanism will be written. The lazy sleep should be replaced by some condition checks.
-        TimeUnit.SECONDS.sleep(30);
-        verify(cloudWatchLogsClient, atLeastOnce()).putLogEvents(captor.capture());
+        tempDirectoryPath = Files.createDirectory(tempRootDir.resolve("logs"));
+        LogConfig.getRootLogConfig().setLevel(Level.TRACE);
+        LogConfig.getRootLogConfig().setStore(LogStore.FILE);
+        LogManager.getLogConfigurations().putIfAbsent("UserComponentB",
+                newLogConfigFromRootConfig(LogConfigUpdate.builder().fileName("UserComponentB.log").build()));
+
+        List<LogFile> logFiles = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            String randomName1 = UUID.randomUUID().toString();
+            String randomName2 = UUID.randomUUID().toString();
+            LogFile logFile = createTempFileAndWriteDataAndReturnFile(tempDirectoryPath,
+                    randomName1 + "UserComponentB.", randomName2);
+            logFiles.add(logFile);
+        }
+
+        setupKernel(tempDirectoryPath, "randomlyNamedFilesWithoutComponentsConfig.yaml");
+        TimeUnit.SECONDS.sleep(15);
+
+        // randomly rename file and see if uploader trying to process more file.
+        logFiles.sort(Comparator.comparingLong(LogFile::lastModified));
+        for (int i = 0; i < logFiles.size(); i++) {
+            LogFile logFile = logFiles.get(i);
+            String randomName3 = UUID.randomUUID().toString();
+            String randomName4 = UUID.randomUUID().toString();
+            LogFile renameFile = new LogFile(Files.createTempFile(tempDirectoryPath,
+                    randomName3 + "UserComponentB.", randomName4).toUri());
+            String tempFileHash = logFile.hashString();
+            logFile.renameTo(renameFile);
+            if (i == logFiles.size() - 1) {
+                 //generate 10250 bytes
+                 List<String> randomMessages = generateRandomMessages();
+                 for (String messageBytes : randomMessages) {
+                    addDataToFile(messageBytes, renameFile.toPath());
+                 }
+            }
+
+            assertEquals(renameFile.hashString(), tempFileHash);
+            assertFalse(logFile.exists());
+        }
+
+        TimeUnit.SECONDS.sleep(15);
+
+        // Even the file are all renamed, the cloudWatchClient should only try to upload events once, and the total
+        // size should be contents of 4 files.
+        verify(cloudWatchLogsClient, times(2)).putLogEvents(captor.capture());
 
         List<PutLogEventsRequest> putLogEventsRequests = captor.getAllValues();
-        assertEquals(1, putLogEventsRequests.size());
-
-        for (PutLogEventsRequest request : putLogEventsRequests) {
+        assertEquals(2, putLogEventsRequests.size());
+        for (int i=0; i < 2; i++) {
+            PutLogEventsRequest request = putLogEventsRequests.get(i);
             assertEquals(calculateLogStreamName(THING_NAME, LOCAL_DEPLOYMENT_GROUP_NAME), request.logStreamName());
-            assertEquals("/aws/greengrass/GreengrassSystemComponent/" + AWS_REGION + "/System",
-                    request.logGroupName());
+            assertEquals("/aws/greengrass/UserComponent/" + AWS_REGION + "/UserComponentB", request.logGroupName());
             assertNotNull(request.logEvents());
-            assertTrue(request.logEvents().size() >= DEFAULT_LOG_LINE_IN_FILE * 6);
-            assertTrue(request.logEvents().stream().mapToLong(value -> value.message().length()).sum()
-                    >= DEFAULT_FILE_SIZE * 6);
+            if (i == 1) {
+                assertEquals(DEFAULT_LOG_LINE_IN_FILE, request.logEvents().size());
+                assertEquals(DEFAULT_FILE_SIZE,
+                        request.logEvents().stream().mapToLong(value -> value.message().length()).sum());
+            }
+            if (i == 0) {
+                assertEquals(DEFAULT_LOG_LINE_IN_FILE * 4, request.logEvents().size());
+                assertEquals(DEFAULT_FILE_SIZE * 4,
+                        request.logEvents().stream().mapToLong(value -> value.message().length()).sum());
+            }
         }
+
         File folder = tempDirectoryPath.toFile();
-        Pattern logFileNamePattern = Pattern.compile(String.format(DEFAULT_FILE_REGEX, fileName));
+        Pattern logFileNamePattern = Pattern.compile("\\w*UserComponentB\\w*.\\w*");
         List<File> allFiles = new ArrayList<>();
-        File[] filesInDirectory = folder.listFiles();
-        if (filesInDirectory != null) {
-            for (File file : filesInDirectory) {
-                if (file.isFile()
-                        && logFileNamePattern.matcher(file.getName()).find()
-                        && file.length() > 0) {
+        File[] files = folder.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file.isFile() && logFileNamePattern.matcher(file.getName()).find() && file.length() > 0) {
                     allFiles.add(file);
                 }
             }
         }
-        assertEquals(1, allFiles.size());
-        //logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
+        assertEquals(4, allFiles.size());
+
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -180,8 +180,8 @@ class LogManagerTest extends BaseITCase {
             assertEquals("/aws/greengrass/UserComponent/" + AWS_REGION + "/UserComponentA",
                     request.logGroupName());
             assertNotNull(request.logEvents());
-            assertEquals(50, request.logEvents().size());
-            assertEquals(51200, request.logEvents().stream().mapToLong(value -> value.message().length())
+            assertEquals(DEFAULT_LOG_LINE_IN_FILE*6, request.logEvents().size());
+            assertEquals(DEFAULT_FILE_SIZE*6, request.logEvents().stream().mapToLong(value -> value.message().length())
                     .sum());
         }
         File folder = tempDirectoryPath.toFile();
@@ -228,8 +228,8 @@ class LogManagerTest extends BaseITCase {
             assertEquals("/aws/greengrass/UserComponent/" + AWS_REGION + "/UserComponentB",
                     request.logGroupName());
             assertNotNull(request.logEvents());
-            assertEquals(50, request.logEvents().size());
-            assertEquals(51200, request.logEvents().stream().mapToLong(value -> value.message().length())
+            assertEquals(DEFAULT_LOG_LINE_IN_FILE*6, request.logEvents().size());
+            assertEquals(DEFAULT_FILE_SIZE*6, request.logEvents().stream().mapToLong(value -> value.message().length())
                     .sum());
         }
         File folder = tempDirectoryPath.toFile();
@@ -276,9 +276,9 @@ class LogManagerTest extends BaseITCase {
             assertEquals("/aws/greengrass/GreengrassSystemComponent/" + AWS_REGION + "/System",
                     request.logGroupName());
             assertNotNull(request.logEvents());
-            assertTrue(request.logEvents().size() >= 50);
+            assertTrue(request.logEvents().size() >= DEFAULT_LOG_LINE_IN_FILE*6);
             assertTrue(request.logEvents().stream().mapToLong(value -> value.message().length()).sum()
-                    >= 51200);
+                    >= DEFAULT_FILE_SIZE*6);
         }
         File folder = tempDirectoryPath.toFile();
         Pattern logFileNamePattern = Pattern.compile(String.format(DEFAULT_FILE_REGEX, fileName));
@@ -337,8 +337,9 @@ class LogManagerTest extends BaseITCase {
             assertEquals(calculateLogStreamName(THING_NAME, LOCAL_DEPLOYMENT_GROUP_NAME), request.logStreamName());
             assertEquals("/aws/greengrass/UserComponent/" + AWS_REGION + "/UserComponentA", request.logGroupName());
             assertNotNull(request.logEvents());
-            assertEquals(50, request.logEvents().size());
-            assertEquals(51200, request.logEvents().stream().mapToLong(value -> value.message().length()).sum());
+            assertEquals(DEFAULT_LOG_LINE_IN_FILE*6, request.logEvents().size());
+            assertEquals(DEFAULT_FILE_SIZE*6,
+                    request.logEvents().stream().mapToLong(value -> value.message().length()).sum());
         }
         File folder = tempDirectoryPath.toFile();
         Pattern logFileNamePattern = Pattern.compile("^integTestRandomLogFiles.log\\w*");
@@ -361,7 +362,7 @@ class LogManagerTest extends BaseITCase {
             throws Exception {
         when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
                 .thenReturn(PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
-        logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
+        //logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         tempDirectoryPath = Files.createTempDirectory(tempRootDir, "IntegrationTestsTemporaryLogFiles");
 
         for (int i = 0; i < 5; i++) {
@@ -400,7 +401,7 @@ class LogManagerTest extends BaseITCase {
             }
         }
         assertEquals(1, allFiles.size());
-        logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
+        //logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     //TODO: this test is only for getting some certain level of knowledge of current change uploading active log file
@@ -410,7 +411,7 @@ class LogManagerTest extends BaseITCase {
             ExtensionContext ec) throws Exception {
         when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
                 .thenReturn(PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
-        logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
+        //logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         LogManager.getRootLogConfiguration().setStoreDirectory(tempRootDir);
         tempDirectoryPath = LogManager.getRootLogConfiguration().getStoreDirectory().resolve("logs");
         String fileName = LogManager.getRootLogConfiguration().getFileName();
@@ -451,6 +452,6 @@ class LogManagerTest extends BaseITCase {
             }
         }
         assertEquals(1, allFiles.size());
-        logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
+        //logManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/util/LogFileHelper.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/util/LogFileHelper.java
@@ -5,6 +5,8 @@
 
 package com.aws.greengrass.integrationtests.logmanager.util;
 
+import com.aws.greengrass.logmanager.model.LogFile;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -60,7 +62,6 @@ public final class LogFileHelper {
             throws IOException {
         Path filePath = tempDirectoryPath.resolve(fileName + ".log");
         if (!Files.exists(filePath)) {
-            System.out.println(fileName + " does not exist");
             Files.createFile(filePath);
         }
         File file = filePath.toFile();
@@ -68,5 +69,16 @@ public final class LogFileHelper {
         for (String messageBytes : randomMessages) {
             addDataToFile(messageBytes, file.toPath());
         }
+    }
+
+    public static LogFile createTempFileAndWriteDataAndReturnFile(Path tempDirectoryPath, String fileNamePrefix,
+                                                                  String fileNameSuffix) throws IOException {
+        Path filePath = Files.createTempFile(tempDirectoryPath, fileNamePrefix, fileNameSuffix);
+        File file = filePath.toFile();
+        List<String> randomMessages = generateRandomMessages();
+        for (String messageBytes : randomMessages) {
+            addDataToFile(messageBytes, file.toPath());
+        }
+        return LogFile.of(file);
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/util/LogFileHelper.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/util/LogFileHelper.java
@@ -60,6 +60,7 @@ public final class LogFileHelper {
             throws IOException {
         Path filePath = tempDirectoryPath.resolve(fileName + ".log");
         if (!Files.exists(filePath)) {
+            System.out.println(fileName + " does not exist");
             Files.createFile(filePath);
         }
         File file = filePath.toFile();

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/randomlyNamedFilesWithoutComponentsConfig.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/randomlyNamedFilesWithoutComponentsConfig.yaml
@@ -1,0 +1,20 @@
+---
+services:
+  aws.greengrass.LogManager:
+    configuration:
+      periodicUploadIntervalSec: 10
+      logsUploaderConfiguration:
+        componentLogsConfiguration:
+          - componentName: 'UserComponentB'
+            logFileRegex: '\w*UserComponentB\w*.\w*'
+            logFileDirectoryPath: '{{logFileDirectoryPath}}'
+            minimumLogLevel: 'INFO'
+            diskSpaceLimit: '25'
+            diskSpaceLimitUnit: 'MB'
+            deleteLogFileAfterCloudUpload: 'false'
+  main:
+    lifecycle:
+      install:
+        all: echo All installed
+    dependencies:
+      - aws.greengrass.LogManager

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -101,12 +101,8 @@ public class LogManagerService extends PluginService {
     public static final String DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME = "deleteLogFileAfterCloudUpload";
     public static final String UPLOAD_TO_CW_CONFIG_TOPIC_NAME = "uploadToCloudWatch";
     public static final String MULTILINE_PATTERN_CONFIG_TOPIC_NAME = "multiLineStartPattern";
-    public static final String USER_COMPONENT_UPLOAD_TO_CW_CONFIG_TOPIC_NAME = "userComponentUploadToCloudWatch";
     public static final int DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC = 300;
     private final Object spaceManagementLock = new Object();
-    // TODO: this is the flag to marking the code that used for the feature development, in order to maintain PR
-    //  small and we can modify tests in the following PR.
-    public static final AtomicBoolean ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG = new AtomicBoolean(true);
 
     // public only for integ tests
     public final Map<String, Instant> lastComponentUploadedLogFileInstantMap =
@@ -251,10 +247,9 @@ public class LogManagerService extends PluginService {
         logger.atInfo().kv("componentName", componentLogConfiguration.getName())
                 .log("Process LogManager configuration for Greengrass user component");
         setCommonComponentConfiguration(componentConfigMap, componentLogConfiguration);
-        if (componentLogConfiguration.isUploadToCloudWatch()) {
-            newComponentLogConfigurations.put(componentLogConfiguration.getName(), componentLogConfiguration);
-            loadStateFromConfiguration(componentLogConfiguration.getName());
-        }
+        newComponentLogConfigurations.put(componentLogConfiguration.getName(), componentLogConfiguration);
+        loadStateFromConfiguration(componentLogConfiguration.getName());
+
     }
 
     @SuppressWarnings("PMD.ConfusingTernary")
@@ -285,9 +280,6 @@ public class LogManagerService extends PluginService {
                         componentLogConfiguration.setMultiLineStartPattern(Pattern
                                 .compile(multiLineStartPatternString));
                     }
-                    break;
-                case USER_COMPONENT_UPLOAD_TO_CW_CONFIG_TOPIC_NAME:
-                    componentLogConfiguration.setUploadToCloudWatch(Coerce.toBoolean(val));
                     break;
                 default:
                     break;
@@ -631,14 +623,12 @@ public class LogManagerService extends PluginService {
                                 }
                             }
 
-                            //TODO: setting this flag is only to develop incrementally without having to changed all
-                            // tests yet, so that we can avoid a massive PR. This will be removed in the end.
-                            if (ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.get()) {
-                                if (file.fileEquals(logFileGroup.getActiveFile().get())
-                                        && startPosition == file.length()) {
-                                    isActiveFileCompleted.set(true);
-                                }
+                            // if this is the active file and already uploaded all contents, we shall not process it.
+                            if (file.fileEquals(logFileGroup.getActiveFile().get())
+                                    && startPosition == file.length()) {
+                                isActiveFileCompleted.set(true);
                             }
+
 
                             LogFileInformation logFileInformation = LogFileInformation.builder()
                                             .logFile(file)

--- a/src/main/java/com/aws/greengrass/logmanager/model/ComponentLogConfiguration.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/ComponentLogConfiguration.java
@@ -25,6 +25,5 @@ public class ComponentLogConfiguration {
     private Level minimumLogLevel = Level.INFO;
     private Long diskSpaceLimit;
     private boolean deleteLogFileAfterCloudUpload;
-    private boolean uploadToCloudWatch;
     private ComponentType componentType;
 }

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -55,12 +55,20 @@ public final class LogFileGroup {
         if (files.length != 0) {
             for (LogFile file: files) {
                 String fileHash = file.hashString();
+                boolean isModifiedAfterLastUpdatedFile =
+                        lastUpdated.isBefore(Instant.ofEpochMilli(file.lastModified()));
+                boolean isNameMatchPattern = filePattern.matcher(file.getName()).find();
+                boolean isEmptyFileHash = Utils.isEmpty(fileHash);
+                System.out.println("before: " + file.getName() + " | empty hash: " + isEmptyFileHash + " | name "
+                        + "match: "
+                        + isNameMatchPattern + " | modify:" + isModifiedAfterLastUpdatedFile);
                 if (file.isFile()
-                        && lastUpdated.isBefore(Instant.ofEpochMilli(file.lastModified()))
-                        && filePattern.matcher(file.getName()).find()
-                        && !Utils.isEmpty(fileHash)) {
+                        && isModifiedAfterLastUpdatedFile
+                        && isNameMatchPattern
+                        && !isEmptyFileHash) {
                     allFiles.add(file);
                     fileHashToLogFile.put(fileHash, file);
+                    System.out.println(file.getName());
                 }
             }
         }

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -16,7 +16,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
-import static com.aws.greengrass.logmanager.LogManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG;
 
 public final class LogFileGroup {
     @Getter
@@ -70,14 +69,6 @@ public final class LogFileGroup {
             }
         }
         allFiles.sort(Comparator.comparingLong(LogFile::lastModified));
-        //TODO: setting this flag is only to develop incrementally without having to changed all tests yet, so that
-        // we can avoid a massive PR. This will be removed in the end.
-        if (!ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.get()) {
-            if (allFiles.size() - 1 <= 0) {
-                return new LogFileGroup(new ArrayList<>(), filePattern, directoryURI, lastUpdated);
-            }
-            allFiles = allFiles.subList(0, allFiles.size() - 1);
-        }
         return new LogFileGroup(allFiles, filePattern, directoryURI, lastUpdated);
     }
 

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -59,16 +59,13 @@ public final class LogFileGroup {
                         lastUpdated.isBefore(Instant.ofEpochMilli(file.lastModified()));
                 boolean isNameMatchPattern = filePattern.matcher(file.getName()).find();
                 boolean isEmptyFileHash = Utils.isEmpty(fileHash);
-                System.out.println("before: " + file.getName() + " | empty hash: " + isEmptyFileHash + " | name "
-                        + "match: "
-                        + isNameMatchPattern + " | modify:" + isModifiedAfterLastUpdatedFile);
+
                 if (file.isFile()
                         && isModifiedAfterLastUpdatedFile
                         && isNameMatchPattern
                         && !isEmptyFileHash) {
                     allFiles.add(file);
                     fileHashToLogFile.put(fileHash, file);
-                    System.out.println(file.getName());
                 }
             }
         }

--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
@@ -7,11 +7,13 @@ package com.aws.greengrass.logmanager;
 
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.logmanager.exceptions.InvalidLogGroupException;
 import com.aws.greengrass.logmanager.model.CloudWatchAttempt;
 import com.aws.greengrass.logmanager.model.CloudWatchAttemptLogInformation;
 import com.aws.greengrass.logmanager.model.ComponentLogFileInformation;
 import com.aws.greengrass.logmanager.model.ComponentType;
 import com.aws.greengrass.logmanager.model.LogFile;
+import com.aws.greengrass.logmanager.model.LogFileGroup;
 import com.aws.greengrass.logmanager.model.LogFileInformation;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
@@ -57,6 +59,7 @@ import java.util.regex.Pattern;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_AWS_REGION;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
 import static com.aws.greengrass.logmanager.CloudWatchAttemptLogsProcessor.DEFAULT_LOG_GROUP_NAME;
+import static com.aws.greengrass.logmanager.util.TestUtils.createLogFileWithSize;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -85,6 +88,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     static Path directoryPath;
 
     private CloudWatchAttemptLogsProcessor logsProcessor;
+    private final static Instant mockInstant = Instant.EPOCH;
 
     @BeforeEach
     public void startup() {
@@ -96,12 +100,14 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
     @Test
     void GIVEN_one_system_component_one_file_less_than_max_WHEN_merge_THEN_reads_entire_file(ExtensionContext ec)
-            throws URISyntaxException {
+            throws URISyntaxException, IOException, InvalidLogGroupException {
         ignoreExceptionOfType(ec, DateTimeParseException.class);
+        //LogFile logFile1 = createLogFileWithSize(getClass().getResource("testlogs2.log").toURI(), 1061);
         File file1 = new File(getClass().getResource("testlogs2.log").toURI());
         LogFile logFile1 = LogFile.of(file1);
+        String fileHash = logFile1.hashString();
         List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile1).build());
+        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile1).fileHash(fileHash).build());
         ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                 .name("TestComponent")
                 .desiredLogLevel(Level.INFO)
@@ -121,9 +127,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
         assertNotNull(logEventsForStream1.getLogEvents());
         assertEquals(13, logEventsForStream1.getLogEvents().size());
-        assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file1.getAbsolutePath()));
-        assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getStartPosition());
-        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
+        assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
+        assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getStartPosition());
+        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
         assertEquals("TestComponent", logEventsForStream1.getComponentName());
         for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
             Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
@@ -142,8 +148,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
         File file1 = new File(getClass().getResource("testlogs2.log").toURI());
         LogFile logFile1 = LogFile.of(file1);
+        String fileHash = logFile1.hashString();
         List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile1).build());
+        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile1).fileHash(fileHash).build());
         ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                 .name("TestComponent")
                 .desiredLogLevel(Level.INFO)
@@ -163,9 +170,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
         assertNotNull(logEventsForStream1.getLogEvents());
         assertEquals(13, logEventsForStream1.getLogEvents().size());
-        assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file1.getAbsolutePath()));
-        assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getStartPosition());
-        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
+        assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
+        assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getStartPosition());
+        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
         assertEquals("TestComponent", logEventsForStream1.getComponentName());
         for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
             Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
@@ -184,8 +191,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
         File file1 = new File(getClass().getResource("testlogs2.log").toURI());
         LogFile logFile1 = LogFile.of(file1);
+        String fileHash = logFile1.hashString();
         List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile1).build());
+        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile1).fileHash(fileHash).build());
         ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                 .name("TestComponent")
                 .desiredLogLevel(Level.INFO)
@@ -205,9 +213,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
         assertNotNull(logEventsForStream1.getLogEvents());
         assertEquals(13, logEventsForStream1.getLogEvents().size());
-        assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file1.getAbsolutePath()));
-        assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getStartPosition());
-        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
+        assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
+        assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getStartPosition());
+        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
         assertEquals("TestComponent", logEventsForStream1.getComponentName());
         for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
             Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
@@ -225,7 +233,6 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
         ignoreExceptionOfType(context1, DateTimeParseException.class);
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
-        LogFile logFile = LogFile.of(file);
         assertTrue(file.createNewFile());
         assertTrue(file.setReadable(true));
         assertTrue(file.setWritable(true));
@@ -239,10 +246,11 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
                 fileOutputStream.write(generatedString.toString().getBytes(StandardCharsets.UTF_8));
             }
         }
-
+        LogFile logFile = LogFile.of(file);
+        String fileHash = logFile.hashString();
         try {
             List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).build());
+            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).fileHash(fileHash).build());
             ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                     .name("TestComponent")
                     .desiredLogLevel(Level.INFO)
@@ -263,9 +271,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
             assertNotNull(logEventsForStream1.getLogEvents());
             assertEquals(991, logEventsForStream1.getLogEvents().size());
-            assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file.getAbsolutePath()));
-            assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath()).getStartPosition());
-            assertEquals(1016766, logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath()).getBytesRead());
+            assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
+            assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getStartPosition());
+            assertEquals(1016766, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
             assertEquals("TestComponent", logEventsForStream1.getComponentName());
             LocalDateTime localDateTimeNow = LocalDateTime.now(ZoneOffset.UTC);
             for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
@@ -285,7 +293,6 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     void GIVEN_one_component_one_file_24h_gap_WHEN_merge_THEN_reads_partial_file()
             throws IOException {
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
-        LogFile logFile = LogFile.of(file);
         assertTrue(file.createNewFile());
         assertTrue(file.setReadable(true));
         assertTrue(file.setWritable(true));
@@ -298,10 +305,11 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             fileOutputStream.write((sdf.format(new Date(now.toEpochMilli())) + "T01:00:00Z ABC3\n").getBytes(StandardCharsets.UTF_8));
             fileOutputStream.write((sdf.format(new Date(now.toEpochMilli())) + "T02:00:00Z ABC4\n").getBytes(StandardCharsets.UTF_8));
         }
-
+        LogFile logFile = LogFile.of(file);
+        String fileHash = logFile.hashString();
         try {
             List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).build());
+            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).fileHash(fileHash).build());
             ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                     .name("TestComponent")
                     .desiredLogLevel(Level.INFO)
@@ -326,7 +334,6 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     void GIVEN_one_component_WHEN_file_older_than_14_days_THEN_skip_file()
             throws IOException {
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
-        LogFile logFile = LogFile.of(file);
         assertTrue(file.createNewFile());
         assertTrue(file.setReadable(true));
         assertTrue(file.setWritable(true));
@@ -339,10 +346,11 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             fileOutputStream.write("2021-06-09T02:00:00Z ABC4\n".getBytes(StandardCharsets.UTF_8));
             fileOutputStream.write((sdf.format(new Date(now.toEpochMilli())) + "T02:00:00Z ABC5\n").getBytes(StandardCharsets.UTF_8));
         }
-
+        LogFile logFile = LogFile.of(file);
+        String fileHash = logFile.hashString();
         try {
             List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).build());
+            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).fileHash(fileHash).build());
             ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                     .name("TestComponent")
                     .desiredLogLevel(Level.INFO)
@@ -370,13 +378,13 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             throws URISyntaxException {
         ignoreExceptionOfType(ec, DateTimeParseException.class);
 
-        File file1 = new File(getClass().getResource("testlogs2.log").toURI());
-        LogFile logFile1 = LogFile.of(file1);
-        File file2 = new File(getClass().getResource("testlogs1.log").toURI());
-        LogFile logFile2 = LogFile.of(file2);
+        LogFile logFile1 = new LogFile(getClass().getResource("testlogs2.log").toURI());
+        String fileHash1 = logFile1.hashString();
+        LogFile logFile2 = new LogFile(getClass().getResource("testlogs1.log").toURI());
+        String fileHash2 = logFile2.hashString();
         List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile1).build());
-        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile2).build());
+        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile1).fileHash(fileHash1).build());
+        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile2).fileHash(fileHash2).build());
         ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                 .name("TestComponent")
                 .desiredLogLevel(Level.INFO)
@@ -400,9 +408,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         CloudWatchAttemptLogInformation logEventsForStream2 = attempt.getLogStreamsToLogEventsMap().get(logStream2);
         assertNotNull(logEventsForStream1.getLogEvents());
         assertEquals(13, logEventsForStream1.getLogEvents().size());
-        assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file1.getAbsolutePath()));
-        assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getStartPosition());
-        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(file1.getAbsolutePath()).getBytesRead());
+        assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash1));
+        assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash1).getStartPosition());
+        assertEquals(2943, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash1).getBytesRead());
         assertEquals("TestComponent", logEventsForStream1.getComponentName());
         for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
             Instant logTimestamp = Instant.ofEpochMilli(logEvent.timestamp());
@@ -415,9 +423,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
         assertNotNull(logEventsForStream2.getLogEvents());
         assertEquals(4, logEventsForStream2.getLogEvents().size());
-        assertTrue(logEventsForStream2.getAttemptLogFileInformationMap().containsKey(file2.getAbsolutePath()));
-        assertEquals(0, logEventsForStream2.getAttemptLogFileInformationMap().get(file2.getAbsolutePath()).getStartPosition());
-        assertEquals(1239, logEventsForStream2.getAttemptLogFileInformationMap().get(file2.getAbsolutePath()).getBytesRead());
+        assertTrue(logEventsForStream2.getAttemptLogFileInformationMap().containsKey(fileHash2));
+        assertEquals(0, logEventsForStream2.getAttemptLogFileInformationMap().get(fileHash2).getStartPosition());
+        assertEquals(1239, logEventsForStream2.getAttemptLogFileInformationMap().get(fileHash2).getBytesRead());
         assertEquals("TestComponent", logEventsForStream2.getComponentName());
     }
 
@@ -426,7 +434,6 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
         ignoreExceptionOfType(ec, DateTimeParseException.class);
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
-        LogFile logFile = LogFile.of(file);
         assertTrue(file.createNewFile());
         assertTrue(file.setReadable(true));
         assertTrue(file.setWritable(true));
@@ -448,8 +455,10 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             byte[] fileContentBytes = fileContent.toString().getBytes(StandardCharsets.UTF_8);
             fileOutputStream.write(fileContentBytes);
 
+            LogFile logFile = LogFile.of(file);
+            String fileHash = logFile.hashString();
             List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).build());
+            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).fileHash(fileHash).build());
             ComponentLogFileInformation componentLogFileInformation =
                     ComponentLogFileInformation.builder().name("TestComponent")
                             .desiredLogLevel(Level.INFO).componentType(ComponentType.GreengrassSystemComponent)
@@ -475,11 +484,11 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             assertEquals(overSizeLogLine.substring(0, MAX_EVENT_LENGTH), logEvents.get(1).message());
             assertEquals(overSizeLogLine.substring(MAX_EVENT_LENGTH), logEvents.get(2).message());
 
-            assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file.getAbsolutePath()));
-            assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath())
+            assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
+            assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash)
                     .getStartPosition());
             assertEquals(fileContentBytes.length,
-                    logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath()).getBytesRead());
+                    logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
             assertEquals("TestComponent", logEventsForStream1.getComponentName());
 
         } finally {
@@ -493,7 +502,6 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
         ignoreExceptionOfType(ec, DateTimeParseException.class);
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
-        LogFile logFile = LogFile.of(file);
         assertTrue(file.createNewFile());
         assertTrue(file.setReadable(true));
         assertTrue(file.setWritable(true));
@@ -514,8 +522,10 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             int expectedBytesRead = 2*4 + 1024*1 + MAX_EVENT_LENGTH*2 + 1 + 1*1024*256;
             fileOutputStream.write(fileContent.toString().getBytes(StandardCharsets.UTF_8));
 
+            LogFile logFile = LogFile.of(file);
+            String fileHash = logFile.hashString();
             List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).build());
+            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).fileHash(fileHash).build());
             ComponentLogFileInformation componentLogFileInformation =
                     ComponentLogFileInformation.builder().name("TestComponent")
                             .desiredLogLevel(Level.INFO).componentType(ComponentType.GreengrassSystemComponent)
@@ -536,11 +546,11 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             assertNotNull(logEventsForStream1.getLogEvents());
             // Total log events: 1 (first line) + 2 (second line) + 2 (third line) = 5
             assertEquals(5, logEventsForStream1.getLogEvents().size());
-            assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file.getAbsolutePath()));
-            assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath())
+            assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
+            assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash)
                     .getStartPosition());
             assertEquals(expectedBytesRead,
-                    logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath()).getBytesRead());
+                    logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
             assertEquals("TestComponent", logEventsForStream1.getComponentName());
 
         } finally {
@@ -552,7 +562,6 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
         ignoreExceptionOfType(ec, DateTimeParseException.class);
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
-        LogFile logFile = LogFile.of(file);
         assertTrue(file.createNewFile());
         assertTrue(file.setReadable(true));
         assertTrue(file.setWritable(true));
@@ -560,9 +569,12 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             fileOutputStream.write("null\n".getBytes(StandardCharsets.UTF_8));
         }
 
+        LogFile logFile = LogFile.of(file);
+        String fileHash = logFile.hashString();
+
         try {
             List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).build());
+            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).fileHash(fileHash).build());
             ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                     .name("TestComponent")
                     .desiredLogLevel(Level.INFO)
@@ -583,8 +595,8 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
             assertNotNull(logEventsForStream1.getLogEvents());
             assertEquals(1, logEventsForStream1.getLogEvents().size());
-            assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file.getAbsolutePath()));
-            assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath()).getStartPosition());
+            assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
+            assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getStartPosition());
             assertEquals("TestComponent", logEventsForStream1.getComponentName());
             LocalDateTime localDateTimeNow = LocalDateTime.now(ZoneOffset.UTC);
             for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
@@ -605,7 +617,6 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
         ignoreExceptionOfType(ec, DateTimeParseException.class);
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
-        LogFile logFile = LogFile.of(file);
         assertTrue(file.createNewFile());
         assertTrue(file.setReadable(true));
         assertTrue(file.setWritable(true));
@@ -620,9 +631,12 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             fileOutputStream.write(largeLineWithEmptyChunk.toString().getBytes(StandardCharsets.UTF_8));
         }
 
+        LogFile logFile = LogFile.of(file);
+        String fileHash = logFile.hashString();
+
         try {
             List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).build());
+            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).fileHash(fileHash).build());
             ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                     .name("TestComponent")
                     .desiredLogLevel(Level.INFO)
@@ -643,8 +657,8 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
             assertNotNull(logEventsForStream1.getLogEvents());
             assertEquals(2, logEventsForStream1.getLogEvents().size());
-            assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(file.getAbsolutePath()));
-            assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(file.getAbsolutePath()).getStartPosition());
+            assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
+            assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getStartPosition());
             assertEquals("TestComponent", logEventsForStream1.getComponentName());
             LocalDateTime localDateTimeNow = LocalDateTime.now(ZoneOffset.UTC);
             for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
@@ -663,7 +677,6 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     @Test
     void GIVEN_component_multiline_pattern_default_WHEN_logs_start_with_whitespace_THEN_append_to_previous_log() throws IOException{
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
-        LogFile logFile = LogFile.of(file);
         assertTrue(file.createNewFile());
         assertTrue(file.setReadable(true));
         assertTrue(file.setWritable(true));
@@ -675,9 +688,11 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             fileOutputStream.write("    at java.util.concurrent\n".getBytes(StandardCharsets.UTF_8));
             fileOutputStream.write("Caused by: NoAvailableComponentVersionException\n".getBytes(StandardCharsets.UTF_8));
         }
+        LogFile logFile = LogFile.of(file);
+        String fileHash = logFile.hashString();
         try {
             List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).build());
+            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).fileHash(fileHash).build());
             ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                     .name("TestComponent")
                     .desiredLogLevel(Level.INFO)
@@ -705,7 +720,6 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     @Test
     void GIVEN_component_multiline_pattern_set_WHEN_log_lines_do_not_match_pattern_THEN_append_to_previous_log() throws IOException{
         File file = new File(directoryPath.resolve("greengrass_test.log").toUri());
-        LogFile logFile = LogFile.of(file);
         assertTrue(file.createNewFile());
         assertTrue(file.setReadable(true));
         assertTrue(file.setWritable(true));
@@ -718,9 +732,11 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             fileOutputStream.write("   at java.util.concurrent\n".getBytes(StandardCharsets.UTF_8));
             fileOutputStream.write("4Caused by: NoAvailableComponentVersionException\n".getBytes(StandardCharsets.UTF_8));
         }
+        LogFile logFile = LogFile.of(file);
+        String fileHash = logFile.hashString();
         try {
             List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).build());
+            logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).fileHash(fileHash).build());
             ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                     .name("TestComponent")
                     .desiredLogLevel(Level.INFO)
@@ -757,9 +773,9 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
 
         File file = new File(getClass().getResource("stackoverflow.log").toURI());
         LogFile logFile = LogFile.of(file);
-
+        String fileHash = logFile.hashString();
         List<LogFileInformation> logFileInformationSet = new ArrayList<>();
-        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).build());
+        logFileInformationSet.add(LogFileInformation.builder().startPosition(0).logFile(logFile).fileHash(fileHash).build());
         ComponentLogFileInformation componentLogFileInformation = ComponentLogFileInformation.builder()
                 .name("TestComponent")
                 .desiredLogLevel(Level.INFO)

--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
@@ -13,7 +13,6 @@ import com.aws.greengrass.logmanager.model.CloudWatchAttemptLogInformation;
 import com.aws.greengrass.logmanager.model.ComponentLogFileInformation;
 import com.aws.greengrass.logmanager.model.ComponentType;
 import com.aws.greengrass.logmanager.model.LogFile;
-import com.aws.greengrass.logmanager.model.LogFileGroup;
 import com.aws.greengrass.logmanager.model.LogFileInformation;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
@@ -59,7 +58,6 @@ import java.util.regex.Pattern;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_AWS_REGION;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
 import static com.aws.greengrass.logmanager.CloudWatchAttemptLogsProcessor.DEFAULT_LOG_GROUP_NAME;
-import static com.aws.greengrass.logmanager.util.TestUtils.createLogFileWithSize;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -88,7 +86,6 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
     static Path directoryPath;
 
     private CloudWatchAttemptLogsProcessor logsProcessor;
-    private final static Instant mockInstant = Instant.EPOCH;
 
     @BeforeEach
     public void startup() {

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -263,7 +263,6 @@ class LogManagerServiceTest extends GGServiceTestUtil {
     void GIVEN_system_log_files_to_be_uploaded_WHEN_merger_merges_THEN_we_get_all_log_files()
             throws InterruptedException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -311,14 +310,12 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
         assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 6);
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_user_component_log_files_to_be_uploaded_with_required_config_as_array_WHEN_merger_merges_THEN_we_get_all_log_files()
             throws InterruptedException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -366,14 +363,12 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
         assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 6);
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_user_component_log_files_to_be_uploaded_with_required_config_WHEN_merger_merges_THEN_we_get_all_log_files()
             throws InterruptedException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -419,14 +414,12 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
         assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 6);
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_user_component_log_files_to_be_uploaded_with_all_config_WHEN_merger_merges_THEN_we_get_all_log_files()
             throws InterruptedException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -473,14 +466,12 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
         assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 6);
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_multiple_user_components_log_files_to_be_uploaded_with_all_config_WHEN_merger_merges_THEN_we_get_all_log_files()
             throws InterruptedException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -535,7 +526,6 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
         assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 6);
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     private void startServiceOnAnotherThread() {
@@ -551,7 +541,6 @@ class LogManagerServiceTest extends GGServiceTestUtil {
     void GIVEN_null_config_WHEN_config_is_processed_THEN_no_component_config_is_added(
             ExtensionContext context1) {
         ignoreExceptionOfType(context1, MismatchedInputException.class);
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
@@ -565,14 +554,12 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor);
         startServiceOnAnotherThread();
         assertThat(logsUploaderService.componentCurrentProcessingLogFile.values(), IsEmptyCollection.empty());
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_cloud_watch_attempt_handler_WHEN_attempt_completes_THEN_successfully_updates_states_for_each_component()
             throws URISyntaxException, IOException, InvalidLogGroupException {
         mockDefaultPersistedState();
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1000");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -677,14 +664,12 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertEquals(processingFile.hashString(), logsUploaderService.componentCurrentProcessingLogFile.get(
                 "TestComponent2").getFileHash());
         assertEquals(1061, logsUploaderService.componentCurrentProcessingLogFile.get("TestComponent2").getStartPosition());
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_some_system_files_uploaded_and_another_partially_uploaded_WHEN_merger_merges_THEN_sets_the_start_position_correctly()
             throws InterruptedException {
         mockDefaultPersistedState();
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -735,14 +720,12 @@ class LogManagerServiceTest extends GGServiceTestUtil {
             }
         });
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_user_component_with_space_management_WHEN_log_file_size_exceeds_limit_THEN_deletes_excess_log_files()
             throws InterruptedException, IOException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -796,7 +779,6 @@ class LogManagerServiceTest extends GGServiceTestUtil {
             assertTrue(Files.exists(Paths.get(fileNames.get(i))));
             assertEquals(1024 ,new File(Paths.get(fileNames.get(i)).toUri()).length());
         }
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
@@ -805,7 +787,6 @@ class LogManagerServiceTest extends GGServiceTestUtil {
             throws InterruptedException, IOException, UnsupportedInputTypeException, InvalidLogGroupException {
         ignoreExceptionOfType(ec, NoSuchFileException.class);
         mockDefaultPersistedState();
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -903,14 +884,12 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         for (int i = 2; i < 5; i++) {
             assertTrue(Files.exists(Paths.get(fileNames.get(i))));
         }
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_a_partially_uploaded_file_but_rotated_WHEN_merger_merges_THEN_sets_the_start_position_correctly()
             throws InterruptedException {
         mockDefaultPersistedState();
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -956,12 +935,10 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         componentLogFileInformation.getLogFileInformationList().forEach(logFileInformation ->
                 assertEquals(0, logFileInformation.getStartPosition()));
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_persisted_data_WHEN_log_uploader_initialises_THEN_correctly_sets_the_persisted_data() throws UnsupportedInputTypeException {
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -1054,6 +1031,5 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertEquals("TestFileHash2", userComponentInfo.getFileHash());
         assertEquals(10000, userComponentInfo.getStartPosition());
         assertEquals(now.toEpochMilli(), userComponentInfo.getLastModifiedTime());
-        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 }

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -26,6 +26,7 @@ import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import com.aws.greengrass.util.Coerce;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import lombok.extern.java.Log;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.IsNot;
@@ -125,6 +126,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
     static Path directoryPath;
     private LogManagerService logsUploaderService;
     private final ExecutorService executor = Executors.newCachedThreadPool();
+    private static final Instant mockInstant = Instant.EPOCH;
 
     @BeforeAll
     static void setupBefore() throws IOException, InterruptedException {
@@ -262,6 +264,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
     void GIVEN_system_log_files_to_be_uploaded_WHEN_merger_merges_THEN_we_get_all_log_files()
             throws InterruptedException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -307,14 +310,16 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertEquals(Level.INFO, componentLogFileInformation.getDesiredLogLevel());
         assertNotNull(componentLogFileInformation.getLogFileInformationList());
         assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
-        assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 5);
+        assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 6);
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_user_component_log_files_to_be_uploaded_with_required_config_as_array_WHEN_merger_merges_THEN_we_get_all_log_files()
             throws InterruptedException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -360,14 +365,16 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertEquals(Level.DEBUG, componentLogFileInformation.getDesiredLogLevel());
         assertNotNull(componentLogFileInformation.getLogFileInformationList());
         assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
-        assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 5);
+        assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 6);
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_user_component_log_files_to_be_uploaded_with_required_config_WHEN_merger_merges_THEN_we_get_all_log_files()
             throws InterruptedException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -411,14 +418,16 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertEquals(Level.DEBUG, componentLogFileInformation.getDesiredLogLevel());
         assertNotNull(componentLogFileInformation.getLogFileInformationList());
         assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
-        assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 5);
+        assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 6);
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_user_component_log_files_to_be_uploaded_with_all_config_WHEN_merger_merges_THEN_we_get_all_log_files()
             throws InterruptedException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -463,14 +472,16 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertEquals(Level.DEBUG, componentLogFileInformation.getDesiredLogLevel());
         assertNotNull(componentLogFileInformation.getLogFileInformationList());
         assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
-        assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 5);
+        assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 6);
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_multiple_user_components_log_files_to_be_uploaded_with_all_config_WHEN_merger_merges_THEN_we_get_all_log_files()
             throws InterruptedException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "1");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -523,8 +534,9 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertEquals(Level.DEBUG, componentLogFileInformation.getDesiredLogLevel());
         assertNotNull(componentLogFileInformation.getLogFileInformationList());
         assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
-        assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 5);
+        assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 6);
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     private void startServiceOnAnotherThread() {
@@ -540,7 +552,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
     void GIVEN_null_config_WHEN_config_is_processed_THEN_no_component_config_is_added(
             ExtensionContext context1) {
         ignoreExceptionOfType(context1, MismatchedInputException.class);
-
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
@@ -554,6 +566,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor);
         startServiceOnAnotherThread();
         assertThat(logsUploaderService.componentCurrentProcessingLogFile.values(), IsEmptyCollection.empty());
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
@@ -596,25 +609,24 @@ class LogManagerServiceTest extends GGServiceTestUtil {
 
         LogFile lastProcessedFile = createLogFileWithSize(directoryPath.resolve("testlogs2.log").toUri(), 2943);
         Pattern pattern1 = Pattern.compile("^testlogs2.log\\w*$");
-        Instant instant1 = Instant.EPOCH;
         // Create another file intentionally, so that the lastProcessedFile will be processed.
         createLogFileWithSize(directoryPath.resolve("testlogs2.log_active").toUri(), 2943);
-        LogFileGroup LastProcessedLogFileGroup = LogFileGroup.create(pattern1, lastProcessedFile.getParentFile().toURI(), instant1);
+        LogFileGroup LastProcessedLogFileGroup = LogFileGroup.create(pattern1, lastProcessedFile.getParentFile().toURI(), mockInstant);
 
         LogFile processingFile = createLogFileWithSize(directoryPath.resolve("testlogs1.log").toUri(), 1061);
         Pattern pattern2 = Pattern.compile("^testlogs1.log$");
-        Instant instant2 = Instant.EPOCH;
-        LogFileGroup processingLogFileGroup = LogFileGroup.create(pattern2, processingFile.getParentFile().toURI(), instant2);
+        LogFileGroup processingLogFileGroup = LogFileGroup.create(pattern2, processingFile.getParentFile().toURI(), mockInstant);
 
         Map<String, CloudWatchAttemptLogFileInformation> LastProcessedAttemptLogFileInformationMap = new HashMap<>();
-        LastProcessedAttemptLogFileInformationMap.put(lastProcessedFile.getAbsolutePath(), CloudWatchAttemptLogFileInformation.builder()
+        LastProcessedAttemptLogFileInformationMap.put(lastProcessedFile.hashString(),
+                CloudWatchAttemptLogFileInformation.builder()
                 .startPosition(0)
                 .bytesRead(2943)
                 .lastModifiedTime(lastProcessedFile.lastModified())
                 .fileHash(lastProcessedFile.hashString())
                 .build());
         Map<String, CloudWatchAttemptLogFileInformation> processingAttemptLogFileInformationMap2 = new HashMap<>();
-        processingAttemptLogFileInformationMap2.put(processingFile.getAbsolutePath(), CloudWatchAttemptLogFileInformation.builder()
+        processingAttemptLogFileInformationMap2.put(processingFile.hashString(), CloudWatchAttemptLogFileInformation.builder()
                 .startPosition(0)
                 .bytesRead(1061)
                 .lastModifiedTime(processingFile.lastModified())
@@ -652,7 +664,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         LogManagerService.CurrentProcessingFileInformation currentProcessingFileInformation =
                 LogManagerService.CurrentProcessingFileInformation
                         .convertFromMapOfObjects(partiallyReadComponentLogFileInformation.get(0));
-        assertEquals(processingFile.getAbsolutePath(), currentProcessingFileInformation.getFileName());
+        assertEquals(processingFile.hashString(), currentProcessingFileInformation.getFileHash());
         assertEquals(1061, currentProcessingFileInformation.getStartPosition());
         assertEquals(processingFile.lastModified(), currentProcessingFileInformation.getLastModifiedTime());
 
@@ -663,7 +675,8 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertNotNull(logsUploaderService.componentCurrentProcessingLogFile);
         assertThat(logsUploaderService.componentCurrentProcessingLogFile.entrySet(), IsNot.not(IsEmptyCollection.empty()));
         assertTrue(logsUploaderService.componentCurrentProcessingLogFile.containsKey("TestComponent2"));
-        assertEquals(processingFile.getAbsolutePath(), logsUploaderService.componentCurrentProcessingLogFile.get("TestComponent2").getFileName());
+        assertEquals(processingFile.hashString(), logsUploaderService.componentCurrentProcessingLogFile.get(
+                "TestComponent2").getFileHash());
         assertEquals(1061, logsUploaderService.componentCurrentProcessingLogFile.get("TestComponent2").getStartPosition());
         logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
@@ -672,6 +685,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
     void GIVEN_some_system_files_uploaded_and_another_partially_uploaded_WHEN_merger_merges_THEN_sets_the_start_position_correctly()
             throws InterruptedException {
         mockDefaultPersistedState();
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -690,13 +704,14 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(logsUploaderConfigTopics);
 
         logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor);
-        File file = new File(directoryPath.resolve("greengrass_test_2.log").toUri());
-        File currentProcessingFile = new File(directoryPath.resolve("greengrass_test_3.log").toUri());
+        // These two files are existed, and the active file is greengrass.log
+        LogFile file = new LogFile(directoryPath.resolve("greengrass_test_2.log").toUri());
+        LogFile currentProcessingFile = new LogFile(directoryPath.resolve("greengrass_test_3.log").toUri());
         logsUploaderService.lastComponentUploadedLogFileInstantMap.put(SYSTEM_LOGS_COMPONENT_NAME,
                 Instant.ofEpochMilli(file.lastModified()));
         logsUploaderService.componentCurrentProcessingLogFile.put(SYSTEM_LOGS_COMPONENT_NAME,
                 LogManagerService.CurrentProcessingFileInformation.builder()
-                        .fileName(currentProcessingFile.getAbsolutePath())
+                        .fileHash(currentProcessingFile.hashString())
                         .lastModifiedTime(currentProcessingFile.lastModified())
                         .startPosition(2)
                         .build());
@@ -721,12 +736,14 @@ class LogManagerServiceTest extends GGServiceTestUtil {
             }
         });
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_user_component_with_space_management_WHEN_log_file_size_exceeds_limit_THEN_deletes_excess_log_files()
             throws InterruptedException, IOException, UnsupportedInputTypeException {
         mockDefaultPersistedState();
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -780,13 +797,16 @@ class LogManagerServiceTest extends GGServiceTestUtil {
             assertTrue(Files.exists(Paths.get(fileNames.get(i))));
             assertEquals(1024 ,new File(Paths.get(fileNames.get(i)).toUri()).length());
         }
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_user_component_logs_delete_file_after_upload_set_WHEN_upload_logs_THEN_deletes_uploaded_log_files(
-            ExtensionContext ec) throws InterruptedException, IOException, UnsupportedInputTypeException {
+            ExtensionContext ec)
+            throws InterruptedException, IOException, UnsupportedInputTypeException, InvalidLogGroupException {
         ignoreExceptionOfType(ec, NoSuchFileException.class);
         mockDefaultPersistedState();
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -813,10 +833,12 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(logsUploaderConfigTopics);
 
         List<String> fileNames = new ArrayList<>();
+        Instant instant = Instant.EPOCH;
         for (int i = 0; i < 5; i++) {
             Path fileNamePath = directoryPath.resolve("log2.txt_" + UUID.randomUUID().toString());
             fileNames.add(fileNamePath.toAbsolutePath().toString());
             File file1 = new File(fileNamePath.toUri());
+
             if (Files.notExists(file1.toPath())) {
                 assertTrue(file1.createNewFile());
             }
@@ -829,25 +851,35 @@ class LogManagerServiceTest extends GGServiceTestUtil {
             }
             TimeUnit.SECONDS.sleep(1);
         }
+
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logStreamsToLogInformationMap = new HashMap<>();
-        File file1 = new File(directoryPath.resolve(fileNames.get(0)).toUri());
-        File file2 = new File(directoryPath.resolve(fileNames.get(1)).toUri());
+        LogFile file1 = new LogFile(directoryPath.resolve(fileNames.get(0)).toUri());
+        LogFile file2 = new LogFile(directoryPath.resolve(fileNames.get(1)).toUri());
+        //TODO
+        //System.out.println(file1.getName());
+        //System.out.println(file2.getName());
+        //System.out.println("test create logFileGroup");
+        Pattern pattern = Pattern.compile("^log2.txt\\w*");
+        LogFileGroup logFileGroup = LogFileGroup.create(pattern, file1.getParentFile().toURI(), instant);
         Map<String, CloudWatchAttemptLogFileInformation> attemptLogFileInformationMap1 = new HashMap<>();
-        attemptLogFileInformationMap1.put(file1.getAbsolutePath(), CloudWatchAttemptLogFileInformation.builder()
+        attemptLogFileInformationMap1.put(file1.hashString(), CloudWatchAttemptLogFileInformation.builder()
                 .startPosition(0)
                 .bytesRead(file1.length())
                 .lastModifiedTime(file1.lastModified())
+                .fileHash(file1.hashString())
                 .build());
-        attemptLogFileInformationMap1.put(file2.getAbsolutePath(), CloudWatchAttemptLogFileInformation.builder()
+        attemptLogFileInformationMap1.put(file2.hashString(), CloudWatchAttemptLogFileInformation.builder()
                 .startPosition(0)
                 .bytesRead(file2.length())
                 .lastModifiedTime(file2.lastModified())
+                .fileHash(file2.hashString())
                 .build());
 
         CloudWatchAttemptLogInformation attemptLogInformation1 = CloudWatchAttemptLogInformation.builder()
                 .componentName("UserComponentA")
                 .attemptLogFileInformationMap(attemptLogFileInformationMap1)
+                .logFileGroup(logFileGroup)
                 .build();
         logStreamsToLogInformationMap.put("testStream", attemptLogInformation1);
         attempt.setLogStreamsToLogEventsMap(logStreamsToLogInformationMap);
@@ -875,12 +907,14 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         for (int i = 2; i < 5; i++) {
             assertTrue(Files.exists(Paths.get(fileNames.get(i))));
         }
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_a_partially_uploaded_file_but_rotated_WHEN_merger_merges_THEN_sets_the_start_position_correctly()
             throws InterruptedException {
         mockDefaultPersistedState();
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -901,13 +935,13 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor);
         startServiceOnAnotherThread();
 
-        File file = new File(directoryPath.resolve("greengrass.log_test_2").toUri());
-        File currentProcessingFile = new File(directoryPath.resolve("greengrass.log_test-3").toUri());
+        LogFile file = new LogFile(directoryPath.resolve("greengrass.log_test_2").toUri());
+        LogFile currentProcessingFile = new LogFile(directoryPath.resolve("greengrass.log_test-3").toUri());
         logsUploaderService.lastComponentUploadedLogFileInstantMap.put(SYSTEM_LOGS_COMPONENT_NAME,
                 Instant.ofEpochMilli(file.lastModified()));
         logsUploaderService.componentCurrentProcessingLogFile.put(SYSTEM_LOGS_COMPONENT_NAME,
                 LogManagerService.CurrentProcessingFileInformation.builder()
-                        .fileName(currentProcessingFile.getAbsolutePath())
+                        .fileHash(currentProcessingFile.hashString())
                         .lastModifiedTime(currentProcessingFile.lastModified() - 1000)
                         .startPosition(2)
                         .build());
@@ -926,10 +960,12 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         componentLogFileInformation.getLogFileInformationList().forEach(logFileInformation ->
                 assertEquals(0, logFileInformation.getStartPosition()));
         verify(mockUploader, times(1)).upload(any(CloudWatchAttempt.class), anyInt());
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 
     @Test
     void GIVEN_persisted_data_WHEN_log_uploader_initialises_THEN_correctly_sets_the_persisted_data() throws UnsupportedInputTypeException {
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -964,13 +1000,13 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 Topics.of(context, "UserComponentA", allCurrentProcessingComponentTopics1);
         LogManagerService.CurrentProcessingFileInformation currentProcessingFileInformation1 =
                 LogManagerService.CurrentProcessingFileInformation.builder()
-                        .fileName("TestFile")
+                        .fileHash("TestFileHash")
                         .lastModifiedTime(Instant.EPOCH.toEpochMilli())
                         .startPosition(200)
                         .build();
         LogManagerService.CurrentProcessingFileInformation currentProcessingFileInformation2 =
                 LogManagerService.CurrentProcessingFileInformation.builder()
-                        .fileName("TestFile2")
+                        .fileHash("TestFileHash2")
                         .lastModifiedTime(now.toEpochMilli())
                         .startPosition(10000)
                         .build();
@@ -1014,13 +1050,14 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertTrue(logsUploaderService.componentCurrentProcessingLogFile.containsKey("UserComponentA"));
         LogManagerService.CurrentProcessingFileInformation systemInfo =
                 logsUploaderService.componentCurrentProcessingLogFile.get(SYSTEM_LOGS_COMPONENT_NAME);
-        assertEquals("TestFile", systemInfo.getFileName());
+        assertEquals("TestFileHash", systemInfo.getFileHash());
         assertEquals(200, systemInfo.getStartPosition());
         assertEquals(Instant.EPOCH.toEpochMilli(), systemInfo.getLastModifiedTime());
         LogManagerService.CurrentProcessingFileInformation userComponentInfo =
                 logsUploaderService.componentCurrentProcessingLogFile.get("UserComponentA");
-        assertEquals("TestFile2", userComponentInfo.getFileName());
+        assertEquals("TestFileHash2", userComponentInfo.getFileHash());
         assertEquals(10000, userComponentInfo.getStartPosition());
         assertEquals(now.toEpochMilli(), userComponentInfo.getLastModifiedTime());
+        logsUploaderService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 }

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -26,7 +26,6 @@ import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import com.aws.greengrass.util.Coerce;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import lombok.extern.java.Log;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.IsNot;
@@ -856,10 +855,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         Map<String, CloudWatchAttemptLogInformation> logStreamsToLogInformationMap = new HashMap<>();
         LogFile file1 = new LogFile(directoryPath.resolve(fileNames.get(0)).toUri());
         LogFile file2 = new LogFile(directoryPath.resolve(fileNames.get(1)).toUri());
-        //TODO
-        //System.out.println(file1.getName());
-        //System.out.println(file2.getName());
-        //System.out.println("test create logFileGroup");
+
         Pattern pattern = Pattern.compile("^log2.txt\\w*");
         LogFileGroup logFileGroup = LogFileGroup.create(pattern, file1.getParentFile().toURI(), instant);
         Map<String, CloudWatchAttemptLogFileInformation> attemptLogFileInformationMap1 = new HashMap<>();

--- a/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
@@ -14,7 +14,6 @@ import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import static com.aws.greengrass.logmanager.LogManagerService.ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG;
 import static com.aws.greengrass.logmanager.util.TestUtils.givenAStringOfSize;
 import static com.aws.greengrass.logmanager.util.TestUtils.writeFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,7 +28,6 @@ public class LogFileGroupTest {
     @Test
     void GIVEN_log_files_THEN_find_the_active_file() throws IOException, InterruptedException,
             InvalidLogGroupException {
-        ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(true);
         LogFile file = new LogFile(directoryPath.resolve("greengrass_test.log_1").toUri());
         byte[] bytesArray = givenAStringOfSize(1024).getBytes(StandardCharsets.UTF_8);
         writeFile(file, bytesArray);
@@ -48,6 +46,5 @@ public class LogFileGroupTest {
         assertEquals(2, logFileGroup.getLogFiles().size());
         assertFalse(logFileGroup.getActiveFile().get().fileEquals(file));
         assertTrue(logFileGroup.getActiveFile().get().fileEquals(file2));
-        ACTIVE_LOG_FILE_FEATURE_ENABLED_FLAG.set(false);
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
#51 
**Description of changes:**
Totally remove the fileName, and only use fileHash
**Why is this change necessary:**
Now we can handle active log file uploading
**How was this change tested:**
Existing tests have been modified, and new tests for log rotations are added.
**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x ] Updated or added new unit tests
 - [ x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
