### PR TITLE
Feat port test t1b

### DIFF
--- a/uat/src/main/java/com.aws.greengrass/FileSteps.java
+++ b/uat/src/main/java/com.aws.greengrass/FileSteps.java
@@ -114,12 +114,12 @@ public class FileSteps {
             writer.write(data + "\r\n");
         }
     }
+
     /**
      * Arranges some log files with content on the /logs folder for a component
      * to simulate a devices where logs have already bee written.
      * @param componentName name of the component.
      */
-
     @And("I verify the rotated files are deleted and that the active log file is present for component {word}")
     public void verifyActiveFile(String componentName) {
         Path logsDirectory = testContext.installRoot().resolve("logs");

--- a/uat/src/main/java/com.aws.greengrass/FileSteps.java
+++ b/uat/src/main/java/com.aws.greengrass/FileSteps.java
@@ -114,13 +114,12 @@ public class FileSteps {
             writer.write(data + "\r\n");
         }
     }
-
     /**
      * Arranges some log files with content on the /logs folder for a component
      * to simulate a devices where logs have already bee written.
-     *
      * @param componentName name of the component.
      */
+
     @And("I verify the rotated files are deleted and that the active log file is present for component {word}")
     public void verifyActiveFile(String componentName) {
         Path logsDirectory = testContext.installRoot().resolve("logs");
@@ -140,28 +139,6 @@ public class FileSteps {
 
         String expectedActiveFilePath = scenarioContext.get(componentName + this.ACTIVEFILE);
         assertEquals(expectedActiveFilePath, activeFile.getAbsolutePath());
-    }
-    /**
-     * Arranges some log files with content on the /logs folder for a component
-     * to simulate a devices where logs have already bee written.
-     *
-     * @param componentName name of the component.
-     */
-
-    @And("I verify the rotated files are not deleted except for the active log file for component {word}")
-    public void verifyActiveFilenotDeleted(String componentName) {
-        Path logsDirectory = testContext.installRoot().resolve("logs");
-
-        if (!platform.files().exists(logsDirectory)) {
-            throw new IllegalStateException("No logs directory");
-        }
-
-        List<File> componentFiles = Arrays.stream(logsDirectory.toFile().listFiles())
-                .filter(File::isFile)
-                .filter(file -> file.getName().startsWith(componentName))
-                .sorted(Comparator.comparingLong(File::lastModified))
-                .collect(Collectors.toList());
-        assertEquals(5, componentFiles.size());
     }
 }
 

--- a/uat/src/main/java/com.aws.greengrass/FileSteps.java
+++ b/uat/src/main/java/com.aws.greengrass/FileSteps.java
@@ -120,7 +120,6 @@ public class FileSteps {
      * to simulate a devices where logs have already bee written.
      * @param componentName name of the component.
      */
-
     @And("I verify the rotated files are deleted and that the active log file is present for component {word}")
     public void verifyActiveFile(String componentName) {
         Path logsDirectory = testContext.installRoot().resolve("logs");

--- a/uat/src/main/java/com.aws.greengrass/FileSteps.java
+++ b/uat/src/main/java/com.aws.greengrass/FileSteps.java
@@ -40,7 +40,7 @@ public class FileSteps {
     private final TestContext testContext;
     private final ScenarioContext scenarioContext;
 
-    private final String ACTIVE_FILE = "ActiveFile";
+    public static final String ACTIVE_FILE = "ActiveFile";
 
     /**
      * Arranges some log files with content on the /logs folder for a component
@@ -141,6 +141,14 @@ public class FileSteps {
         String expectedActiveFilePath = scenarioContext.get(componentName + ACTIVE_FILE);
         assertEquals(expectedActiveFilePath, activeFile.getAbsolutePath());
     }
+
+    /**
+     * Arranges some log files with content on the /logs folder for a component
+     * to simulate a devices where logs have already bee written.
+     *
+     * @param componentName name of the component.
+     */
+
     @And("I verify the rotated files are not deleted except for the active log file for component {word}")
     public void verifyActiveFilenotDeleted(String componentName) {
         Path logsDirectory = testContext.installRoot().resolve("logs");

--- a/uat/src/main/java/com.aws.greengrass/FileSteps.java
+++ b/uat/src/main/java/com.aws.greengrass/FileSteps.java
@@ -120,6 +120,7 @@ public class FileSteps {
      * to simulate a devices where logs have already bee written.
      * @param componentName name of the component.
      */
+
     @And("I verify the rotated files are deleted and that the active log file is present for component {word}")
     public void verifyActiveFile(String componentName) {
         Path logsDirectory = testContext.installRoot().resolve("logs");

--- a/uat/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/src/main/resources/greengrass/features/log-manager-1.feature
@@ -32,7 +32,7 @@ Feature: Greengrass V2 LogManager
                         "diskSpaceLimit": "25",
                         "diskSpaceLimitUnit": "MB",
                         "deleteLogFileAfterCloudUpload": "true"
-                        }
+                    }
                 },
                 "periodicUploadIntervalSec": "10"
             }
@@ -65,7 +65,7 @@ Feature: Greengrass V2 LogManager
                         "diskSpaceLimit": "25",
                         "diskSpaceLimitUnit": "MB",
                         "deleteLogFileAfterCloudUpload": "true"
-                        }
+                    }
                 },
                 "periodicUploadIntervalSec": "10"
             }
