### PR TITLE
chore: run lm uats on codebuild pipeline

### DIFF
--- a/.github/workflows/uat.yaml
+++ b/.github/workflows/uat.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+name: OTF UATS
+
+on:
+  pull_request:
+    branches: 'main'
+
+env:
+  AWS_REGION : "us-west-2"
+  CODE_BUILD_PROJECT_LINUX: "LogManagerUatCodeBuildLinux"
+  AWS_ROLE_TO_ASSUME: "arn:aws:iam::686385081908:role/aws-greengrass-log-manager-codebuild-uat-role-linux"
+
+jobs:
+  uat-linux:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+    steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          role-session-name: logManagerCI
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Run UAT on linux
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ env.CODE_BUILD_PROJECT_LINUX }}
+          buildspec-override: uat/codebuild/uat_linux_buildspec.yaml

--- a/uat/codebuild/uat_linux_buildspec.yaml
+++ b/uat/codebuild/uat_linux_buildspec.yaml
@@ -10,16 +10,17 @@ phases:
       java: corretto11
   build:
     commands:
-      - mvn -U -ntp clean verify -f uat/pom.xml
+      - curl -s https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zip > /tmp/greengrass-nucleus-latest.zip
       - mvn -U -ntp verify -DskipTests=true
-      - java -Dggc.archive=./target/aws.greengrass.nucleus.zip
-        -Dtags=smoke -Dggc.install.root=$CODEBUILD_SRC_DIR -Dggc.log.level=INFO -Daws.region=us-west-2
-        -jar uat/testing-features/target/greengrass-log-manager-testing-features
+      - mvn -U -ntp clean verify -f uat/pom.xml
+      - java -Dggc.archive=/tmp/greengrass-nucleus-latest.zip
+        -Dtags='LogManager&!unstable' -Dggc.install.root=$CODEBUILD_SRC_DIR -Dggc.log.level=INFO -Daws.region=us-west-2
+        -jar uat/testing-features/target/greengrass-log-manager-testing-features.jar
 
 artifacts:
   files:
     - 'testResults/**/*'
-  name: 'NucleusUatLinuxLogs.zip'
+  name: 'LogManagerUatLinuxLogs.zip'
 
 reports:
   uat-reports:

--- a/uat/testing-features/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/log-manager-1.feature
@@ -9,25 +9,6 @@ Feature: Greengrass V2 LogManager
         And 5 temporary rotated log files for component aws.greengrass.Nucleus have been created
         And 5 temporary rotated log files for component UserComponentA have been created
 
-    @local
-    Scenario: LogManager-1-T0: install the local custom component
-        Given I create a Greengrass deployment with components
-            | aws.greengrass.Cli        | LATEST |
-        And I deploy the Greengrass deployment configuration
-        Then I wait 120 seconds
-        Then the Greengrass deployment is COMPLETED on the device after 2 minutes
-        When I install the component logGenerator from local store with configuration
-        """
-        {
-            "MERGE": {
-                "FileSize": "15",
-                "FileSizeUnit": "KB"
-            }
-        }
-        """
-        Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
-        Then I wait 30 seconds
-
     Scenario: LogManager-1-T1: configure the log manager component using a componentLogsConfiguration list and logs are uploaded to
     CloudWatch
         Given I create a Greengrass deployment with components
@@ -168,6 +149,7 @@ Feature: Greengrass V2 LogManager
         And I wait 5 seconds
         Then I verify that 10 log files for component UserComponentB are still available
 
+    @unstable
     Scenario: LogManager-1-T4: As a developer, logs uploader will handle network interruptions gracefully and upload logs from the last uploaded log after network resumes
         Given I create a Greengrass deployment with components
             | aws.greengrass.LogManager |  classpath:/greengrass/recipes/recipe.yaml |


### PR DESCRIPTION
**Description of changes:**
Adds workflow to run the uats on codebuild

**Why is this change necessary:**
Extra testing layer to perform e2e tests before merging

**How was this change tested:**
Codebuild flow passing