### PR TITLE
fix: step 4

### DIFF
--- a/uat/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/src/main/resources/greengrass/features/log-manager-1.feature
@@ -162,7 +162,7 @@ Feature: Greengrass V2 LogManager
                 "logsUploaderConfiguration": {
                      "componentLogsConfigurationMap": {
                         "UserComponentA": {
-                            "logFileRegex": "UserComponentA_(.)+.log,
+                            "logFileRegex": "UserComponentA_(.)+.log",
                             "logFileDirectoryPath": "${UserComponentALogDirectory}"
                         }
                     },


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
LogManager-1-T4: As a developer, logs uploader will handle network interruptions gracefully and upload logs from the last uploaded log after network resumes
**Why is this change necessary:**
need some correction in Configuration 
**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
