### PR TITLE
Feat port t3

### DIFF
--- a/uat/src/main/java/com.aws.greengrass/FileSteps.java
+++ b/uat/src/main/java/com.aws.greengrass/FileSteps.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.testing.platform.Platform;
 import com.google.inject.Inject;
 import io.cucumber.guice.ScenarioScoped;
 import io.cucumber.java.en.And;
+import io.cucumber.java.en.Then;
 import org.apache.commons.text.RandomStringGenerator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,6 +27,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,19 +37,19 @@ public class FileSteps {
 
     private static final RandomStringGenerator RANDOM_STRING_GENERATOR =
             new RandomStringGenerator.Builder().withinRange('a', 'z').build();
+    private static final String ACTIVEFILE = "ActiveFile";
     private static Logger LOGGER = LogManager.getLogger(FileSteps.class);
     private final Platform platform;
     private final TestContext testContext;
     private final ScenarioContext scenarioContext;
-    private static final String ACTIVEFILE = "ActiveFile";
 
 
     /**
      * Arranges some log files with content on the /logs folder for a component
      * to simulate a devices where logs have already bee written.
      *
-     * @param platform     number of log files to write.
-     * @param testContext name of the component.
+     * @param platform        number of log files to write.
+     * @param testContext     name of the component.
      * @param scenarioContext name of the component.
      */
     @Inject
@@ -66,6 +68,14 @@ public class FileSteps {
         return msgs;
     }
 
+    private static List<File> getComponentLogFiles(String componentName, Path logsDirectory) {
+        return Arrays.stream(logsDirectory.toFile().listFiles())
+                .filter(File::isFile)
+                .filter(file -> file.getName().startsWith(componentName))
+                .sorted(Comparator.comparingLong(File::lastModified))
+                .collect(Collectors.toList());
+    }
+
     /**
      * Arranges some log files with content on the /logs folder for a component
      * to simulate a devices where logs have already bee written.
@@ -77,7 +87,7 @@ public class FileSteps {
     @And("{int} temporary rotated log files for component {word} have been created")
     public void arrangeComponentLogFiles(int numFiles, String componentName) throws IOException {
         Path logsDirectory = testContext.installRoot().resolve("logs");
-        LOGGER.info("Writing {} log files into {}", numFiles, logsDirectory.toString());
+        LOGGER.info("Writing {} log files into {}", numFiles, ((Path) logsDirectory).toString());
         if (!platform.files().exists(logsDirectory)) {
             throw new IllegalStateException("No logs directory");
         }
@@ -88,7 +98,7 @@ public class FileSteps {
         }
         String fileName = "";
         for (int i = 0; i < numFiles; i++) {
-            fileName = String.format("%s_%d.log", filePrefix, i);
+            fileName = String.format("%s_%s.log", filePrefix, UUID.randomUUID());
             createFileAndWriteData(logsDirectory, fileName, false);
         }
         scenarioContext.put(componentName + ACTIVEFILE, logsDirectory.resolve(fileName).toAbsolutePath().toString());
@@ -118,6 +128,24 @@ public class FileSteps {
     /**
      * Arranges some log files with content on the /logs folder for a component
      * to simulate a devices where logs have already bee written.
+     *
+     * @param componentName name of the component.
+     * @param nfiles        number of log files to write.
+     */
+    @Then("I verify that {int} temporary rotated log files for component {word} are still available")
+    public void verifyRotatedFilesAvailable(int nfiles, String componentName) {
+        Path logsDirectory = testContext.installRoot().resolve("logs");
+        if (!platform.files().exists(logsDirectory)) {
+            throw new IllegalStateException("No logs directory");
+        }
+        List<File> componentFiles = getComponentLogFiles(componentName, logsDirectory);
+        assertEquals(nfiles, componentFiles.size());
+    }
+
+    /**
+     * Arranges some log files with content on the /logs folder for a component
+     * to have already bee written simulate a devices where logs.
+     *
      * @param componentName name of the component.
      */
     @And("I verify the rotated files are deleted and that the active log file is present for component {word}")
@@ -127,42 +155,9 @@ public class FileSteps {
         if (!platform.files().exists(logsDirectory)) {
             throw new IllegalStateException("No logs directory");
         }
-
-        List<File> componentFiles = Arrays.stream(logsDirectory.toFile().listFiles())
-                .filter(File::isFile)
-                .filter(file -> file.getName().startsWith(componentName))
-                .sorted(Comparator.comparingLong(File::lastModified))
-                .collect(Collectors.toList());
-
-        assertEquals(1, componentFiles.size());
-        File activeFile = componentFiles.get(componentFiles.size() - 1);
-
+        List<File> sortedFileList = getComponentLogFiles(componentName, logsDirectory);
         String expectedActiveFilePath = scenarioContext.get(componentName + this.ACTIVEFILE);
+        File activeFile = sortedFileList.get(sortedFileList.size() - 1);
         assertEquals(expectedActiveFilePath, activeFile.getAbsolutePath());
     }
-
-    /**
-     * Arranges some log files with content on the /logs folder for a component
-     * to simulate a devices where logs have already bee written.
-     *
-     * @param componentName name of the component.
-     */
-
-    @And("I verify the rotated files are not deleted except for the active log file for component {word}")
-    public void verifyActiveFilenotDeleted(String componentName) {
-        Path logsDirectory = testContext.installRoot().resolve("logs");
-
-        if (!platform.files().exists(logsDirectory)) {
-            throw new IllegalStateException("No logs directory");
-        }
-
-        List<File> componentFiles = Arrays.stream(logsDirectory.toFile().listFiles())
-                .filter(File::isFile)
-                .filter(file -> file.getName().startsWith(componentName))
-                .sorted(Comparator.comparingLong(File::lastModified))
-                .collect(Collectors.toList());
-        assertEquals(5, componentFiles.size());
-    }
 }