@@ -100,7 +100,7 @@ Feature: Greengrass V2 LogManager
                         "diskSpaceLimit": "25",
                         "diskSpaceLimitUnit": "MB",
                         "deleteLogFileAfterCloudUpload": "true"
-                        }
+                    }
                 },
                 "periodicUploadIntervalSec": "10"
             }

--- a/uat/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/src/main/resources/greengrass/features/log-manager-1.feature
@@ -40,9 +40,43 @@ Feature: Greengrass V2 LogManager
         """
         And I deploy the Greengrass deployment configuration
         Then the Greengrass deployment is COMPLETED on the device after 2 minutes
+        Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         Then I verify that it created a log group for component type GreengrassSystemComponent for component System, with streams within 120 seconds in CloudWatch
         And I verify that it created a log group for component type UserComponent for component UserComponentA, with streams within 120 seconds in CloudWatch
         And I verify the rotated files are not deleted except for the active log file for component UserComponentA
+
+    Scenario: LogManager-1-T1-b: As a customer I can configure the logs uploader component using a componentLogsConfigurationMap and logs are uploaded to CloudWatch
+        Given I create a Greengrass deployment with components
+            | aws.greengrass.Cli        | LATEST |
+            | aws.greengrass.LogManager     | LATEST |
+        When I update my Greengrass deployment configuration, setting the component aws.greengrass.LogManager configuration to:
+            """
+            {
+                "MERGE": {
+                    "logsUploaderConfiguration": {
+                        "componentLogsConfigurationMap": {
+                             "UserComponentA": {
+                            "logFileRegex": "UserComponentA_\\w*.log",
+                            "logFileDirectoryPath": "${UserComponentALogDirectory}"
+                             }
+                        },
+                            "systemLogsConfiguration": {
+                                "uploadToCloudWatch":"true",
+                                "minimumLogLevel":"INFO",
+                                "diskSpaceLimit":"25",
+                                "diskSpaceLimitUnit":"MB",
+                                "deleteLogFileAfterCloudUpload":"true"
+                            }
+                    },
+                    "periodicUploadIntervalSec": "10"
+                }
+            }
+            """
+        And I deploy the Greengrass deployment configuration
+        Then the Greengrass deployment is COMPLETED on the device after 3 minutes
+        Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
+        Then I verify that it created a log group for component type GreengrassSystemComponent for component System, with streams within 120 seconds in CloudWatch
+        And I verify that it created a log group for component type UserComponent for component UserComponentA, with streams within 120 seconds in CloudWatch
 
     @smoke
     Scenario: LogManager-1-T2: As a customer I can configure the logs uploader to delete log files after all logs from the file have been uploaded to CloudWatch
@@ -75,5 +109,6 @@ Feature: Greengrass V2 LogManager
             """
         And I deploy the Greengrass deployment configuration
         Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+        Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         And I verify that it created a log group for component type UserComponent for component UserComponentA, with streams within 120 seconds in CloudWatch
         And I verify the rotated files are deleted except for the active log file for component UserComponentA

