### PR TITLE
refactor: pass ComponentLogConfiguration object to LogFileGroup

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -16,6 +16,7 @@ import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.logging.impl.config.LogStore;
 import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import com.aws.greengrass.logmanager.LogManagerService;
+import com.aws.greengrass.logmanager.model.ComponentLogConfiguration;
 import com.aws.greengrass.logmanager.model.EventType;
 import com.aws.greengrass.logmanager.model.LogFileGroup;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -192,8 +193,11 @@ class LogManagerTest extends BaseITCase {
                 request.logEvents().stream().mapToLong(value -> value.message().length()).sum());
 
         Pattern logFileNamePattern = Pattern.compile("^integTestRandomLogFiles.log\\w*");
+        ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
+                .directoryPath(tempDirectoryPath)
+                .fileNameRegex(logFileNamePattern).build();
         LogFileGroup logFileGroup =
-                LogFileGroup.create(logFileNamePattern, tempDirectoryPath.toUri(), mockInstant, workDir);
+                LogFileGroup.create(compLogInfo, mockInstant, workDir);
         assertEquals(1, logFileGroup.getLogFiles().size());
     }
 
@@ -230,8 +234,11 @@ class LogManagerTest extends BaseITCase {
         assertEquals(DEFAULT_FILE_SIZE * testFileNumber,
                 request.logEvents().stream().mapToLong(value -> value.message().length()).sum());
         Pattern logFileNamePattern = Pattern.compile("^UserComponentB\\w*.log");
+        ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
+                .directoryPath(tempDirectoryPath)
+                .fileNameRegex(logFileNamePattern).build();
         LogFileGroup logFileGroup =
-                LogFileGroup.create(logFileNamePattern, tempDirectoryPath.toUri(), mockInstant, workDir);
+                LogFileGroup.create(compLogInfo, mockInstant, workDir);
         assertEquals(1, logFileGroup.getLogFiles().size());
     }
 
@@ -268,8 +275,11 @@ class LogManagerTest extends BaseITCase {
                 >= DEFAULT_FILE_SIZE * testFileNumber);
 
         Pattern logFileNamePattern = Pattern.compile(String.format(DEFAULT_FILE_REGEX, fileName));
+        ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
+                .directoryPath(tempDirectoryPath)
+                .fileNameRegex(logFileNamePattern).build();
         LogFileGroup logFileGroup =
-                LogFileGroup.create(logFileNamePattern, tempDirectoryPath.toUri(), mockInstant, workDir);
+                LogFileGroup.create(compLogInfo, mockInstant, workDir);
         assertEquals(1, logFileGroup.getLogFiles().size());
     }
 
@@ -319,8 +329,11 @@ class LogManagerTest extends BaseITCase {
                     request.logEvents().stream().mapToLong(value -> value.message().length()).sum());
         }
         Pattern logFileNamePattern = Pattern.compile("^integTestRandomLogFiles.log\\w*");
+        ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
+                .directoryPath(tempDirectoryPath)
+                .fileNameRegex(logFileNamePattern).build();
         LogFileGroup logFileGroup =
-                LogFileGroup.create(logFileNamePattern, tempDirectoryPath.toUri(), mockInstant, workDir);
+                LogFileGroup.create(compLogInfo, mockInstant, workDir);
         assertEquals(1, logFileGroup.getLogFiles().size());
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.logmanager.LogManagerService;
 import com.aws.greengrass.logmanager.exceptions.InvalidLogGroupException;
+import com.aws.greengrass.logmanager.model.ComponentLogConfiguration;
 import com.aws.greengrass.logmanager.model.LogFileGroup;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.exceptions.TLSAuthException;
