### PR TITLE
feat: simplify space management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+greengrass-build
 target
 .DS_Store
 ._*

--- a/gdk-config.json
+++ b/gdk-config.json
@@ -7,7 +7,7 @@
         "build_system": "maven"
       },
       "publish": {
-        "bucket": "BUCKET_NAME",
+        "bucket": "BUCKETNAME",
         "region": "REGION"
       }
     }

--- a/gdk-config.json
+++ b/gdk-config.json
@@ -7,8 +7,8 @@
         "build_system": "maven"
       },
       "publish": {
-        "bucket": "gg-dev-artifacts",
-        "region": "us-west-2"
+        "bucket": "BUCKET_NAME",
+        "region": "REGION"
       }
     }
   },

--- a/gdk-config.json
+++ b/gdk-config.json
@@ -1,0 +1,16 @@
+{
+  "component" :{
+    "aws.greengrass.LogManager": {
+      "author": "AWS",
+      "version": "NEXT_PATCH",
+      "build": {
+        "build_system": "maven"
+      },
+      "publish": {
+        "bucket": "gg-dev-artifacts",
+        "region": "us-west-2"
+      }
+    }
+  },
+  "gdk_version": "1.1.0"
+}

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,10 +1,10 @@
 ---
 RecipeFormatVersion: '2020-01-25'
-ComponentName: aws.greengrass.LogManager
+ComponentName: '{COMPONENT_NAME}'
 ComponentDescription: AWS Greengrass Log Manager
 ComponentPublisher: AWS
-ComponentVersion: '2.0.0'
+ComponentVersion: '{COMPONENT_VERSION}'
 ComponentType: aws.greengrass.plugin
 Manifests:
     - Artifacts:
-        - URI: s3://gg-dev-artifacts-$stage/$componentName/$version/aws.greengrass.LogManager.jar
+        - URI: s3://gg-dev-artifacts-$stage/$componentName/$version/LogManager.jar

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallSpaceManagementPeriodicIntervalConfig.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallSpaceManagementPeriodicIntervalConfig.yaml
@@ -11,6 +11,7 @@ services:
             diskSpaceLimit: '105'
             diskSpaceLimitUnit: 'KB'
             deleteLogFileAfterCloudUpload: 'true'
+      periodicUploadIntervalSec: 1
   main:
     lifecycle:
       install: echo All installed

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -490,10 +490,7 @@ public class LogManagerService extends PluginService {
             }
 
             // Delete files based on diskspace
