### PR TITLE
chore: point otf standalone dependency to 0.1.0

### DIFF
--- a/uat/pom.xml
+++ b/uat/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>aws-greengrass-testing-standalone</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Description of changes:**
Now that we have made some fixes to OTF so that it could be built in windows, the version OTF builds as is version 0.1.0. We are changing the version to that one so that we can reference the local version of OTF when developing tests so that changes made in OTF can be reflected immediately when added as a dependency.

**Why is this change necessary:**
Pull OTF local version instead of the one on a maven repo
