### PR TITLE
fix: add missing steps

### DIFF
--- a/uat/src/main/java/com.aws.greengrass/FileSteps.java
+++ b/uat/src/main/java/com.aws.greengrass/FileSteps.java
@@ -39,7 +39,7 @@ public class FileSteps {
     private final Platform platform;
     private final TestContext testContext;
     private final ScenarioContext scenarioContext;
-    private static final String activeFile = "ActiveFile";
+    private static final String ACTIVEFILE = "ActiveFile";
 
     /**
      * Arranges some log files with content on the /logs folder for a component
@@ -90,7 +90,7 @@ public class FileSteps {
             fileName = String.format("%s_%d.log", filePrefix, i);
             createFileAndWriteData(logsDirectory, fileName, false);
         }
-        scenarioContext.put(componentName + activeFile, logsDirectory.resolve(fileName).toAbsolutePath().toString());
+        scenarioContext.put(componentName + ACTIVEFILE, logsDirectory.resolve(fileName).toAbsolutePath().toString());
     }
 
     private void createFileAndWriteData(Path tempDirectoryPath, String fileNamePrefix, boolean isTemp)
@@ -137,7 +137,7 @@ public class FileSteps {
         assertEquals(1, componentFiles.size());
         File activeFile = componentFiles.get(componentFiles.size() - 1);
 
-        String expectedActiveFilePath = scenarioContext.get(componentName + this.activeFile);
+        String expectedActiveFilePath = scenarioContext.get(componentName + this.ACTIVEFILE);
         assertEquals(expectedActiveFilePath, activeFile.getAbsolutePath());
     }
 }

--- a/uat/src/main/java/com.aws.greengrass/FileSteps.java
+++ b/uat/src/main/java/com.aws.greengrass/FileSteps.java
@@ -39,8 +39,7 @@ public class FileSteps {
     private final Platform platform;
     private final TestContext testContext;
     private final ScenarioContext scenarioContext;
-
-    private final String ACTIVE_FILE = "ActiveFile";
+    private static final String activeFile = "ActiveFile";
 
     /**
      * Arranges some log files with content on the /logs folder for a component
@@ -91,7 +90,7 @@ public class FileSteps {
             fileName = String.format("%s_%d.log", filePrefix, i);
             createFileAndWriteData(logsDirectory, fileName, false);
         }
-        scenarioContext.put(componentName + ACTIVE_FILE, logsDirectory.resolve(fileName).toAbsolutePath().toString());
+        scenarioContext.put(componentName + activeFile, logsDirectory.resolve(fileName).toAbsolutePath().toString());
     }
 
     private void createFileAndWriteData(Path tempDirectoryPath, String fileNamePrefix, boolean isTemp)
@@ -121,7 +120,7 @@ public class FileSteps {
      *
      * @param componentName name of the component.
      */
-    @And("I verify the rotated files are deleted except for the active log file for component {word}")
+    @And("I verify the rotated files are deleted and that the active log file is present for component {word}")
     public void verifyActiveFile(String componentName) {
         Path logsDirectory = testContext.installRoot().resolve("logs");
 
@@ -138,23 +137,8 @@ public class FileSteps {
         assertEquals(1, componentFiles.size());
         File activeFile = componentFiles.get(componentFiles.size() - 1);
 
-        String expectedActiveFilePath = scenarioContext.get(componentName + ACTIVE_FILE);
+        String expectedActiveFilePath = scenarioContext.get(componentName + this.activeFile);
         assertEquals(expectedActiveFilePath, activeFile.getAbsolutePath());
-    }
-    @And("I verify the rotated files are not deleted except for the active log file for component {word}")
-    public void verifyActiveFilenotDeleted(String componentName) {
-        Path logsDirectory = testContext.installRoot().resolve("logs");
-
-        if (!platform.files().exists(logsDirectory)) {
-            throw new IllegalStateException("No logs directory");
-        }
-
-        List<File> componentFiles = Arrays.stream(logsDirectory.toFile().listFiles())
-                .filter(File::isFile)
-                .filter(file -> file.getName().startsWith(componentName))
-                .sorted(Comparator.comparingLong(File::lastModified))
-                .collect(Collectors.toList());
-        assertEquals(5, componentFiles.size());
     }
 }
 

--- a/uat/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/src/main/resources/greengrass/features/log-manager-1.feature
@@ -43,7 +43,6 @@ Feature: Greengrass V2 LogManager
         Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         Then I verify that it created a log group for component type GreengrassSystemComponent for component System, with streams within 120 seconds in CloudWatch
         And I verify that it created a log group for component type UserComponent for component UserComponentA, with streams within 120 seconds in CloudWatch
-        And I verify the rotated files are not deleted except for the active log file for component UserComponentA
 
     @smoke
     Scenario: LogManager-1-T2: As a customer I can configure the logs uploader to delete log files after all logs from the file have been uploaded to CloudWatch
@@ -78,4 +77,4 @@ Feature: Greengrass V2 LogManager
         Then the Greengrass deployment is COMPLETED on the device after 5 minutes
         Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         And I verify that it created a log group for component type UserComponent for component UserComponentA, with streams within 120 seconds in CloudWatch
-        And I verify the rotated files are deleted except for the active log file for component UserComponentA
+        And I verify the rotated files are deleted and that the active log file is present for component UserComponentA

--- a/uat/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/src/main/resources/greengrass/features/log-manager-1.feature
@@ -40,6 +40,7 @@ Feature: Greengrass V2 LogManager
         """
         And I deploy the Greengrass deployment configuration
         Then the Greengrass deployment is COMPLETED on the device after 2 minutes
+        Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         Then I verify that it created a log group for component type GreengrassSystemComponent for component System, with streams within 120 seconds in CloudWatch
         And I verify that it created a log group for component type UserComponent for component UserComponentA, with streams within 120 seconds in CloudWatch
         And I verify the rotated files are not deleted except for the active log file for component UserComponentA
@@ -75,5 +76,6 @@ Feature: Greengrass V2 LogManager
             """
         And I deploy the Greengrass deployment configuration
         Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+        Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         And I verify that it created a log group for component type UserComponent for component UserComponentA, with streams within 120 seconds in CloudWatch
         And I verify the rotated files are deleted except for the active log file for component UserComponentA


### PR DESCRIPTION
**Description of changes:**
Now that we can reference the locally installed version of OTF there are a few steps that we were missing that are available. This PR just adds those steps in to the tests the were already ported.

Other changes:
* Fix checkstyle violations
* Remove bad step


**Why is this change necessary:**
Ensures we wait first for the LogManager to be running