-            this.diskSpaceManagementService.freeDiskSpace(
-                attemptLogInformation.getLogFileGroup(),
-                lastComponentUploadedLogFileInstantMap.get(componentName)
-            );
+            this.diskSpaceManagementService.freeDiskSpace(attemptLogInformation.getLogFileGroup());
 
             // Delete after upload
             ComponentLogConfiguration componentLogConfiguration = componentLogConfigurations.get(componentName);

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -647,7 +647,7 @@ public class LogManagerService extends PluginService {
                     LogFileGroup logFileGroup = LogFileGroup.create(componentLogConfiguration,
                             lastUploadedLogFileTimeMs, workDir);
 
-                    if (logFileGroup.isEmpty()) {
+                    if (logFileGroup.getLogFiles().isEmpty()) {
                         continue;
                     }
 

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -661,7 +661,7 @@ public class LogManagerService extends PluginService {
 
                     componentMetadata.add(logFileInfo);
 
-                    logFileGroup.forEach(file -> {
+                    logFileGroup.getLogFiles().forEach(file -> {
                         long startPosition = 0;
                         String fileHash = file.hashString();
 

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -479,13 +478,12 @@ public class LogManagerService extends PluginService {
 
             // Update the last updated
             String componentName = attemptLogInformation.getComponentName();
-            Set<LogFile> completedFiles = completedLogFilePerComponent.get(componentName);
+            Set<LogFile> completedFiles = completedLogFilePerComponent.getOrDefault(componentName, new HashSet<>());
 
             // Record the last processed file timestamp
             completedFiles.forEach(file -> {
                 updatelastComponentUploadedLogFile(lastComponentUploadedLogFileInstantMap, componentName, file);
             });
-
 
             if (!componentLogConfigurations.containsKey(componentName)) {
                 return;

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFileGroup.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -58,7 +57,6 @@ public final class LogFileGroup {
                 .filter(file -> this.lastProcessed.isBefore(Instant.ofEpochMilli(file.lastModified())))
                 .collect(Collectors.toList());
     }
-
 
     private LogFileGroup(
             List<LogFile> files,
@@ -205,10 +203,6 @@ public final class LogFileGroup {
         logFiles.remove(logFiles.size() - 1); // remove the active file
 
         return logFiles;
-    }
-
-    public void forEach(Consumer<LogFile> callback) {
-        logFiles.forEach(callback::accept);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/logmanager/services/DiskSpaceManagementService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/services/DiskSpaceManagementService.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.logmanager.services;
 import com.aws.greengrass.logmanager.model.LogFile;
 import com.aws.greengrass.logmanager.model.LogFileGroup;
 
-import java.time.Instant;
 import java.util.List;
 
 
@@ -19,13 +18,8 @@ public class DiskSpaceManagementService {
      * disk space usage limit.
      *
      * @param group - a Log File group
-     * @param lastUpdated - the timestamp of the last processed file
      */
-    public void freeDiskSpace(LogFileGroup group, Instant lastUpdated) {
-        if (lastUpdated == null || group == null) {
-            return;
-        }
-
+    public void freeDiskSpace(LogFileGroup group) {
         if (!group.hasExceededDiskUsage()) {
             return;
         }

--- a/src/main/java/com/aws/greengrass/logmanager/services/DiskSpaceManagementService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/services/DiskSpaceManagementService.java
@@ -5,215 +5,39 @@
 
 package com.aws.greengrass.logmanager.services;
 
-import com.aws.greengrass.logging.api.Logger;
-import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.logmanager.model.ComponentLogConfiguration;
-import com.aws.greengrass.util.Coerce;
-import com.aws.greengrass.util.Utils;
+import com.aws.greengrass.logmanager.model.LogFile;
+import com.aws.greengrass.logmanager.model.LogFileGroup;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchEvent;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.nio.file.Watchable;
-import java.util.Comparator;
-import java.util.HashMap;
+import java.time.Instant;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 
 public class DiskSpaceManagementService {
-    private static final Logger logger = LogManager.getLogger(DiskSpaceManagementService.class);
-
-    private final Object spaceManagementLock = new Object();
-    private Future<?> spaceManagementThread;
-    private final ExecutorService executorService;
-
-
     /**
      * Constructor.
-     *
-     * @param executorService {@link ExecutorService}
      */
-    public DiskSpaceManagementService(ExecutorService executorService) {
-        this.executorService = executorService;
-    }
+    public DiskSpaceManagementService() {}
 
-
-    public void start(Map<String, ComponentLogConfiguration> componentLogConfigurations) {
-        this.scheduleSpaceManagementThread(componentLogConfigurations);
-    }
-
-    @SuppressWarnings("PMD.AvoidCatchingThrowable")
-    private void scheduleSpaceManagementThread(Map<String, ComponentLogConfiguration> componentLogConfigurations) {
-        synchronized (spaceManagementLock) {
-            if (spaceManagementThread != null) {
-                spaceManagementThread.cancel(true);
-            }
-            spaceManagementThread = this.executorService.submit(() -> {
-                try {
-                    logger.atInfo().log("Starting space management thread");
-                    startWatchServiceOnLogFilePaths(componentLogConfigurations);
-                } catch (IOException e) {
-                    //TODO: fail the deployment?
-                    logger.atError().cause(e).log("Unable to start space management thread.");
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } catch (Throwable e) {
-                    logger.atError().log("Failure in log manager space management", e);
-                    scheduleSpaceManagementThread(componentLogConfigurations); // restart space management
-                }
-            });
-        }
-    }
-
-    /**
-     * Starts a Watch Service on all the log directories where customer has specified disk space limit.
-     * If any file is modified and created in any of those directories, we get an event containing that information.
-     * The log manager will then verify that the size of all log files in that directory for the component does not
-     * exceed the disk space limit set by the customer. If it does, the log manager will delete the log files until
-     * the limit is met.
-     *
-     * @throws IOException          if unable to initialise a new Watch Service.
-     * @throws InterruptedException if thread is shutdown
-     */
-    private void startWatchServiceOnLogFilePaths(Map<String, ComponentLogConfiguration> componentLogConfigurations)
-            throws IOException, InterruptedException {
-        //TODO: Optimize this.
-        // The optimization would be to have best of both worlds. The file watcher will mark the changed components
-        // log directories. Another scheduled thread will look at that and clean up files if necessary.
-        try (WatchService watchService = FileSystems.getDefault().newWatchService()) {
-            try {
-                componentLogConfigurations.forEach((componentName, componentLogConfiguration) -> {
-                    // Only register the path of a component if the disk space limit is set.
-                    if (componentLogConfiguration != null && componentLogConfiguration.getDiskSpaceLimit() != null
-                            && componentLogConfiguration.getDiskSpaceLimit() > 0) {
-                        Path path = componentLogConfiguration.getDirectoryPath();
-                        try {
-                            path.register(watchService, StandardWatchEventKinds.ENTRY_CREATE,
-                                    StandardWatchEventKinds.ENTRY_MODIFY);
-                            logger.atDebug().kv("filePath", path).log("Start watching file for log space management.");
-                        } catch (IOException e) {
-                            logger.atError().cause(e).log("Unable to watch {} for log space management.",
-                                    path);
-                        }
-                    }
-                });
-
-                while (true) {
-                    final WatchKey watchKey = watchService.take();
-                    final Watchable watchable = watchKey.watchable();
-
-                    //Since we are registering only paths in thw watch service, the watchables must be paths
-                    if (watchable instanceof Path) {
-                        final Path directory = (Path) watchable;
-                        Map<String, ComponentLogConfiguration> updatedComponentsConfiguration = new HashMap<>();
-                        // Based on the directory and file name created/modified, the log manager will store the
-                        // component information which need to be checked.
-                        List<ComponentLogConfiguration> allComponentsConfiguration =
-                                componentLogConfigurations.values().stream()
-                                        .filter(componentLogConfiguration ->
-                                                componentLogConfiguration.getDirectoryPath().equals(directory))
-                                        .collect(Collectors.toList());
-
-                        // The events can have multiple log files in the same directory. We need to make sure we get the
-                        // correct component based on the file name pattern.
-                        for (WatchEvent<?> event : watchKey.pollEvents()) {
-                            String fileName = Coerce.toString(event.context());
-                            if (fileName == null) {
-                                continue;
-                            }
-                            List<ComponentLogConfiguration> list = allComponentsConfiguration.stream()
-                                    .filter(componentLogConfiguration -> componentLogConfiguration
-                                            .getFileNameRegex().matcher(fileName).find())
-                                    .collect(Collectors.toList());
-                            list.forEach(componentLogConfiguration ->
-                                    updatedComponentsConfiguration.putIfAbsent(componentLogConfiguration.getName(),
-                                            componentLogConfiguration));
-                        }
-
-                        // Get the total log files size in the directories for all updates components. If the log files
-                        // size exceed the limit set by the customer, the log manager will figure out the minimum bytes
-                        // to be deleted inorder to meet the limit. It will then go ahead and delete the oldest files
-                        // until the minimum bytes have been deleted.
-                        for (ComponentLogConfiguration componentLogConfiguration :
-                                updatedComponentsConfiguration.values()) {
-                            try {
-                                deleteFilesIfNecessary(componentLogConfiguration);
-                            } catch (UncheckedIOException e) {
-                                logger.atWarn().log("Unchecked error thrown when collecting files to be deleted",
-                                        Utils.getUltimateCause(e));
-                            }
-                        }
-                    }
-
-                    if (!watchKey.reset()) {
-                        logger.atError().log("Log Space Management encountered an issue. Returning.");
-                        scheduleSpaceManagementThread(componentLogConfigurations);
-                        break;
-                    }
-                }
-            } catch (IOException e) {
-                // If there is any other IOException, then we should restart the thread.
-                scheduleSpaceManagementThread(componentLogConfigurations);
-            }
-        }
-    }
-
-    /**
-     * Deletes the oldest log files which matches the file name pattern. The log files will be deleted until the
-     * minimum number of bytes have been deleted.
-     *
-     * @param componentLogConfiguration Log configuration to investigate for deletion
-     * @throws IOException for errors during directory walking
-     */
-    private void deleteFilesIfNecessary(ComponentLogConfiguration componentLogConfiguration) throws IOException {
-        if (componentLogConfiguration.getDiskSpaceLimit() == null) {
+    public void freeDiskSpace(LogFileGroup group, Instant lastUpdated) {
+        if (group.hasExceededDiskUsage()) {
             return;
         }
-        try (Stream<Path> fileStream = Files.walk(componentLogConfiguration.getDirectoryPath())
-                .filter(p -> {
-                    File file = p.toFile();
-                    return file.isFile() && componentLogConfiguration.getFileNameRegex()
-                            .matcher(file.getName()).find();
-                })) {
-            List<Path> paths = fileStream.collect(Collectors.toList());
-            long totalBytes = paths.stream().mapToLong(p -> p.toFile().length()).sum();
-            long minimumBytesToBeDeleted = totalBytes - componentLogConfiguration.getDiskSpaceLimit();
 
-            // If we don't need to remove any bytes, or if the file count is only 1 (or less), then there's nothing
-            // to do.
-            if (minimumBytesToBeDeleted <= 0 || paths.size() < 2) {
-                return;
-            }
+        if (!group.getMaxBytes().isPresent()) {
+            return;
+        }
 
-            long bytesDeleted = 0;
-            // Sort the files by the last modified time.
-            paths.sort(Comparator.comparingLong((p) -> p.toFile().lastModified()));
-            int fileIndex = 0;
-            // stop before the end to skip the active file which should have the newest modified time
-            while (bytesDeleted < minimumBytesToBeDeleted && fileIndex < paths.size() - 1) {
-                Path fileToBeDeleted = paths.get(fileIndex++);
-                long fileSize = fileToBeDeleted.toFile().length();
-                try {
-                    Files.deleteIfExists(fileToBeDeleted);
-                } catch (IOException e) {
-                    logger.atWarn().log("Unable to delete file: {}", fileToBeDeleted.toAbsolutePath(), e);
-                    break;
-                }
-                logger.atInfo().log("Successfully deleted file: {}", fileToBeDeleted.toAbsolutePath());
-                bytesDeleted += fileSize;
-            }
+        long bytesDeleted = 0;
+        long minimumBytesToBeDeleted = Math.max(group.totalSizeInBytes() - group.getMaxBytes().get(), 0);
+
+        List<LogFile> deletableFiles = group.getLogFiles().stream()
+                .filter(file ->  lastUpdated.isAfter(Instant.ofEpochMilli(file.lastModified())))
+                .collect(Collectors.toList());
+
+        for (LogFile logFile: deletableFiles) {
+            if (bytesDeleted < minimumBytesToBeDeleted) break;
+            group.remove(logFile);
         }
     }
 }

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -310,7 +310,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(logsUploaderConfigTopics);
         doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
 
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
         startServiceOnAnotherThread();
 
         TimeUnit.SECONDS.sleep(5);
@@ -365,7 +365,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
 
         doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
 
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
         startServiceOnAnotherThread();
 
         TimeUnit.SECONDS.sleep(5);
@@ -416,7 +416,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
 
         doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
 
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
         startServiceOnAnotherThread();
 
         TimeUnit.SECONDS.sleep(5);
@@ -468,7 +468,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
 
         doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
 
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
         startServiceOnAnotherThread();
 
         TimeUnit.SECONDS.sleep(5);
@@ -528,7 +528,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
 
         doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
 
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
         startServiceOnAnotherThread();
 
         TimeUnit.SECONDS.sleep(5);
@@ -571,7 +571,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(logsUploaderConfigTopic);
 
 
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
         startServiceOnAnotherThread();
         assertThat(logsUploaderService.processingFilesInformation.values(), IsEmptyCollection.empty());
     }
@@ -702,7 +702,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         ComponentLogFileInformation info1 = ComponentLogFileInformation.builder().build();
         lenient().doReturn(attempt1).when(mockMerger).processLogFiles(info1);
         lenient().doNothing().when(mockUploader).upload(attempt1, 1);
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
         startServiceOnAnotherThread();
         callbackCaptor.getValue().accept(attempt);
 
@@ -755,7 +755,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
                 .thenReturn(logsUploaderConfigTopics);
 
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
         // These two files are existed, and the active file is greengrass.log
         LogFile file = new LogFile(directoryPath.resolve("greengrass_test_2.log").toUri());
         LogFile currentProcessingFile = new LogFile(directoryPath.resolve("greengrass_test_3.log").toUri());
@@ -820,7 +820,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
                 .thenReturn(logsUploaderConfigTopics);
 
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
         startServiceOnAnotherThread();
         TimeUnit.SECONDS.sleep(5);
         List<String> fileNames = new ArrayList<>();
@@ -943,9 +943,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, "UserComponentA"))
                 .thenReturn(componentTopics1);
 
-
-
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
         startServiceOnAnotherThread();
 
         callbackCaptor.getValue().accept(attempt);
@@ -981,7 +979,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
                 .thenReturn(logsUploaderConfigTopics);
 
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
         startServiceOnAnotherThread();
 
         LogFile file = new LogFile(directoryPath.resolve("greengrass.log_test_2").toUri());
@@ -1093,7 +1091,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION_V2, "UserComponentA"))
                 .thenReturn(currentProcessingComponentTopics2);
 
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, executor, nucleusPaths);
+        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
 
         assertNotNull(logsUploaderService.processingFilesInformation);
         assertNotNull(logsUploaderService.lastComponentUploadedLogFileInstantMap);

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -792,65 +792,6 @@ class LogManagerServiceTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_user_component_with_space_management_WHEN_log_file_size_exceeds_limit_THEN_deletes_excess_log_files()
-            throws InterruptedException, IOException {
-        mockDefaultPersistedState();
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
-
-        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
-        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
-        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
-
-        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
-        Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
-        componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^log.txt\\w*");
-        componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
-        componentATopic.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("DEBUG");
-        componentATopic.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("2");
-        componentATopic.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("KB");
-        componentATopic.createLeafChild(DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue("false");
-
-        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
-        systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("true");
-        systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
-        systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
-        systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("KB");
-        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(logsUploaderConfigTopics);
-
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
-        startServiceOnAnotherThread();
-        TimeUnit.SECONDS.sleep(5);
-        List<String> fileNames = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            Path fileNamePath = directoryPath.resolve("log.txt_" + UUID.randomUUID());
-            fileNames.add(fileNamePath.toAbsolutePath().toString());
-            File file1 = new File(fileNamePath.toUri());
-            assertTrue(file1.createNewFile());
-            assertTrue(file1.setReadable(true));
-            assertTrue(file1.setWritable(true));
-
-            try (OutputStream fileOutputStream = Files.newOutputStream(file1.toPath())) {
-                String generatedString = RandomStringUtils.randomAlphabetic(1024);
-                fileOutputStream.write(generatedString.getBytes(StandardCharsets.UTF_8));
-            }
-            TimeUnit.SECONDS.sleep(1);
-        }
-        TimeUnit.SECONDS.sleep(5);
-
-        for (int i = 0; i < 3; i++) {
-            assertTrue(Files.notExists(Paths.get(fileNames.get(i))));
-        }
-
-        for (int i = 3; i < 5; i++) {
-            assertTrue(Files.exists(Paths.get(fileNames.get(i))));
-            assertEquals(1024, new File(Paths.get(fileNames.get(i)).toUri()).length());
-        }
-    }
-
-    @Test
     void GIVEN_user_component_logs_delete_file_after_upload_set_WHEN_upload_logs_THEN_deletes_uploaded_log_files(
             ExtensionContext ec)
             throws InterruptedException, IOException, InvalidLogGroupException {

--- a/src/test/java/com/aws/greengrass/logmanager/services/DiskSpaceManagementServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/services/DiskSpaceManagementServiceTest.java
@@ -68,7 +68,7 @@ class DiskSpaceManagementServiceTest extends GGServiceTestUtil {
 
         // When
         DiskSpaceManagementService service = new DiskSpaceManagementService();
-        service.freeDiskSpace(group, lastProcessedInstant);
+        service.freeDiskSpace(group);
 
         // Then
         assertEquals(1, group.getLogFiles().size());
@@ -88,7 +88,7 @@ class DiskSpaceManagementServiceTest extends GGServiceTestUtil {
 
         // When
         DiskSpaceManagementService service = new DiskSpaceManagementService();
-        service.freeDiskSpace(group, lastProcessedFileInstant);
+        service.freeDiskSpace(group);
 
         // Then
         assertEquals(2, group.getLogFiles().size());
@@ -108,24 +108,7 @@ class DiskSpaceManagementServiceTest extends GGServiceTestUtil {
 
         // When
         DiskSpaceManagementService service = new DiskSpaceManagementService();
-        service.freeDiskSpace(group, lastProcessedFileInstant);
-
-        // Then
-        assertEquals(1, group.getLogFiles().size());
-        assertTrue(Files.exists(activeFile.toPath()));
-    }
-
-    @Test
-    void GIVEN_log_files_WHEN_null_last_updated_THEN_checks_skipped()
-            throws IOException, InvalidLogGroupException, InterruptedException {
-        // Given
-        LogFile activeFile = arrangeLogFile("test.log", 1024);
-        Instant lastProcessedFileInstant = Instant.EPOCH;
-        LogFileGroup group = arrangeLogGroup(Pattern.compile("test.log\\w*"), lastProcessedFileInstant, 0L);
-
-        // When
-        DiskSpaceManagementService service = new DiskSpaceManagementService();
-        service.freeDiskSpace(group, null);
+        service.freeDiskSpace(group);
 
         // Then
         assertEquals(1, group.getLogFiles().size());
@@ -146,7 +129,7 @@ class DiskSpaceManagementServiceTest extends GGServiceTestUtil {
 
         // When
         DiskSpaceManagementService service = new DiskSpaceManagementService();
-        service.freeDiskSpace(group, lastProcessedFileInstant);
+        service.freeDiskSpace(group);
 
         // Then
         assertEquals(1, group.getLogFiles().size());
@@ -166,7 +149,7 @@ class DiskSpaceManagementServiceTest extends GGServiceTestUtil {
         assertTrue(Files.exists(directoryPath.resolve("test.log.2")));
 
         DiskSpaceManagementService service = new DiskSpaceManagementService();
-        service.freeDiskSpace(group, lastProcessedFileInstant);
+        service.freeDiskSpace(group);
 
         // Then
         assertEquals(directoryPath.resolve("test.log"), newActive.toPath());

--- a/src/test/java/com/aws/greengrass/logmanager/services/DiskSpaceManagementServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/services/DiskSpaceManagementServiceTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.logmanager.services;
+
+import com.aws.greengrass.logmanager.exceptions.InvalidLogGroupException;
+import com.aws.greengrass.logmanager.model.ComponentLogConfiguration;
+import com.aws.greengrass.logmanager.model.LogFile;
+import com.aws.greengrass.logmanager.model.LogFileGroup;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static com.aws.greengrass.logmanager.util.TestUtils.createLogFileWithSize;
+import static com.aws.greengrass.logmanager.util.TestUtils.rotateFilesByRenamingThem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class DiskSpaceManagementServiceTest extends GGServiceTestUtil {
+    @TempDir
+    private Path directoryPath;
+
+    @TempDir
+    private Path workDirPath;
+
+    public LogFileGroup arrangeLogGroup(Pattern pattern, long diskSpaceLimitBytes) throws InvalidLogGroupException {
+        ComponentLogConfiguration config = ComponentLogConfiguration.builder()
+                .directoryPath(directoryPath)
+                .fileNameRegex(pattern).name("greengrass_test")
+                .diskSpaceLimit(diskSpaceLimitBytes)
+                .build();
+        Instant instant = Instant.EPOCH;
+        return LogFileGroup.create(config, instant, workDirPath);
+    }
+
+    public LogFile arrangeLogFile(String name, int byteSize) throws InterruptedException, IOException {
+       LogFile file = createLogFileWithSize(directoryPath.resolve(name).toUri(), byteSize);
+        // Wait to avoid file's lastModified to be the same if called to fast
+        TimeUnit.MILLISECONDS.sleep(100);
+       return file;
+    }
+
+    @Test
+    void GIVEN_log_files_WHEN_max_disk_usage_exceeded_THEN_files_removed() throws IOException, InvalidLogGroupException,
+            InterruptedException {
+        // Given
+        LogFile aLogFile = arrangeLogFile("test.log.1", 2048);
+        LogFile activeFile = arrangeLogFile("test.log", 1024);
+        LogFileGroup group = arrangeLogGroup(Pattern.compile("test.log\\w*"), 1024L);
+
+        // When
+        DiskSpaceManagementService service = new DiskSpaceManagementService();
+        Instant lastProcessedFileInstant = Instant.ofEpochMilli(activeFile.lastModified());
+        service.freeDiskSpace(group, lastProcessedFileInstant);
+
+        // Then
+        assertEquals(1, group.getLogFiles().size());
+        assertTrue(Files.notExists(aLogFile.toPath()));
+    }
+
+    @Test
+    void GIVEN_log_files_WHEN_max_disk_usage_exceeded_THEN_only_unprocessed_files_are_deletable()
+            throws IOException, InvalidLogGroupException, InterruptedException {
+        // Given
+        LogFile cLogFile = arrangeLogFile("test.log.3", 2048);
+        LogFile bLogFile = arrangeLogFile("test.log.2", 2048);
+        LogFile aLogFile = arrangeLogFile("test.log.1", 2048);
+        LogFile activeFile = arrangeLogFile("test.log", 1024);
+        LogFileGroup group = arrangeLogGroup(Pattern.compile("test.log\\w*"), 1024L);
+
+        // When
+        DiskSpaceManagementService service = new DiskSpaceManagementService();
+        Instant lastProcessedFileInstant = Instant.ofEpochMilli(aLogFile.lastModified());
+        service.freeDiskSpace(group, lastProcessedFileInstant);
+
+        // Then
+        assertEquals(2, group.getLogFiles().size());
+        assertTrue(Files.notExists(cLogFile.toPath()));
+        assertTrue(Files.notExists(bLogFile.toPath()));
+        assertTrue(Files.exists(aLogFile.toPath()));
+        assertTrue(Files.exists(activeFile.toPath()));
+    }
+
+    @Test
+    void GIVEN_log_files_WHEN_max_disk_usage_exceeded_THEN_active_file_is_not_removed()
+            throws IOException, InvalidLogGroupException, InterruptedException {
+        // Given
+        LogFile activeFile = arrangeLogFile("test.log", 1024);
+        LogFileGroup group = arrangeLogGroup(Pattern.compile("test.log\\w*"), 0L);
+
+        // When
+        DiskSpaceManagementService service = new DiskSpaceManagementService();
+        service.freeDiskSpace(group, Instant.now());
+
+        // Then
+        assertEquals(1, group.getLogFiles().size());
+        assertTrue(Files.exists(activeFile.toPath()));
+    }
+
+    @Test
+    void GIVEN_file_was_delete_by_externally_WHEN_freeing_space_THEN_it_does_not_fail()
+            throws IOException, InvalidLogGroupException, InterruptedException {
+        // Given
+        LogFile aLogFile = arrangeLogFile("test.log.1", 2048);
+        arrangeLogFile("test.log", 1024);
+        LogFileGroup group = arrangeLogGroup(Pattern.compile("test.log\\w*"), 0L);
+
+        aLogFile.delete(); // Deleted externally
+        assertTrue(Files.notExists(aLogFile.toPath()));
+
+        // When
+        DiskSpaceManagementService service = new DiskSpaceManagementService();
+        service.freeDiskSpace(group, Instant.now());
+
+        // Then
+        assertEquals(1, group.getLogFiles().size());
+    }
+
+    @Test
+    void GIVEN_file_rotates_WHEN_freeing_space_THEN_it_deletes_the_oldest_files_first()
+            throws IOException, InvalidLogGroupException, InterruptedException {
+        // Given
+        LogFile aLogFile = arrangeLogFile("test.log.1", 2048);
+        LogFile prevActive = arrangeLogFile("test.log", 1024);
+        LogFileGroup group = arrangeLogGroup(Pattern.compile("test.log\\w*"), 0L);
+
+        // When
+        File newActive = rotateFilesByRenamingThem(prevActive, aLogFile); // Files rotate before freed
+        DiskSpaceManagementService service = new DiskSpaceManagementService();
+        service.freeDiskSpace(group, Instant.now());
+
+        // Then
+        assertEquals(directoryPath.resolve("test.log"), newActive.toPath());
+        assertEquals(0, group.getLogFiles().size());
+        assertTrue(Files.notExists(directoryPath.resolve("test.log.2")));
+        assertTrue(Files.notExists(directoryPath.resolve("test.log.1")));
+        assertTrue(Files.exists(directoryPath.resolve("test.log")));
+    }
+}


### PR DESCRIPTION
**Description of changes:**
This changes simplify the disk space management functionality to avoid some of the pitfalls that have bitten us in the past. 

The existing code:

* Competes with uploads and could delete a file while it is uploaded (sure, we could have added synchronization and locks but complexity comes at a cost)
* Deletes the active log file depending on the configuration
* Uses watchers and re-dispatches a thread when there are failures
* Competes with the delete after cloud upload functionality
* Does not deal with file rotation, it can end up deleting the wrong file

The new code operates on the same upload thread and frees space after the uploads are complete and only clears files that have not been processed. It could come at a tiny cost addition of deleting files but if it becomes a problem we could always schedule a separate thread to handle delete I/O

**Why is this change necessary:**
Simplifies code complexity and make it work appropriately without competing with files uploads and deals with file rotations.

**How was this change tested:**
Unit + Integration tests
