### PR TITLE
feat: update delete after upload

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -472,15 +472,11 @@ public class LogManagerService extends PluginService {
                 return;
             }
             completedFiles.forEach(file -> {
-                try {
-                    boolean successfullyDeleted = Files.deleteIfExists(Paths.get(file.getSourcePath()));
-                    if (successfullyDeleted) {
-                        logger.atDebug().log("Successfully deleted file with name {}", file.getSourcePath());
-                    } else {
-                        logger.atWarn().log("Unable to delete file with name {}", file.getSourcePath());
-                    }
-                } catch (IOException e) {
-                    logger.atError().cause(e).log("Unable to delete file with name: {}", file.getSourcePath());
+                boolean successfullyDeleted = file.delete();
+                if (successfullyDeleted) {
+                    logger.atDebug().log("Successfully deleted file with name {}", file.getName());
+                } else {
+                    logger.atWarn().log("Unable to delete file with name {}", file.getName());
                 }
             });
         });
@@ -522,9 +518,6 @@ public class LogManagerService extends PluginService {
             return;
         }
 
-        // @deprecated  This is deprecated value in versions greater than 2.2, but keep it here to avoid
-        // upgrade-downgrade issues.
-        String fileName = file.getSourcePath();
         // If we have completely read the file, then we need add it to the completed files list and remove it
         // it (if necessary) for the current processing list.
         String componentName = attemptLogInformation.getComponentName();
@@ -548,7 +541,7 @@ public class LogManagerService extends PluginService {
             // upgrade-downgrade issues.
             CurrentProcessingFileInformation processingFileInformation =
                     CurrentProcessingFileInformation.builder()
-                            .fileName(fileName)
+                            .fileName(file.getSourcePath())
                             .startPosition(cloudWatchAttemptLogFileInformation.getStartPosition()
                                     + cloudWatchAttemptLogFileInformation.getBytesRead())
                             .lastModifiedTime(cloudWatchAttemptLogFileInformation.getLastModifiedTime())

--- a/src/test/java/com/aws/greengrass/logmanager/util/TestUtils.java
+++ b/src/test/java/com/aws/greengrass/logmanager/util/TestUtils.java
@@ -2,11 +2,13 @@ package com.aws.greengrass.logmanager.util;
 
 import com.aws.greengrass.logmanager.model.LogFile;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Random;
 
 public final class TestUtils {
@@ -24,10 +26,17 @@ public final class TestUtils {
         return testStrings.toString();
     }
 
-    public static void writeFile(LogFile file, byte[] byteArray) throws IOException {
+    public static void writeFile(File file, byte[] byteArray) throws IOException {
         try (OutputStream fileOutputStream = Files.newOutputStream(file.toPath())) {
             fileOutputStream.write(byteArray);
         }
+    }
+
+    public static File createFileWithContent(Path filePath, String content) throws IOException {
+        File file = new File(filePath.toUri());
+        byte[] bytesArray = content.getBytes(StandardCharsets.UTF_8);
+        writeFile(file, bytesArray);
+        return file;
     }
 
     public static LogFile createLogFileWithSize(URI uri, int bytesNeeded) throws IOException {
@@ -35,5 +44,22 @@ public final class TestUtils {
         byte[] bytesArray = givenAStringOfSize(bytesNeeded).getBytes(StandardCharsets.UTF_8);
         writeFile(file, bytesArray);
         return file;
+    }
+
+    public static File rotateFilesByRenamingThem(File... files) throws IOException {
+        // Create new active file
+        String activeFilePath = files[0].getAbsolutePath();
+
+        for (int i = files.length - 1; i >= 0; i--) {
+            File current = files[i];
+            // to avoid changing the file on the array. Simulates closer what would happen on a real scenario
+            File toModify = new File(activeFilePath + "." + (i + 1));
+            current.renameTo(toModify);
+        }
+
+        File activeFile = new File(activeFilePath);
+        activeFile.createNewFile();
+
+        return activeFile;
     }
 }


### PR DESCRIPTION
**Description of changes:**
Hardlinks can't return the source path they are tracking. When we delete a file we want to ensure we are deleting the correct file and not the file path the hardlink got originally created with.

**Why is this change necessary:**
We might end up not deleting the files or deleting the wrong file.

**How was this change tested:**
Unit tests