### PR TITLE
chore: update otf dependency to open source version

### DIFF
--- a/uat/pom.xml
+++ b/uat/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>aws-greengrass-testing-standalone</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Description of changes:**
OTF version got bumped to 1.0.0-SNAPSHOT when open sourced. This PR just changes the version so that we can build OTF locally and it references the correct and also so that it fetched the new version from the maven reposittory




