### PR TITLE
chore: adapt to OTF 1.1.0

### DIFF
--- a/uat/testing-features/pom.xml
+++ b/uat/testing-features/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>aws-greengrass-testing-standalone</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Issue #, if available:**
OTF 1.1.0 is released, so cutting this PR to adapt to use 1.1.0.


**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