-
-

--- a/uat/src/main/java/com.aws.greengrass/FileSteps.java
+++ b/uat/src/main/java/com.aws.greengrass/FileSteps.java
@@ -40,7 +40,7 @@ public class FileSteps {
     private final TestContext testContext;
     private final ScenarioContext scenarioContext;
 
-    private final String ACTIVE_FILE = "ActiveFile";
+    public static final String ACTIVE_FILE = "ActiveFile";
 
     /**
      * Arranges some log files with content on the /logs folder for a component
@@ -141,6 +141,14 @@ public class FileSteps {
         String expectedActiveFilePath = scenarioContext.get(componentName + ACTIVE_FILE);
         assertEquals(expectedActiveFilePath, activeFile.getAbsolutePath());
     }
+
+    /**
+     * Arranges some log files with content on the /logs folder for a component
+     * to simulate a devices where logs have already bee written.
+     *
+     * @param componentName name of the component.
+     */
+
     @And("I verify the rotated files are not deleted except for the active log file for component {word}")
     public void verifyActiveFilenotDeleted(String componentName) {
         Path logsDirectory = testContext.installRoot().resolve("logs");

--- a/uat/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/src/main/resources/greengrass/features/log-manager-1.feature
@@ -21,7 +21,7 @@ Feature: Greengrass V2 LogManager
                 "logsUploaderConfiguration": {
                      "componentLogsConfigurationMap": {
                         "UserComponentA": {
-                            "logFileRegex": "UserComponentA_\\w*.log",
+                            "logFileRegex": "UserComponentA_(.)+.log",
                             "logFileDirectoryPath": "${UserComponentALogDirectory}",
                             "deleteLogFileAfterCloudUpload": "false"
                         }
@@ -44,39 +44,6 @@ Feature: Greengrass V2 LogManager
         Then I verify that it created a log group for component type GreengrassSystemComponent for component System, with streams within 120 seconds in CloudWatch
         And I verify that it created a log group for component type UserComponent for component UserComponentA, with streams within 120 seconds in CloudWatch
 
-    Scenario: LogManager-1-T1-b: As a customer I can configure the logs uploader component using a componentLogsConfigurationMap and logs are uploaded to CloudWatch
-        Given I create a Greengrass deployment with components
-            | aws.greengrass.Cli        | LATEST |
-            | aws.greengrass.LogManager     | LATEST |
-        When I update my Greengrass deployment configuration, setting the component aws.greengrass.LogManager configuration to:
-        """
-        {
-            "MERGE": {
-                "logsUploaderConfiguration": {
-                     "componentLogsConfigurationMap": {
-                        "UserComponentA": {
-                            "logFileRegex": "UserComponentA_\\w*.log",
-                            "logFileDirectoryPath": "${UserComponentALogDirectory}"
-                        }
-                    },
-                    "systemLogsConfiguration": {
-                        "uploadToCloudWatch": "true",
-                        "minimumLogLevel": "INFO",
-                        "diskSpaceLimit": "25",
-                        "diskSpaceLimitUnit": "MB",
-                        "deleteLogFileAfterCloudUpload": "true"
-                    }
-                },
-                "periodicUploadIntervalSec": "10"
-            }
-        }
-        """
-        And I deploy the Greengrass deployment configuration
-        Then the Greengrass deployment is COMPLETED on the device after 3 minutes
-        Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
-        Then I verify that it created a log group for component type GreengrassSystemComponent for component System, with streams within 120 seconds in CloudWatch
-        And I verify that it created a log group for component type UserComponent for component UserComponentA, with streams within 120 seconds in CloudWatch
-
     @smoke
     Scenario: LogManager-1-T2: As a customer I can configure the logs uploader to delete log files after all logs from the file have been uploaded to CloudWatch
         Given I create a Greengrass deployment with components
@@ -89,7 +56,7 @@ Feature: Greengrass V2 LogManager
                 "logsUploaderConfiguration": {
                      "componentLogsConfigurationMap": {
                         "UserComponentA": {
-                            "logFileRegex": "UserComponentA_\\w*.log",
+                            "logFileRegex": "UserComponentA_(.)+.log",
                             "logFileDirectoryPath": "${UserComponentALogDirectory}",
                             "deleteLogFileAfterCloudUpload": "true"
                         }
@@ -112,3 +79,39 @@ Feature: Greengrass V2 LogManager
         And I verify that it created a log group for component type UserComponent for component UserComponentA, with streams within 120 seconds in CloudWatch
         And I verify the rotated files are deleted and that the active log file is present for component UserComponentA
 
+    @R1    @functional @M2 @B1 @stable
+    Scenario: LogManager-1-T3: As a customer I can configure the logs uploader to delete log oldest log files inorder to keep the disk space limit configured by the customer
+        Given 10 temporary rotated log files for component UserComponentB have been created
+        Given I create a Greengrass deployment with components
+            | aws.greengrass.Cli        | LATEST |
+            | aws.greengrass.LogManager | LATEST |
+        When I update my Greengrass deployment configuration, setting the component aws.greengrass.LogManager configuration to:
+        """
+        {
+            "MERGE": {
+                "logsUploaderConfiguration": {
+                     "componentLogsConfigurationMap": {
+                        "UserComponentB": {
+                            "logFileRegex": "UserComponentB_(.)+.log",
+                            "logFileDirectoryPath": "${UserComponentBLogDirectory}",
+                            "diskSpaceLimit":"100",
+                            "diskSpaceLimitUnit":"KB"
+                        }
+                    },
+                    "systemLogsConfiguration": {
+                        "uploadToCloudWatch": "true",
+                        "minimumLogLevel": "INFO",
+                        "diskSpaceLimit": "25",
+                        "diskSpaceLimitUnit": "MB",
+                        "deleteLogFileAfterCloudUpload": "true"
+                    }
+                },
+                "periodicUploadIntervalSec": "500"
+            }
+        }
+        """
+        And I deploy the Greengrass deployment configuration
+        Then the Greengrass deployment is COMPLETED on the device after 4 minutes
+        Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
+        And I wait 5 seconds
+        Then I verify that 10 temporary rotated log files for component UserComponentB are still available


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
LogManager-1-T3: As a customer I can configure the logs uploader to delete log oldest log files inorder to keep the disk space limit configured by the customer

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
