### PR TITLE
feat: add log events from cloud and local in OTF

### DIFF
--- a/uat/custom-components/src/main/java/com/aws/greengrass/artifacts/logGenerator.java
+++ b/uat/custom-components/src/main/java/com/aws/greengrass/artifacts/logGenerator.java
@@ -14,6 +14,7 @@ import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
 import ch.qos.logback.core.util.FileSize;
 
+import java.io.File;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -48,8 +49,15 @@ public class logGenerator implements Consumer<String[]> {
 
         // the default log FIle path is where this instance locates. If running OTF, it will be on DUT. If running
         // the uni testing, it would be on the local machine.
+        String logFilePath = null;
         if (targetLogFilePath.isEmpty()) {
             targetLogFilePath = System.getProperty("user.dir");
+            System.out.println("file path in logGenerator: " + System.getProperty("user.dir"));
+            System.out.println("user home: " + System.getProperty("user.home"));
+            File currentFile = new File(targetLogFilePath);
+            File logFileParent = currentFile.getParentFile().getParentFile();
+            logFilePath = logFileParent.getAbsolutePath() + "/logs";
+            System.out.println("new file path: " + logFilePath);
         }
 
         try {
@@ -59,11 +67,17 @@ public class logGenerator implements Consumer<String[]> {
         }
 
         // configure the logger by setting the context, rolling policy, encoder
-        Logger logger = configureLogger(targetLogFilePath, logFileName, logFileExtension, fileSizeBytes);
+        Logger logger = configureLogger(logFilePath, logFileName, logFileExtension, fileSizeBytes);
 
         // starting logging message
         performLogging(logger, totalLogNumbers, logWriteFreqSeconds);
 
+        //verify
+        File logFileFolder = new File(logFilePath);
+        System.out.println("files in the path: " + logFileFolder.listFiles().length);
+        for (File file : logFileFolder.listFiles()) {
+            System.out.println(file.getName());
+        }
     }
 
     private static Logger configureLogger(String currentPath, String fileName, String extension, int fileSizeBytes) {

--- a/uat/testing-features/src/main/java/com/aws/greengrass/CloudWatchSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/CloudWatchSteps.java
@@ -96,7 +96,8 @@ public class CloudWatchSteps {
         LOGGER.info("Verifying log group {} with stream {} was created", logGroupName, logStreamNamePattern);
         waitSteps.untilTrue(() -> doesStreamExistInGroup(logGroupName, logStreamNamePattern), timeout,
                 TimeUnit.SECONDS);
-
+// Note: this only works on assumption that the log files are not deleted yet. And there are several ways we could achieve this: 1) do not delete files after uploading 2) adjust steps to make sure we get log first before start uploading when allowing deletion of logs from logmanager. 
+// The perfect solution will be grabbing the log dynamically when uploading. 
         Set<String> messages = getLocalLogs("logGeneratorLogger\\w*.log");
 
         LOGGER.info("Getting log events from log group {} with stream pattern {}", logGroupName,

--- a/uat/testing-features/src/main/java/com/aws/greengrass/resources/CloudWatchLogsLifecycle.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/resources/CloudWatchLogsLifecycle.java
@@ -11,6 +11,9 @@ import com.google.auto.service.AutoService;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogStreamsRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogStreamsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.FilterLogEventsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.FilterLogEventsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.FilteredLogEvent;
 import software.amazon.awssdk.services.cloudwatchlogs.model.LogStream;
 
 import java.util.List;
@@ -38,5 +41,15 @@ public class CloudWatchLogsLifecycle extends AbstractAWSResourceLifecycle<CloudW
 
         DescribeLogStreamsResponse response = client.describeLogStreams(request);
         return response.logStreams();
+    }
+
+    public List<FilteredLogEvent> getAllLogEvents(String groupName, String logStreamNamePattern) {
+        FilterLogEventsRequest request = FilterLogEventsRequest.builder()
+                .logGroupName(groupName)
+                .logStreamNamePrefix(logStreamNamePattern)
+                .build();
+
+        FilterLogEventsResponse response = client.filterLogEvents(request);
+        return response.events();
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This provides the methods to grab log events from cloudwatch and local. Then it enables the further verification relied on these events. The verification steps could be in next PR. 
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
