### PR TITLE
refactor: read the files from the fs instead of caching the hashes

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
@@ -137,12 +137,12 @@ class SpaceManagementTest extends BaseITCase {
         }
 
         Pattern logFileNamePattern = Pattern.compile("^integTestRandomLogFiles.log\\w*");
-        LogFileGroup logFileGroup = LogFileGroup.create(logFileNamePattern, tempDirectoryPath.toUri(), mockInstant);
         // Then
 
         assertThat("log group size should eventually be less than 105 KB",() -> {
             try {
-                logFileGroup.syncDirectory();
+                LogFileGroup logFileGroup = LogFileGroup.create(
+                        logFileNamePattern, tempDirectoryPath.toUri(), mockInstant);
                 long kb = logFileGroup.totalSizeInBytes() / 1024;
                 return kb <= 105;
             } catch (InvalidLogGroupException e) {

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -59,6 +59,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -516,51 +517,49 @@ public class LogManagerService extends PluginService {
                                                         String fileHash,
                                                         CloudWatchAttemptLogFileInformation
                                                                 cloudWatchAttemptLogFileInformation) {
-        try {
-            LogFileGroup logFileGroup = attemptLogInformation.getLogFileGroup().syncDirectory();
-            if (!logFileGroup.isHashExist(fileHash)) {
-                logger.atTrace().kv("fileHash", fileHash).log("component",
-                        logFileGroup.getFilePattern(), "File not found in directory");
-                return;
-            }
-            LogFile file = logFileGroup.getFile(fileHash);
-            // @deprecated  This is deprecated value in versions greater than 2.2, but keep it here to avoid
-            // upgrade-downgrade issues.
-            String fileName = file.getAbsolutePath();
-            // If we have completely read the file, then we need add it to the completed files list and remove it
-            // it (if necessary) for the current processing list.
-            String componentName = attemptLogInformation.getComponentName();
-            if (!logFileGroup.isActiveFile(file) && file.length() == cloudWatchAttemptLogFileInformation.getBytesRead()
-                    + cloudWatchAttemptLogFileInformation.getStartPosition()) {
-                Set<LogFile> completedFiles = completedLogFilePerComponent.getOrDefault(componentName,
-                        new HashSet<>());
-                completedFiles.add(file);
-                completedLogFilePerComponent.put(componentName, completedFiles);
-                if (currentProcessingLogFilePerComponent.containsKey(componentName)) {
-                    CurrentProcessingFileInformation fileInformation = currentProcessingLogFilePerComponent
-                            .get(componentName);
-                    if (fileInformation.fileHash.equals(fileHash)) {
-                        currentProcessingLogFilePerComponent.remove(componentName);
-                    }
+        LogFileGroup logFileGroup = attemptLogInformation.getLogFileGroup();
+        Optional<LogFile> logFile = logFileGroup.getFile(fileHash);
+
+        if (!logFile.isPresent()) {
+            logger.atTrace().kv("fileHash", fileHash).log("component",
+                    logFileGroup.getFilePattern(), "File not found in directory");
+            return;
+        }
+        LogFile file = logFile.get();
+        // @deprecated  This is deprecated value in versions greater than 2.2, but keep it here to avoid
+        // upgrade-downgrade issues.
+        String fileName = file.getAbsolutePath();
+        // If we have completely read the file, then we need add it to the completed files list and remove it`
+        // it (if necessary) for the current processing list.
+        String componentName = attemptLogInformation.getComponentName();
+        if (!logFileGroup.isActiveFile(file) && file.length() == cloudWatchAttemptLogFileInformation.getBytesRead()
+                + cloudWatchAttemptLogFileInformation.getStartPosition()) {
+            Set<LogFile> completedFiles = completedLogFilePerComponent.getOrDefault(componentName,
+                    new HashSet<>());
+            completedFiles.add(file);
+            completedLogFilePerComponent.put(componentName, completedFiles);
+            if (currentProcessingLogFilePerComponent.containsKey(componentName)) {
+                CurrentProcessingFileInformation fileInformation = currentProcessingLogFilePerComponent
+                        .get(componentName);
+                if (fileInformation.fileHash.equals(fileHash)) {
+                    currentProcessingLogFilePerComponent.remove(componentName);
                 }
-            } else {
-                // Add the file to the current processing list for the component.
-                // Note: There should always be only 1 file which will be in progress at any given time.
-                // @deprecated The fileName is deprecated value in versions greater than 2.2, but keep it here to avoid
-                // upgrade-downgrade issues.
-                CurrentProcessingFileInformation processingFileInformation =
-                        CurrentProcessingFileInformation.builder()
-                                .fileName(fileName)
-                                .startPosition(cloudWatchAttemptLogFileInformation.getStartPosition()
-                                        + cloudWatchAttemptLogFileInformation.getBytesRead())
-                                .lastModifiedTime(cloudWatchAttemptLogFileInformation.getLastModifiedTime())
-                                .fileHash(fileHash)
-                                .build();
-                currentProcessingLogFilePerComponent.put(attemptLogInformation.getComponentName(),
-                        processingFileInformation);
             }
-        } catch (InvalidLogGroupException e) {
-            logger.atDebug().cause(e).log("Invalid log group");
+        } else {
+            // Add the file to the current processing list for the component.
+            // Note: There should always be only 1 file which will be in progress at any given time.
+            // @deprecated The fileName is deprecated value in versions greater than 2.2, but keep it here to avoid
+            // upgrade-downgrade issues.
+            CurrentProcessingFileInformation processingFileInformation =
+                    CurrentProcessingFileInformation.builder()
+                            .fileName(fileName)
+                            .startPosition(cloudWatchAttemptLogFileInformation.getStartPosition()
+                                    + cloudWatchAttemptLogFileInformation.getBytesRead())
+                            .lastModifiedTime(cloudWatchAttemptLogFileInformation.getLastModifiedTime())
+                            .fileHash(fileHash)
+                            .build();
+            currentProcessingLogFilePerComponent.put(attemptLogInformation.getComponentName(),
+                    processingFileInformation);
         }
     }
 


### PR DESCRIPTION
**Description of changes:**

Modified the log group so that any time we want to get a file it read the files from the directory that were provided instead of relying on cached values.

This does not fix all the issues with files being rotated while being processed but we will use it as a step to achieve that. With this in place instead of passing the file objects around we just pass the hash and calls this methods on the loggroup to get the file we want. As an improvement I am thinking when getting a file it could open it and return the the byte channel with it.
