### PR TITLE
chore: exclude uat folder from uber jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -439,6 +439,7 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>uat/*</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
**Description of changes:**
Excludes the contents inside the uat folder from being included on the final uber jar.

**Why is this change necessary:**
Avoid bloating the project size when uats grow

