### PR TITLE
feat: rollback to only uploading rotated files if we fail to create hardlinks

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -80,7 +80,7 @@ public final class LogFileGroup {
         }
 
         Map<String, LogFile> fileHashToLogFileMap = new ConcurrentHashMap<>();
-        boolean isUsingHardlinks;
+        boolean isUsingHardlinks = true;
         List<LogFile> allFiles;
 
         files = Arrays.stream(files)
@@ -90,7 +90,6 @@ public final class LogFileGroup {
 
         // Convert files into log files
         try {
-            isUsingHardlinks = true;
             allFiles = convertToLogFiles(files, componentHardlinksDirectory);
         } catch (IOException e) {
             logger.atDebug().cause(e).log("Failed to create hardlinks for files. Falling back to only uploading "


### PR DESCRIPTION
**Description of changes:**
We can not create hard links for log files being created on a volume separate to the one greengrass is running on. In the scenario where that happens we want to rollback and only upload the rotated log files and stop processing the active file. Effectively working how it used to work before

**Why is this change necessary:**
Ensure we are not breaking customers that have a setup where they track log files being written to a separate volume.

**How was this change tested:**
Manual tests, we will cover with unit and integration tests but we have to make more changes to make this scenarios more easily testable.


