### PR TITLE
feat: return false if the original active file has rotated

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
@@ -14,6 +14,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 
 import static com.aws.greengrass.util.Digest.calculate;
@@ -25,7 +26,6 @@ public class LogFile extends File {
     private static final Logger logger = LogManager.getLogger(LogManagerService.class);
     public static final int bytesNeeded = 1024;
     public static final String HASH_VALUE_OF_EMPTY_STRING = "";
-    @SuppressWarnings("PMD.UnusedPrivateField")
     private final String sourcePath;
 
     public LogFile(Path sourcePath, Path hardLinkPath) {
@@ -113,6 +113,19 @@ public class LogFile extends File {
 
     public boolean isEmpty() {
         return Utils.isEmpty(this.hashString());
+    }
+
+    /**
+     * Determines if a file has rotated by comparing the current file on the sourcePath against the hardlink
+     * path. This returns false if the file that the hardlink is tracking is not the same it was
+     * originally created with.
+     */
+    public boolean hasRotated() {
+        try {
+            return !Files.isSameFile(Paths.get(sourcePath), toPath());
+        } catch (IOException e) {
+            return true;
+        }
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -133,8 +133,13 @@ public final class LogFileGroup {
         if (logFiles.isEmpty()) {
             return false;
         }
+
         LogFile activeFile = logFiles.get(logFiles.size() - 1);
-        // TODO: Check if rotation happened
+
+        if (activeFile.hasRotated()) {
+            return false;
+        }
+
         return file.hashString().equals(activeFile.hashString());
     }
 }


### PR DESCRIPTION
**Description of changes:**
Fixes the `isActive` method on the `LogFileGroup` so that if the active file has rotated by the time we check if it is the active file, then we return false so it doesn't get set as the currently processing file.

**Why is this change necessary:**
Would cause an active file that just got rotated to be processed twice.

**How was this change tested:**
Manual tests