### PR TITLE
refactor: cleanup and add some unit tests for log group and log file

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -73,7 +73,6 @@ import javax.inject.Inject;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.logmanager.LogManagerService.LOGS_UPLOADER_SERVICE_TOPICS;
-import static com.aws.greengrass.logmanager.model.LogFile.HASH_VALUE_OF_EMPTY_STRING;
 
 
 @ImplementsService(name = LOGS_UPLOADER_SERVICE_TOPICS, version = "2.0.0")
@@ -592,7 +591,7 @@ public class LogManagerService extends PluginService {
                 TimeUnit.SECONDS.sleep(periodicUpdateIntervalSec);
                 continue;
             }
-            List<ComponentLogFileInformation> unitsOfWork = new ArrayList<>();
+            List<ComponentLogFileInformation> componentMetadata = new ArrayList<>();
             // Get the latest known configurations because the componentLogConfigurations can change if a new
             // configuration is received from the customer.
             for (ComponentLogConfiguration componentLogConfiguration : componentLogConfigurations.values()) {
@@ -609,7 +608,7 @@ public class LogManagerService extends PluginService {
                         continue;
                     }
 
-                    ComponentLogFileInformation unitOfWork = ComponentLogFileInformation.builder()
+                    ComponentLogFileInformation logFileInfo = ComponentLogFileInformation.builder()
                             .name(componentName)
                             .multiLineStartPattern(componentLogConfiguration.getMultiLineStartPattern())
                             .desiredLogLevel(componentLogConfiguration.getMinimumLogLevel())
@@ -617,35 +616,33 @@ public class LogManagerService extends PluginService {
                             .logFileGroup(logFileGroup)
                             .build();
 
-                    unitsOfWork.add(unitOfWork);
+                    componentMetadata.add(logFileInfo);
 
                     logFileGroup.forEach(file -> {
                         long startPosition = 0;
                         String fileHash = file.hashString();
-                        // The file must contain enough lines for digest hash, otherwise fileHash is empty string
-                        if (!HASH_VALUE_OF_EMPTY_STRING.equals(fileHash)) {
-                            // If the file was partially read in the previous run, then get the starting position for
-                            // new log lines.
-                            if (componentCurrentProcessingLogFile.containsKey(componentName)) {
-                                CurrentProcessingFileInformation processingFileInformation =
-                                        componentCurrentProcessingLogFile.get(componentName);
-                                if (processingFileInformation.fileHash.equals(fileHash)) {
-                                    startPosition = processingFileInformation.startPosition;
-                                }
-                            }
 
-                            LogFileInformation logFileInformation = LogFileInformation.builder()
-                                    .logFile(file)
-                                    .startPosition(startPosition)
-                                    .fileHash(fileHash)
-                                    .build();
-
-                            if (startPosition < file.length()) {
-                                unitOfWork.getLogFileInformationList().add(logFileInformation);
-                            } else if (startPosition == file.length() && !logFileGroup.isActiveFile(file)) {
-                                updatelastComponentUploadedLogFile(lastComponentUploadedLogFileInstantMap,
-                                        componentName, file);
+                        // If the file was partially read in the previous run, then get the starting position for
+                        // new log lines.
+                        if (componentCurrentProcessingLogFile.containsKey(componentName)) {
+                            CurrentProcessingFileInformation processingFileInformation =
+                                    componentCurrentProcessingLogFile.get(componentName);
+                            if (processingFileInformation.fileHash.equals(fileHash)) {
+                                startPosition = processingFileInformation.startPosition;
                             }
+                        }
+
+                        LogFileInformation logFileInformation = LogFileInformation.builder()
+                                .logFile(file)
+                                .startPosition(startPosition)
+                                .fileHash(fileHash)
+                                .build();
+
+                        if (startPosition < file.length()) {
+                            logFileInfo.getLogFileInformationList().add(logFileInformation);
+                        } else if (startPosition == file.length() && !logFileGroup.isActiveFile(file)) {
+                            updatelastComponentUploadedLogFile(lastComponentUploadedLogFileInstantMap,
+                                    componentName, file);
                         }
                     });
                 } catch (SecurityException e) {
@@ -655,16 +652,20 @@ public class LogManagerService extends PluginService {
                     logger.atDebug().cause(e).log("Unable to read the directory");
                 }
             }
-            //TODO: need to refactor. This is for the case unitOfWork may be empty. This will get refactored when the
-            // logFilgeGroup won't return files that should not be processed.
-            unitsOfWork = unitsOfWork.stream().filter(unit -> !unit.getLogFileInformationList().isEmpty()).collect(
-                    Collectors.toList());
 
-            unitsOfWork.forEach((unit) -> {
+            //TODO: need to refactor. This is for the case componentMetadata may be empty.
+            // This will get refactored when the logFileGroup won't return files that should not be processed.
+            componentMetadata = componentMetadata.stream()
+                    .filter(metaData -> !metaData.getLogFileInformationList().isEmpty())
+                    .collect(Collectors.toList());
+
+            componentMetadata.forEach((unit) -> {
                 CloudWatchAttempt cloudWatchAttempt = logsProcessor.processLogFiles(unit);
                 uploader.upload(cloudWatchAttempt, 1);
             });
             isCurrentlyUploading.set(false);
+
+            // TODO: Change this. It is only added for testing
             emitEventStatus(EventType.ALL_COMPONENTS_PROCESSED);
             // after handle one cycle, we sleep for interval to avoid seamless scanning and processing next cycle.
             // TODO, do not use lazy sleep. Use scheduler to unblock the thread.

--- a/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/model/LogFileGroupTest.java
@@ -2,19 +2,24 @@ package com.aws.greengrass.logmanager.model;
 
 import com.aws.greengrass.logmanager.exceptions.InvalidLogGroupException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+import static com.aws.greengrass.logmanager.util.TestUtils.createLogFileWithSize;
 import static com.aws.greengrass.logmanager.util.TestUtils.givenAStringOfSize;
+import static com.aws.greengrass.logmanager.util.TestUtils.readFileContent;
 import static com.aws.greengrass.logmanager.util.TestUtils.writeFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,6 +31,11 @@ public class LogFileGroupTest {
     static Path directoryPath;
     @TempDir
     private Path workDir;
+
+    @BeforeEach
+    void setup() {
+        Arrays.stream(directoryPath.toFile().listFiles()).forEach(File::delete);
+    }
 
     @Test
     void GIVEN_log_files_THEN_find_the_active_file() throws IOException, InterruptedException,
@@ -51,5 +61,27 @@ public class LogFileGroupTest {
         assertEquals(2, logFileGroup.getLogFiles().size());
         assertFalse(logFileGroup.isActiveFile(file));
         assertTrue(logFileGroup.isActiveFile(file2));
+    }
+
+
+    @Test
+    void GIVEN_fileWithNotEnoughBytes_WHEN_logGroupCreated_THEN_itIsExcluded() throws IOException,
+            InvalidLogGroupException {
+        // Given
+        File rotatedFile = createLogFileWithSize(directoryPath.resolve("test.log.1").toUri(), 2048);
+        createLogFileWithSize(directoryPath.resolve("test.log").toUri(), 500); // active file
+
+        // When
+        Pattern pattern = Pattern.compile("test.log\\w*");
+        ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
+                .directoryPath(directoryPath)
+                .fileNameRegex(pattern).name("greengrass_test").build();
+        Instant instant = Instant.EPOCH;
+        LogFileGroup logFileGroup = LogFileGroup.create(compLogInfo, instant, workDir);
+
+        // Then
+        assertEquals(1, logFileGroup.getLogFiles().size());
+        LogFile logFile = logFileGroup.getLogFiles().get(0);
+        assertEquals(readFileContent(rotatedFile), readFileContent(logFile));
     }
 }

--- a/src/test/java/com/aws/greengrass/logmanager/util/TestUtils.java
+++ b/src/test/java/com/aws/greengrass/logmanager/util/TestUtils.java
@@ -2,8 +2,10 @@ package com.aws.greengrass.logmanager.util;
 
 import com.aws.greengrass.logmanager.model.LogFile;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -44,6 +46,19 @@ public final class TestUtils {
         byte[] bytesArray = givenAStringOfSize(bytesNeeded).getBytes(StandardCharsets.UTF_8);
         writeFile(file, bytesArray);
         return file;
+    }
+
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    public static String readFileContent(File file) throws IOException {
+        StringBuilder content = new StringBuilder();
+
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(Files.newInputStream(file.toPath())))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                content.append(line);
+            }
+        }
+        return content.toString();
     }
 
     public static File rotateFilesByRenamingThem(File... files) throws IOException {


### PR DESCRIPTION
**Description of changes:**
Add a few unit tests for the LogFile and the LogFileGroup and also made it so the log group does not return files that do not have a hash so we don't have to be sprinkling that logic around the codebase

**Why is this change necessary:**
Encapsulate logic related to which files should be processed.

**How was this change tested:**
Unit tests
