### PR TITLE
feat: detect rotation when getting log group files

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -25,16 +25,8 @@ public final class LogFileGroup {
     private final URI directoryURI;
     private final Instant lastUpdated;
 
-    /**
-     * Creates a log file group without initializing the logFiles. To initialize them you must call
-     * getLogFiles.
-     * @param logFiles - the log group log files
-     * @param filePattern - the pattern use to match files on the provided directoryURI
-     * @param directoryURI - the directory where log files are located
-     * @param lastUpdated - instant used to filter out log files last modified after its value
-     */
-    public LogFileGroup(List<LogFile> logFiles, Pattern filePattern, URI directoryURI, Instant lastUpdated) {
-        this.logFiles = logFiles;
+    private LogFileGroup(List<LogFile> files, Pattern filePattern, URI directoryURI, Instant lastUpdated) {
+        this.logFiles = files;
         this.filePattern = filePattern;
         this.directoryURI = directoryURI;
         this.lastUpdated = lastUpdated;
@@ -49,7 +41,7 @@ public final class LogFileGroup {
      * that do not match the log group pattern and have been last modified after the provided lastUpdated value.
      * @param allDirectoryLogFiles - files in a directory
      */
-    public List<LogFile> getLogFiles(File... allDirectoryLogFiles) {
+    List<LogFile> getLogFiles(File... allDirectoryLogFiles) {
         List<LogFile> files = getLogFilesInternal(allDirectoryLogFiles);
 
         if (haveRotated(files)) {

--- a/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
@@ -7,17 +7,26 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import static com.aws.greengrass.logmanager.util.TestUtils.createLogFileWithSize;
 import static com.aws.greengrass.logmanager.util.TestUtils.givenAStringOfSize;
+import static com.aws.greengrass.logmanager.util.TestUtils.rotateFilesByRenamingThem;
 import static com.aws.greengrass.logmanager.util.TestUtils.writeFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
@@ -46,5 +55,44 @@ public class LogFileGroupTest {
         assertEquals(2, logFileGroup.getLogFiles().size());
         assertFalse(logFileGroup.isActiveFile(file));
         assertTrue(logFileGroup.isActiveFile(file2));
+    }
+
+    @Test
+    void GIVEN_logManagerGetsFiles_WHEN_fileRotateAfterRetrieved_THEN_itReturnsTheCorrectFiles() throws IOException {
+        // Given
+
+        File rotatedFile1 = createLogFileWithSize(directoryPath.resolve("test.log.1").toUri(), 1024 * 5);
+        File activeFile = createLogFileWithSize(directoryPath.resolve("test.log").toUri(), 1024);
+
+        Pattern filePattern = Pattern.compile("test.log\\w*", Pattern.CASE_INSENSITIVE);
+        Instant lastUploadedFileInstant = Instant.EPOCH;
+        LogFileGroup logGroup = new LogFileGroup(
+                new ArrayList<>(), filePattern, directoryPath.toUri(), lastUploadedFileInstant);
+
+        // When
+
+        File[] directoryFiles = directoryPath.toFile().listFiles();
+        rotateFilesByRenamingThem(activeFile, rotatedFile1);
+        List<LogFile> logFiles = logGroup.getLogFiles(directoryFiles);
+
+        // Assert
+
+        directoryFiles = directoryPath.toFile().listFiles();
+        assertNotNull(directoryFiles);
+        assertEquals(directoryFiles.length, logFiles.size());
+
+        Path[] expectedPaths = {
+            directoryPath.resolve("test.log.2"),
+            directoryPath.resolve("test.log.1"),
+            directoryPath.resolve("test.log")
+        };
+
+        List<Path> filePaths = logFiles.stream().map(File::toPath).collect(Collectors.toList());
+        for (int i = 0; i < expectedPaths.length; i++) {
+            AtomicInteger pointer = new AtomicInteger(i);
+            Optional<Path> expectedPath = filePaths.stream()
+                    .filter(path -> path.equals(expectedPaths[pointer.get()])).findFirst();
+            assertTrue(expectedPath.isPresent());
+        }
     }
 }

--- a/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -58,7 +57,8 @@ public class LogFileGroupTest {
     }
 
     @Test
-    void GIVEN_logManagerGetsFiles_WHEN_fileRotateAfterRetrieved_THEN_itReturnsTheCorrectFiles() throws IOException {
+    void GIVEN_logManagerGetsFiles_WHEN_fileRotateAfterRetrieved_THEN_itReturnsTheCorrectFiles() throws IOException,
+            InvalidLogGroupException {
         // Given
 
         File rotatedFile1 = createLogFileWithSize(directoryPath.resolve("test.log.1").toUri(), 1024 * 5);
@@ -66,8 +66,7 @@ public class LogFileGroupTest {
 
         Pattern filePattern = Pattern.compile("test.log\\w*", Pattern.CASE_INSENSITIVE);
         Instant lastUploadedFileInstant = Instant.EPOCH;
-        LogFileGroup logGroup = new LogFileGroup(
-                new ArrayList<>(), filePattern, directoryPath.toUri(), lastUploadedFileInstant);
+        LogFileGroup logGroup =LogFileGroup.create(filePattern, directoryPath.toUri(), lastUploadedFileInstant);
 
         // When
 

--- a/src/test/java/com/aws/greengrass/logmanager/util/TestUtils.java
+++ b/src/test/java/com/aws/greengrass/logmanager/util/TestUtils.java
@@ -2,6 +2,7 @@ package com.aws.greengrass.logmanager.util;
 
 import com.aws.greengrass.logmanager.model.LogFile;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -35,5 +36,27 @@ public final class TestUtils {
         byte[] bytesArray = givenAStringOfSize(bytesNeeded).getBytes(StandardCharsets.UTF_8);
         writeFile(file, bytesArray);
         return file;
+    }
+
+    /**
+     * Rotates the files by renaming them. For example, if the active log file gets full and there are other rotated files
+     * for instance test.log test.log.1 test.log.2, where test.log is the active file. when rotated, there following
+     * files will be present test.log test.log.1 test.log.2 test.log.3. test.log will be a new file and the previous
+     * active file will become test.log.1 and test.log.1 will become test.log.2 and so on.
+     */
+    public static File rotateFilesByRenamingThem(File... files) throws IOException {
+        // Create new active file
+        String activeFilePath = files[0].getAbsolutePath();
+
+        for (int i = files.length - 1; i >= 0; i--) {
+            File current = files[i];
+            // to avoid changing the file on the array. Simulates closer what would happen on a real scenario
+            File toModify = new File(current.getAbsolutePath());
+            toModify.renameTo(new File(activeFilePath + "." + (i + 1)));
+        }
+
+        File activeFile = new File(activeFilePath);
+        activeFile.createNewFile();
+        return activeFile;
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This PR sets the foundation for detecting if there was a rotation when reading the files that need to be processed from the file system.

* This PR doesn't add yet the generation of hard links but that would be encapsulated inside the creation of the log files via the LogFileGroup.
* The test needs some additional assertions to check that we got the correct file references but this will get added once the hard links are added.