### PR TITLE
feat: use hardlinks of log file during processing

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -195,7 +195,7 @@ class LogManagerTest extends BaseITCase {
         Pattern logFileNamePattern = Pattern.compile("^integTestRandomLogFiles.log\\w*");
         ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
                 .directoryPath(tempDirectoryPath)
-                .fileNameRegex(logFileNamePattern).build();
+                .fileNameRegex(logFileNamePattern).name("UserComponentA").build();
         LogFileGroup logFileGroup =
                 LogFileGroup.create(compLogInfo, mockInstant, workDir);
         assertEquals(1, logFileGroup.getLogFiles().size());
@@ -236,7 +236,7 @@ class LogManagerTest extends BaseITCase {
         Pattern logFileNamePattern = Pattern.compile("^UserComponentB\\w*.log");
         ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
                 .directoryPath(tempDirectoryPath)
-                .fileNameRegex(logFileNamePattern).build();
+                .fileNameRegex(logFileNamePattern).name("UserComponentB").build();
         LogFileGroup logFileGroup =
                 LogFileGroup.create(compLogInfo, mockInstant, workDir);
         assertEquals(1, logFileGroup.getLogFiles().size());
@@ -277,7 +277,7 @@ class LogManagerTest extends BaseITCase {
         Pattern logFileNamePattern = Pattern.compile(String.format(DEFAULT_FILE_REGEX, fileName));
         ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
                 .directoryPath(tempDirectoryPath)
-                .fileNameRegex(logFileNamePattern).build();
+                .fileNameRegex(logFileNamePattern).name("System").build();
         LogFileGroup logFileGroup =
                 LogFileGroup.create(compLogInfo, mockInstant, workDir);
         assertEquals(1, logFileGroup.getLogFiles().size());
@@ -331,7 +331,7 @@ class LogManagerTest extends BaseITCase {
         Pattern logFileNamePattern = Pattern.compile("^integTestRandomLogFiles.log\\w*");
         ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
                 .directoryPath(tempDirectoryPath)
-                .fileNameRegex(logFileNamePattern).build();
+                .fileNameRegex(logFileNamePattern).name("UserComponentA").build();
         LogFileGroup logFileGroup =
                 LogFileGroup.create(compLogInfo, mockInstant, workDir);
         assertEquals(1, logFileGroup.getLogFiles().size());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
@@ -144,7 +144,7 @@ class SpaceManagementTest extends BaseITCase {
         // Then
         ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
                 .directoryPath(tempDirectoryPath)
-                .fileNameRegex(logFileNamePattern).build();
+                .fileNameRegex(logFileNamePattern).name("IntegrationTestsTemporaryLogFiles").build();
         assertThat("log group size should eventually be less than 105 KB",() -> {
             try {
                 LogFileGroup logFileGroup =

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -473,14 +473,14 @@ public class LogManagerService extends PluginService {
             }
             completedFiles.forEach(file -> {
                 try {
-                    boolean successfullyDeleted = Files.deleteIfExists(file.toPath());
+                    boolean successfullyDeleted = Files.deleteIfExists(Paths.get(file.getSourcePath()));
                     if (successfullyDeleted) {
-                        logger.atDebug().log("Successfully deleted file with name {}", file.getAbsolutePath());
+                        logger.atDebug().log("Successfully deleted file with name {}", file.getSourcePath());
                     } else {
-                        logger.atWarn().log("Unable to delete file with name {}", file.getAbsolutePath());
+                        logger.atWarn().log("Unable to delete file with name {}", file.getSourcePath());
                     }
                 } catch (IOException e) {
-                    logger.atError().cause(e).log("Unable to delete file with name: {}", file.getAbsolutePath());
+                    logger.atError().cause(e).log("Unable to delete file with name: {}", file.getSourcePath());
                 }
             });
         });
@@ -514,15 +514,17 @@ public class LogManagerService extends PluginService {
                                                         CloudWatchAttemptLogFileInformation
                                                                 cloudWatchAttemptLogFileInformation) {
         LogFileGroup logFileGroup = attemptLogInformation.getLogFileGroup();
-        if (!logFileGroup.isHashExist(fileHash)) {
+        LogFile file = logFileGroup.getFile(fileHash);
+
+        if (file == null) {
             logger.atTrace().kv("fileHash", fileHash).log("component",
                     logFileGroup.getFilePattern(), "File not found in directory");
             return;
         }
-        LogFile file = logFileGroup.getFile(fileHash);
+
         // @deprecated  This is deprecated value in versions greater than 2.2, but keep it here to avoid
         // upgrade-downgrade issues.
-        String fileName = file.getAbsolutePath();
+        String fileName = file.getSourcePath();
         // If we have completely read the file, then we need add it to the completed files list and remove it
         // it (if necessary) for the current processing list.
         String componentName = attemptLogInformation.getComponentName();

--- a/src/main/java/com/aws/greengrass/logmanager/exceptions/InvalidLogGroupException.java
+++ b/src/main/java/com/aws/greengrass/logmanager/exceptions/InvalidLogGroupException.java
@@ -7,4 +7,8 @@ public class InvalidLogGroupException extends Exception {
     public InvalidLogGroupException(String s) {
         super(s);
     }
+
+    public InvalidLogGroupException(String s, Exception e) {
+        super(s, e);
+    }
 }

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -54,8 +54,8 @@ public final class LogFileGroup {
         if (!folder.isDirectory()) {
             throw new InvalidLogGroupException(String.format("%s must be a directory", directoryURI));
         }
-        Pattern filePattern = componentLogConfiguration.getFileNameRegex();
-        Path componentHardlinksDirectory = workDir.resolve(filePattern.toString());
+        String componentName = componentLogConfiguration.getName();
+        Path componentHardlinksDirectory = workDir.resolve(componentName);
         try {
             Utils.deleteFileRecursively(componentHardlinksDirectory.toFile());
             Utils.createPaths(componentHardlinksDirectory);
@@ -65,8 +65,11 @@ public final class LogFileGroup {
         }
 
         File[] files = folder.listFiles();
-        if (files == null) {
-            logger.atWarn().log("logFiles is null");
+        Pattern filePattern = componentLogConfiguration.getFileNameRegex();
+        if (files == null || files.length == 0) {
+            logger.atDebug().kv("component",componentName)
+                    .kv("directory", directoryURI)
+                    .log("No component logs are found in the directory");
             return new LogFileGroup(Collections.emptyList(), filePattern, new HashMap<>());
         }
 

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -1,15 +1,20 @@
 package com.aws.greengrass.logmanager.model;
 
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.logmanager.exceptions.InvalidLogGroupException;
 import com.aws.greengrass.util.Utils;
 import lombok.Getter;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -18,6 +23,7 @@ import java.util.regex.Pattern;
 
 
 public final class LogFileGroup {
+    private static final Logger logger = LogManager.getLogger(LogFileGroup.class);
     @Getter
     private List<LogFile> logFiles;
     private final Map<String, LogFile> fileHashToLogFile;
@@ -48,25 +54,38 @@ public final class LogFileGroup {
         if (!folder.isDirectory()) {
             throw new InvalidLogGroupException(String.format("%s must be a directory", directoryURI));
         }
-
-        LogFile[] files = LogFile.of(folder.listFiles());
-        List<LogFile> allFiles = new ArrayList<>();
-        Map<String, LogFile> fileHashToLogFileMap = new ConcurrentHashMap<>();
         Pattern filePattern = componentLogConfiguration.getFileNameRegex();
-        if (files.length != 0) {
-            for (LogFile file: files) {
-                String fileHash = file.hashString();
-                boolean isModifiedAfterLastUpdatedFile =
-                        lastUpdated.isBefore(Instant.ofEpochMilli(file.lastModified()));
-                boolean isNameMatchPattern = filePattern.matcher(file.getName()).find();
-                boolean isEmptyFileHash = Utils.isEmpty(fileHash);
+        Path componentHardlinksDirectory = workDir.resolve(filePattern.toString());
+        try {
+            Utils.deleteFileRecursively(componentHardlinksDirectory.toFile());
+            Utils.createPaths(componentHardlinksDirectory);
+        } catch (IOException e) {
+            throw new InvalidLogGroupException(
+                    String.format("%s failed to create hard link directory", componentHardlinksDirectory), e);
+        }
 
-                if (file.isFile()
-                        && isModifiedAfterLastUpdatedFile
-                        && isNameMatchPattern
-                        && !isEmptyFileHash) {
-                    allFiles.add(file);
-                    fileHashToLogFileMap.put(fileHash, file);
+        File[] files = folder.listFiles();
+        if (files == null) {
+            logger.atWarn().log("logFiles is null");
+            return new LogFileGroup(Collections.emptyList(), filePattern, new HashMap<>());
+        }
+
+        Map<String, LogFile> fileHashToLogFileMap = new ConcurrentHashMap<>();
+        List<LogFile> allFiles = new ArrayList<>();
+        // TODO: We have to add the rotation detection mechanism here otherwise there is a chance that while we are
+        //  looping and creating the hardlinks the files gets rotated so the path that
+        for (File file : files) {
+            boolean isModifiedAfterLastUpdatedFile =
+                    lastUpdated.isBefore(Instant.ofEpochMilli(file.lastModified()));
+            boolean isNameMatchPattern = filePattern.matcher(file.getName()).find();
+
+            if (file.isFile() && isModifiedAfterLastUpdatedFile && isNameMatchPattern) {
+                try {
+                    LogFile logfile = LogFile.of(file, componentHardlinksDirectory);
+                    allFiles.add(logfile);
+                    fileHashToLogFileMap.put(logfile.hashString(), logfile);
+                } catch (IOException e) {
+                    logger.atWarn().cause(e).log("Failed to create hardlink");
                 }
             }
         }
@@ -92,15 +111,6 @@ public final class LogFileGroup {
     }
 
     /**
-     * Validate if the hash exists in the current logFileGroup.
-     * @param fileHash the hash of the file.
-     * @return boolean.
-     */
-    public boolean isHashExist(String fileHash) {
-        return fileHashToLogFile.containsKey(fileHash);
-    }
-
-    /**
      * Returns the size in bytes of all the contents being tracked on by the log group.
      */
     public long totalSizeInBytes() {
@@ -121,6 +131,7 @@ public final class LogFileGroup {
             return false;
         }
         LogFile activeFile = logFiles.get(logFiles.size() - 1);
+        // TODO: Check if rotation happened
         return file.hashString().equals(activeFile.hashString());
     }
 }

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -754,7 +754,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertThat(componentLogFileInformation.getLogFileInformationList(), IsNot.not(IsEmptyCollection.empty()));
         assertTrue(componentLogFileInformation.getLogFileInformationList().size() >= 2);
         componentLogFileInformation.getLogFileInformationList().forEach(logFileInformation -> {
-            if (logFileInformation.getLogFile().getAbsolutePath().equals(currentProcessingFile.getAbsolutePath())) {
+            if (logFileInformation.getLogFile().getSourcePath().equals(currentProcessingFile.getSourcePath())) {
                 assertEquals(2, logFileInformation.getStartPosition());
             } else {
                 assertEquals(0, logFileInformation.getStartPosition());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Created hardlinks for log file when collecting the log files to process and upload. 
This can prevent data loss due to rotation as the hardlink still persists even when the source log file is deleted. 

Taken mostly from: https://github.com/aws-greengrass/aws-greengrass-log-manager/pull/136

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