--- a/uat/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/src/main/resources/greengrass/features/log-manager-1.feature
@@ -49,28 +49,28 @@ Feature: Greengrass V2 LogManager
             | aws.greengrass.Cli        | LATEST |
             | aws.greengrass.LogManager     | LATEST |
         When I update my Greengrass deployment configuration, setting the component aws.greengrass.LogManager configuration to:
-            """
-            {
-                "MERGE": {
-                    "logsUploaderConfiguration": {
-                        "componentLogsConfigurationMap": {
-                             "UserComponentA": {
+        """
+        {
+            "MERGE": {
+                "logsUploaderConfiguration": {
+                     "componentLogsConfigurationMap": {
+                        "UserComponentA": {
                             "logFileRegex": "UserComponentA_\\w*.log",
                             "logFileDirectoryPath": "${UserComponentALogDirectory}"
-                             }
-                        },
-                            "systemLogsConfiguration": {
-                                "uploadToCloudWatch":"true",
-                                "minimumLogLevel":"INFO",
-                                "diskSpaceLimit":"25",
-                                "diskSpaceLimitUnit":"MB",
-                                "deleteLogFileAfterCloudUpload":"true"
-                            }
+                        }
                     },
-                    "periodicUploadIntervalSec": "10"
-                }
+                    "systemLogsConfiguration": {
+                        "uploadToCloudWatch": "true",
+                        "minimumLogLevel": "INFO",
+                        "diskSpaceLimit": "25",
+                        "diskSpaceLimitUnit": "MB",
+                        "deleteLogFileAfterCloudUpload": "true"
+                        }
+                },
+                "periodicUploadIntervalSec": "10"
             }
-            """
+        }
+        """
         And I deploy the Greengrass deployment configuration
         Then the Greengrass deployment is COMPLETED on the device after 3 minutes
         Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
@@ -83,29 +83,29 @@ Feature: Greengrass V2 LogManager
             | aws.greengrass.Cli        | LATEST |
             | aws.greengrass.LogManager | LATEST |
         And I update my Greengrass deployment configuration, setting the component aws.greengrass.LogManager configuration to:
-            """
-            {
-                "MERGE": {
-                    "logsUploaderConfiguration": {
-                        "componentLogsConfigurationMap": {
-                            "UserComponentA": {
-                                "logFileRegex": "UserComponentA_\\w*.log",
-                                "logFileDirectoryPath":"${UserComponentALogDirectory}",
-                                "deleteLogFileAfterCloudUpload":"true"
-                            }
-                        },
-                        "systemLogsConfiguration": {
-                            "uploadToCloudWatch":"true",
-                            "minimumLogLevel":"INFO",
-                            "diskSpaceLimit":"25",
-                            "diskSpaceLimitUnit":"MB",
-                            "deleteLogFileAfterCloudUpload":"true"
+         """
+        {
+            "MERGE": {
+                "logsUploaderConfiguration": {
+                     "componentLogsConfigurationMap": {
+                        "UserComponentA": {
+                            "logFileRegex": "UserComponentA_\\w*.log",
+                            "logFileDirectoryPath": "${UserComponentALogDirectory}",
+                            "deleteLogFileAfterCloudUpload": "true"
                         }
                     },
-                    "periodicUploadIntervalSec": "10"
-                }
+                    "systemLogsConfiguration": {
+                        "uploadToCloudWatch": "true",
+                        "minimumLogLevel": "INFO",
+                        "diskSpaceLimit": "25",
+                        "diskSpaceLimitUnit": "MB",
+                        "deleteLogFileAfterCloudUpload": "true"
+                        }
+                },
+                "periodicUploadIntervalSec": "10"
             }
-            """
+        }
+        """
         And I deploy the Greengrass deployment configuration
         Then the Greengrass deployment is COMPLETED on the device after 5 minutes
         Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Port test Logmanager-T1-b
As a customer I can configure the logs uploader component using a componentLogsConfigurationMap and logs are uploaded to CloudWatch
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