@@ -141,11 +142,13 @@ class SpaceManagementTest extends BaseITCase {
 
         Pattern logFileNamePattern = Pattern.compile("^integTestRandomLogFiles.log\\w*");
         // Then
-
+        ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
+                .directoryPath(tempDirectoryPath)
+                .fileNameRegex(logFileNamePattern).build();
         assertThat("log group size should eventually be less than 105 KB",() -> {
             try {
                 LogFileGroup logFileGroup =
-                        LogFileGroup.create(logFileNamePattern, tempDirectoryPath.toUri(), mockInstant, workDir);
+                        LogFileGroup.create(compLogInfo, mockInstant, workDir);
                 long kb = logFileGroup.totalSizeInBytes() / 1024;
                 return kb <= 105;
             } catch (InvalidLogGroupException e) {

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -607,8 +607,8 @@ public class LogManagerService extends PluginService {
                                 Instant.EPOCH);
 
                 try {
-                    LogFileGroup logFileGroup = LogFileGroup.create(componentLogConfiguration.getFileNameRegex(),
-                            componentLogConfiguration.getDirectoryPath().toUri(), lastUploadedLogFileTimeMs, workDir);
+                    LogFileGroup logFileGroup = LogFileGroup.create(componentLogConfiguration,
+                            lastUploadedLogFileTimeMs, workDir);
 
                     if (logFileGroup.isEmpty()) {
                         continue;

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -32,15 +32,17 @@ public final class LogFileGroup {
 
     /**
      * Create a list of Logfiles that are sorted based on lastModified time.
-     * @param filePattern the fileNameRegex used for each component to recognize its log files.
-     * @param directoryURI the directory path of the log files of component.
-     * @param lastUpdated the saved updated time of the last uploaded log of a component.
-     * @param workDir component work directory
+     *
+     * @param componentLogConfiguration component log configuration
+     * @param lastUpdated               the saved updated time of the last uploaded log of a component.
+     * @param workDir                   component work directory
      * @return list of logFile.
      * @throws InvalidLogGroupException the exception if this is not a valid directory.
      */
-    public static LogFileGroup create(Pattern filePattern, URI directoryURI, Instant lastUpdated, Path workDir)
+    public static LogFileGroup create(ComponentLogConfiguration componentLogConfiguration,
+                                      Instant lastUpdated, Path workDir)
             throws InvalidLogGroupException {
+        URI directoryURI = componentLogConfiguration.getDirectoryPath().toUri();
         File folder = new File(directoryURI);
 
         if (!folder.isDirectory()) {
@@ -50,6 +52,7 @@ public final class LogFileGroup {
         LogFile[] files = LogFile.of(folder.listFiles());
         List<LogFile> allFiles = new ArrayList<>();
         Map<String, LogFile> fileHashToLogFileMap = new ConcurrentHashMap<>();
+        Pattern filePattern = componentLogConfiguration.getFileNameRegex();
         if (files.length != 0) {
             for (LogFile file: files) {
                 String fileHash = file.hashString();

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -16,13 +16,7 @@ import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.logging.impl.config.LogStore;
 import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import com.aws.greengrass.logmanager.exceptions.InvalidLogGroupException;
-import com.aws.greengrass.logmanager.model.CloudWatchAttempt;
-import com.aws.greengrass.logmanager.model.CloudWatchAttemptLogFileInformation;
-import com.aws.greengrass.logmanager.model.CloudWatchAttemptLogInformation;
-import com.aws.greengrass.logmanager.model.ComponentLogFileInformation;
-import com.aws.greengrass.logmanager.model.ComponentType;
-import com.aws.greengrass.logmanager.model.LogFile;
-import com.aws.greengrass.logmanager.model.LogFileGroup;
+import com.aws.greengrass.logmanager.model.*;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import com.aws.greengrass.util.Coerce;
@@ -626,8 +620,11 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         // Create another file intentionally, so that the lastProcessedFile will be processed.
         TimeUnit.SECONDS.sleep(5);
         createLogFileWithSize(directoryPath.resolve("testlogs2.log_active").toUri(), 2943);
+        ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
+                .directoryPath(directoryPath)
+                .fileNameRegex(pattern1).build();
         LogFileGroup lastProcessedLogFileGroup =
-                LogFileGroup.create(pattern1, lastProcessedFile.getParentFile().toURI(), mockInstant, workdirectory);
+                LogFileGroup.create(compLogInfo, mockInstant, workdirectory);
         assertEquals(2, lastProcessedLogFileGroup.getLogFiles().size());
         assertFalse(lastProcessedLogFileGroup.isActiveFile(lastProcessedFile));
 
@@ -636,7 +633,10 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         TimeUnit.SECONDS.sleep(5);
         LogFile processingFile = createLogFileWithSize(directoryPath.resolve("testlogs1.log").toUri(), 1061);
         Pattern pattern2 = Pattern.compile("^testlogs1.log$");
-        LogFileGroup processingLogFileGroup = LogFileGroup.create(pattern2, processingFile.getParentFile().toURI(),
+        ComponentLogConfiguration compLogInfo2 = ComponentLogConfiguration.builder()
+                .directoryPath(directoryPath)
+                .fileNameRegex(pattern2).build();
+        LogFileGroup processingLogFileGroup = LogFileGroup.create(compLogInfo2,
                 Instant.ofEpochMilli(processingFile.lastModified() - 1), workdirectory);
         assertEquals(1, processingLogFileGroup.getLogFiles().size());
         assertTrue(processingLogFileGroup.isActiveFile(processingFile));
@@ -879,7 +879,10 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         LogFile file2 = new LogFile(directoryPath.resolve(fileNames.get(1)).toUri());
 
         Pattern pattern = Pattern.compile("^log2.txt\\w*");
-        LogFileGroup logFileGroup = LogFileGroup.create(pattern, file1.getParentFile().toURI(), instant, workdirectory);
+        ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
+                .directoryPath(directoryPath)
+                .fileNameRegex(pattern).build();
+        LogFileGroup logFileGroup = LogFileGroup.create( compLogInfo, instant, workdirectory);
         Map<String, CloudWatchAttemptLogFileInformation> attemptLogFileInformationMap1 = new HashMap<>();
         attemptLogFileInformationMap1.put(file1.hashString(), CloudWatchAttemptLogFileInformation.builder()
                 .startPosition(0)

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -622,7 +622,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         createLogFileWithSize(directoryPath.resolve("testlogs2.log_active").toUri(), 2943);
         ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
                 .directoryPath(directoryPath)
-                .fileNameRegex(pattern1).build();
+                .fileNameRegex(pattern1).name("TestComponent2").build();
         LogFileGroup lastProcessedLogFileGroup =
                 LogFileGroup.create(compLogInfo, mockInstant, workdirectory);
         assertEquals(2, lastProcessedLogFileGroup.getLogFiles().size());
@@ -635,7 +635,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         Pattern pattern2 = Pattern.compile("^testlogs1.log$");
         ComponentLogConfiguration compLogInfo2 = ComponentLogConfiguration.builder()
                 .directoryPath(directoryPath)
-                .fileNameRegex(pattern2).build();
+                .fileNameRegex(pattern2).name("TestComponent1").build();
         LogFileGroup processingLogFileGroup = LogFileGroup.create(compLogInfo2,
                 Instant.ofEpochMilli(processingFile.lastModified() - 1), workdirectory);
         assertEquals(1, processingLogFileGroup.getLogFiles().size());
@@ -881,7 +881,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         Pattern pattern = Pattern.compile("^log2.txt\\w*");
         ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
                 .directoryPath(directoryPath)
-                .fileNameRegex(pattern).build();
+                .fileNameRegex(pattern).name("UserComponentA").build();
         LogFileGroup logFileGroup = LogFileGroup.create( compLogInfo, instant, workdirectory);
         Map<String, CloudWatchAttemptLogFileInformation> attemptLogFileInformationMap1 = new HashMap<>();
         attemptLogFileInformationMap1.put(file1.hashString(), CloudWatchAttemptLogFileInformation.builder()

--- a/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
@@ -42,8 +42,11 @@ public class LogFileGroupTest {
         writeFile(file2, bytesArray2);
 
         Pattern pattern = Pattern.compile("^greengrass_test.log\\w*$");
+        ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
+                .directoryPath(directoryPath)
+                .fileNameRegex(pattern).build();
         Instant instant = Instant.EPOCH;
-        LogFileGroup logFileGroup = LogFileGroup.create(pattern, file.getParentFile().toURI(), instant, workDir);
+        LogFileGroup logFileGroup = LogFileGroup.create(compLogInfo, instant, workDir);
 
         assertEquals(2, logFileGroup.getLogFiles().size());
         assertFalse(logFileGroup.isActiveFile(file));

--- a/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
@@ -44,7 +44,7 @@ public class LogFileGroupTest {
         Pattern pattern = Pattern.compile("^greengrass_test.log\\w*$");
         ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
                 .directoryPath(directoryPath)
-                .fileNameRegex(pattern).build();
+                .fileNameRegex(pattern).name("greengrass_test").build();
         Instant instant = Instant.EPOCH;
         LogFileGroup logFileGroup = LogFileGroup.create(compLogInfo, instant, workDir);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Pass ComponentLogConfiguration object to LogFileGroup instead of passing individual params. This will help us write better log to the files by using the info from the ComponentLogConfiguration. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
