### PR TITLE
fix: file steps

### DIFF
--- a/uat/src/main/java/com.aws.greengrass/FileSteps.java
+++ b/uat/src/main/java/com.aws.greengrass/FileSteps.java
@@ -22,12 +22,11 @@ import java.util.List;
 @ScenarioScoped
 public class FileSteps {
 
-    private final Platform platform;
-    private final TestContext testContext;
-
-    private static Logger LOGGER = LogManager.getLogger(FileSteps.class);
     private static final RandomStringGenerator RANDOM_STRING_GENERATOR =
             new RandomStringGenerator.Builder().withinRange('a', 'z').build();
+    private static Logger LOGGER = LogManager.getLogger(FileSteps.class);
+    private final Platform platform;
+    private final TestContext testContext;
     private final ScenarioContext scenarioContext;
 
     @Inject
@@ -37,12 +36,22 @@ public class FileSteps {
         this.scenarioContext = scenarioContext;
     }
 
+    private static List<String> generateRandomMessages(int n, int length) {
+        List<String> msgs = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            // TODO: Improves this as this is not how the logger writes the logs
+            msgs.add(RANDOM_STRING_GENERATOR.generate(length));
+        }
+        return msgs;
+    }
+
     /**
      * Arranges some log files with content on the /logs folder for a component
      * to simulate a devices where logs have already bee written.
-     * @param numFiles       number of log files to write.
-     * @param componentName  name of the component.
-     * @throws IOException   thrown when file fails to be written.
+     *
+     * @param numFiles      number of log files to write.
+     * @param componentName name of the component.
+     * @throws IOException thrown when file fails to be written.
      */
     @Given("{int} temporary rotated log files for component {word} have been created")
     public void arrangeComponentLogFiles(int numFiles, String componentName) throws IOException {
@@ -51,18 +60,15 @@ public class FileSteps {
         if (!platform.files().exists(logsDirectory)) {
             throw new IllegalStateException("No logs directory");
         }
-        scenarioContext.put(componentName + "LogDirectory",logsDirectory.toString());
-        if (componentName.equals("aws.greengrass.Nucleus")) {
+        scenarioContext.put(componentName + "LogDirectory", logsDirectory.toString());
+        String filePrefix = "greengrass";
+        if (!componentName.equals("aws.greengrass.Nucleus")) {
+            filePrefix = componentName;
+        }
 
-            for (int i = 0; i < numFiles; i++) {
-                String fileName = String.format("greengrass_%s.log", i);
-                createFileAndWriteData(logsDirectory, fileName, false);
-            }
-        } else  {
-            for (int i = 0; i < numFiles; i++) {
-                String fileName = String.format("%s_%s.log",componentName, i);
-                createFileAndWriteData(logsDirectory,fileName, false);
-            }
+        for (int i = 0; i < numFiles; i++) {
+            String fileName = String.format("%s_%d.log", filePrefix, i);
+            createFileAndWriteData(logsDirectory, fileName, false);
         }
     }
 
@@ -79,15 +85,6 @@ public class FileSteps {
         for (String messageBytes : randomMessages) {
             addDataToFile(messageBytes, file.toPath());
         }
-    }
-
-    private static List<String> generateRandomMessages(int n, int length) {
-        List<String> msgs = new ArrayList<>();
-        for (int i = 0; i < n; i++) {
-            // TODO: Improves this as this is not how the logger writes the logs
-            msgs.add(RANDOM_STRING_GENERATOR.generate(length));
-        }
-        return msgs;
     }
 
     private void addDataToFile(String data, Path filePath) throws IOException {

--- a/uat/src/main/java/com.aws.greengrass/FileSteps.java
+++ b/uat/src/main/java/com.aws.greengrass/FileSteps.java
@@ -1,5 +1,6 @@
 package com.aws.greengrass;
 
+import com.aws.greengrass.testing.model.ScenarioContext;
 import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.platform.Platform;
 import com.google.inject.Inject;
@@ -27,11 +28,13 @@ public class FileSteps {
     private static Logger LOGGER = LogManager.getLogger(FileSteps.class);
     private static final RandomStringGenerator RANDOM_STRING_GENERATOR =
             new RandomStringGenerator.Builder().withinRange('a', 'z').build();
+    private final ScenarioContext scenarioContext;
 
     @Inject
-    public FileSteps(Platform platform, TestContext testContext) {
+    public FileSteps(Platform platform, TestContext testContext, ScenarioContext scenarioContext) {
         this.platform = platform;
         this.testContext = testContext;
+        this.scenarioContext = scenarioContext;
     }
 
     /**
@@ -45,21 +48,22 @@ public class FileSteps {
     public void arrangeComponentLogFiles(int numFiles, String componentName) throws IOException {
         Path logsDirectory = testContext.installRoot().resolve("logs");
         LOGGER.info("Writing {} log files into {}", numFiles, logsDirectory.toString());
-
         if (!platform.files().exists(logsDirectory)) {
             throw new IllegalStateException("No logs directory");
         }
-
+        scenarioContext.put(componentName + "LogDirectory",logsDirectory.toString());
         if (componentName.equals("aws.greengrass.Nucleus")) {
+
             for (int i = 0; i < numFiles; i++) {
-                String fileName = String.format("greengrass_%d.log", i);
+                String fileName = String.format("greengrass_%s.log", i);
                 createFileAndWriteData(logsDirectory, fileName, false);
             }
-            return;
+        } else  {
+            for (int i = 0; i < numFiles; i++) {
+                String fileName = String.format("%s_%s.log",componentName, i);
+                createFileAndWriteData(logsDirectory,fileName, false);
+            }
         }
-
-        String message = String.format("Generating log files for %d not yet implemented", componentName);
-        throw new UnsupportedOperationException(message);
     }
 
     private void createFileAndWriteData(Path tempDirectoryPath, String fileNamePrefix, boolean isTemp)

--- a/uat/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/src/main/resources/greengrass/features/log-manager-1.feature
@@ -7,6 +7,7 @@ Feature: Greengrass V2 LogManager
         Given my device is registered as a Thing
         And my device is running Greengrass
         And 5 temporary rotated log files for component aws.greengrass.Nucleus have been created
+        And 5 temporary rotated log files for component UserComponentA have been created
 
     Scenario: configure the log manager component using a componentLogsConfiguration list and logs are uploaded to
     CloudWatch
@@ -18,6 +19,12 @@ Feature: Greengrass V2 LogManager
         {
             "MERGE": {
                 "logsUploaderConfiguration": {
+                     "componentLogsConfigurationMap": {
+                        "UserComponentA": {
+                            "logFileRegex": "UserComponentA_\\w*.log",
+                            "logFileDirectoryPath": "${UserComponentALogDirectory}"
+                        }
+                    },
                     "systemLogsConfiguration": {
                         "uploadToCloudWatch": "true",
                         "minimumLogLevel": "INFO",
@@ -34,3 +41,4 @@ Feature: Greengrass V2 LogManager
         Then the Greengrass deployment is COMPLETED on the device after 2 minutes
         And I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         And I verify that it created a log group for component type GreengrassSystemComponent for component System, with streams within 120 seconds in CloudWatch
+        And I verify that it created a log group for component type UserComponent for component UserComponentA, with streams within 120 seconds in CloudWatch


### PR DESCRIPTION
**Issue #, if available:**
filestep do not have the part to write logs for non Nucleus components

**Description of changes:** 
fix file steps

**Why is this change necessary:**
to write logs for custom component

**How was this change tested:**
by creating new configuration for UserComponentA

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
