### PR TITLE
feat: create a dir inside work folder to store the log file hardlinks

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -11,7 +11,6 @@ import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.UpdateBehaviorTree;
 import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.ImplementsService;
-import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -28,6 +27,7 @@ import com.aws.greengrass.logmanager.model.LogFile;
 import com.aws.greengrass.logmanager.model.LogFileGroup;
 import com.aws.greengrass.logmanager.model.LogFileInformation;
 import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -141,13 +141,12 @@ public class LogManagerService extends PluginService {
      */
     @Inject
     LogManagerService(Topics topics, CloudWatchLogsUploader uploader, CloudWatchAttemptLogsProcessor logProcessor,
-                      ExecutorService executorService, Kernel kernel) throws IOException {
+                      ExecutorService executorService, NucleusPaths nucleusPaths) throws IOException {
         super(topics);
         this.uploader = uploader;
         this.logsProcessor = logProcessor;
         this.executorService = executorService;
-        this.hardlinksDirectoryPath = kernel.getNucleusPaths().workPath(LOGS_UPLOADER_SERVICE_TOPICS)
-                .resolve(HARDLINK_DIRECTORY);
+        this.hardlinksDirectoryPath = nucleusPaths.workPath(LOGS_UPLOADER_SERVICE_TOPICS).resolve(HARDLINK_DIRECTORY);
 
         topics.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((why, newv) -> {
             if (why == WhatHappened.timestampUpdated) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Create hardlinks directory inside of the work folder of the log manager component. This will be used to store component log file hardlinks to avoid data loss due to file rotation.  

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
