### PR TITLE
fix: free up cache space when files get deleted

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerConfigTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerConfigTest.java
@@ -76,7 +76,7 @@ class LogManagerConfigTest extends BaseITCase {
     private static LogManagerService logManagerService;
     private static Path tempDirectoryPath;
     private static Path tempRootDir;
-    private static final  ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+    private static final ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
     private static final String componentName = "UserComponentA";
     private static final Level minimumLogLevelDefault = Level.INFO;
 
@@ -104,7 +104,8 @@ class LogManagerConfigTest extends BaseITCase {
                 logManagerService = (LogManagerService) service;
             }
         });
-        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com", "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath",
+        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
+                "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath",
                 "certFilePath", "caFilePath", "us-east-1", "roleAliasName");
 
         kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
@@ -134,16 +135,16 @@ class LogManagerConfigTest extends BaseITCase {
             Exception {
         setupKernel();
 
-        assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(), eventuallyEval(is(60),
+        assertThat(() -> logManagerService.getPeriodicUpdateIntervalSec(), eventuallyEval(is(60),
                 Duration.ofSeconds(30)));
 
-            logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC).remove();
-            assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(),
-                    eventuallyEval(is(LogManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
+        logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC).remove();
+        assertThat(() -> logManagerService.getPeriodicUpdateIntervalSec(),
+                eventuallyEval(is(LogManagerService.DEFAULT_PERIODIC_UPDATE_INTERVAL_SEC), Duration.ofSeconds(30)));
 
-            logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC).withValue(600);
-            assertThat(()-> logManagerService.getPeriodicUpdateIntervalSec(), eventuallyEval(is(600),
-                    Duration.ofSeconds(30)));
+        logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC).withValue(600);
+        assertThat(() -> logManagerService.getPeriodicUpdateIntervalSec(), eventuallyEval(is(600),
+                Duration.ofSeconds(30)));
     }
 
     @Test
@@ -155,13 +156,13 @@ class LogManagerConfigTest extends BaseITCase {
         assertTrue(logManagerService.getComponentLogConfigurations().containsKey(SYSTEM_LOGS_COMPONENT_NAME));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
-        SYSTEM_LOGS_CONFIG_TOPIC_NAME, UPLOAD_TO_CW_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().containsKey(SYSTEM_LOGS_COMPONENT_NAME),
+                SYSTEM_LOGS_CONFIG_TOPIC_NAME, UPLOAD_TO_CW_CONFIG_TOPIC_NAME).remove();
+        assertThat(() -> logManagerService.getComponentLogConfigurations().containsKey(SYSTEM_LOGS_COMPONENT_NAME),
                 eventuallyEval(is(false), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 SYSTEM_LOGS_CONFIG_TOPIC_NAME, UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue(true);
-        assertThat(()-> logManagerService.getComponentLogConfigurations().containsKey(SYSTEM_LOGS_COMPONENT_NAME),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().containsKey(SYSTEM_LOGS_COMPONENT_NAME),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
     }
 
@@ -170,92 +171,92 @@ class LogManagerConfigTest extends BaseITCase {
             throws Exception {
         setupKernel();
 
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getMinimumLogLevel(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getMinimumLogLevel(),
                 eventuallyEval(is(Level.TRACE), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 SYSTEM_LOGS_CONFIG_TOPIC_NAME, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getMinimumLogLevel(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getMinimumLogLevel(),
                 eventuallyEval(is(minimumLogLevelDefault), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 SYSTEM_LOGS_CONFIG_TOPIC_NAME, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("WARN");
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getMinimumLogLevel(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getMinimumLogLevel(),
                 eventuallyEval(is(Level.WARN), Duration.ofSeconds(30)));
     }
 
     @Test
     void GIVEN_system_deleteLogFileAfterCloudUpload_config_WHEN_value_is_reset_and_replaced_THEN_correct_values_are_used()
-             throws Exception {
+            throws Exception {
         setupKernel();
 
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).isDeleteLogFileAfterCloudUpload(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 SYSTEM_LOGS_CONFIG_TOPIC_NAME, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).isDeleteLogFileAfterCloudUpload(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(false), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 SYSTEM_LOGS_CONFIG_TOPIC_NAME, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue(true);
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).isDeleteLogFileAfterCloudUpload(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
     }
 
     @Test
     void GIVEN_system_diskSpaceLimit_and_diskSpaceLimitUnit_config_WHEN_values_are_reset_and_replaced_THEN_correct_values_are_used()
-             throws Exception {
+            throws Exception {
         setupKernel();
 
-                 // diskSpaceLimit=25 and diskSpaceLimitUnit=MB in config file, so expected value is 26214400 bytes
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getDiskSpaceLimit(),
+        // diskSpaceLimit=25 and diskSpaceLimitUnit=MB in config file, so expected value is 26214400 bytes
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getDiskSpaceLimit(),
                 eventuallyEval(is(26214400L), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 SYSTEM_LOGS_CONFIG_TOPIC_NAME, DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getDiskSpaceLimit() == null,
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getDiskSpaceLimit() == null,
                 eventuallyEval(equalTo(true), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 SYSTEM_LOGS_CONFIG_TOPIC_NAME, DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue(5);
         // diskSpaceLimitUnit in config file is MB, so diskSpaceLimit=5 gives expected value of 5242880 bytes
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getDiskSpaceLimit(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getDiskSpaceLimit(),
                 eventuallyEval(is(5242880L), Duration.ofSeconds(30)));
 
         // verifcation for diskSpaceLimitUnit
         // diskSpaceLimitUnit default is KB, so with diskSpaceLimit=5, expected value is 5120 bytes
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 SYSTEM_LOGS_CONFIG_TOPIC_NAME, DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getDiskSpaceLimit(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getDiskSpaceLimit(),
                 eventuallyEval(is(5120L), Duration.ofSeconds(30)));
 
         // diskSpaceLimit=5 and diskSpaceLimitUnit=MB, so expected value is 5242880 bytes
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 SYSTEM_LOGS_CONFIG_TOPIC_NAME, DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getDiskSpaceLimit(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(SYSTEM_LOGS_COMPONENT_NAME).getDiskSpaceLimit(),
                 eventuallyEval(is(5242880L), Duration.ofSeconds(30)));
     }
 
     @Test
     void GIVEN_component_fileNameRegex_config_WHEN_value_is_reset_and_replaced_THEN_correct_values_are_used()
-            throws Exception{
+            throws Exception {
         setupKernel();
 
         String fileNameRegexDefault = "^\\QUserComponentA\\E\\w*.log";
         String fileNameRegexNew = "RandomLogFileName\\w*.log";
 
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
                 eventuallyEval(is("^integTestRandomLogFiles.log\\w*"), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_REGEX_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
                 eventuallyEval(is(fileNameRegexDefault), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_REGEX_CONFIG_TOPIC_NAME).withValue(fileNameRegexNew);
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getFileNameRegex().pattern(),
                 eventuallyEval(is(fileNameRegexNew), Duration.ofSeconds(30)));
     }
 
@@ -268,18 +269,18 @@ class LogManagerConfigTest extends BaseITCase {
         Path logFileDirectoryPathNew = tempRootDir.resolve("newLogDir");
         Files.createDirectory(logFileDirectoryPathNew);
 
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
                 eventuallyEval(is(tempDirectoryPath), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
                 eventuallyEval(is(logFileDirectoryPathDefault), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                         COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME)
                 .withValue(logFileDirectoryPathNew.toString());
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getDirectoryPath(),
                 eventuallyEval(is(logFileDirectoryPathNew), Duration.ofSeconds(30)));
     }
 
@@ -288,43 +289,43 @@ class LogManagerConfigTest extends BaseITCase {
             throws Exception {
         setupKernel();
 
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
                 eventuallyEval(is(Level.TRACE), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
                 eventuallyEval(is(minimumLogLevelDefault), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("WARN");
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getMinimumLogLevel(),
                 eventuallyEval(is(Level.WARN), Duration.ofSeconds(30)));
     }
 
     @Test
     void GIVEN_component_deleteLogFileAfterCloudUpload_config_WHEN_value_is_reset_and_replaced_THEN_correct_values_are_used()
-             throws Exception {
+            throws Exception {
         setupKernel();
 
         boolean deleteLogFileAfterCloudUploadDefault = false;
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(deleteLogFileAfterCloudUploadDefault), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue(true);
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).isDeleteLogFileAfterCloudUpload(),
                 eventuallyEval(is(true), Duration.ofSeconds(30)));
     }
 
     @Test
     void GIVEN_component_diskSpaceLimit_anddiskSpaceLimitUnit_config_WHEN_values_are_reset_and_replaced_THEN_correct_values_are_used()
-             throws Exception {
+            throws Exception {
         setupKernel();
 
         // diskSpaceLimit=10 diskSpaceLimitUnit=GB in config file, so expected value is 10737418240 bytes
@@ -347,13 +348,13 @@ class LogManagerConfigTest extends BaseITCase {
         // diskSpaceLimitUnit default is KB, so with diskSpaceLimit=5, expected value is 5120 bytes
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit(),
                 eventuallyEval(is(5120L), Duration.ofSeconds(30)));
 
         // diskSpaceLimit=5 and diskSpaceLimitUnit=MB, so expected value is 5242880 bytes
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("MB");
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getDiskSpaceLimit(),
                 eventuallyEval(is(5242880L), Duration.ofSeconds(30)));
     }
 
@@ -363,36 +364,37 @@ class LogManagerConfigTest extends BaseITCase {
         setupKernel();
         String multiLineStartPatternNew = "[0-9].*";
 
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMultiLineStartPattern().pattern(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getMultiLineStartPattern().pattern(),
                 eventuallyEval(is("^\\\\d.*$"), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().find(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, MULTILINE_PATTERN_CONFIG_TOPIC_NAME).remove();
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMultiLineStartPattern() == null,
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getMultiLineStartPattern() == null,
                 eventuallyEval(equalTo(true), Duration.ofSeconds(30)));
 
         logManagerService.getConfig().lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC,
                 COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME, componentName, MULTILINE_PATTERN_CONFIG_TOPIC_NAME).withValue(multiLineStartPatternNew);
-        assertThat(()-> logManagerService.getComponentLogConfigurations().get(componentName).getMultiLineStartPattern().pattern(),
+        assertThat(() -> logManagerService.getComponentLogConfigurations().get(componentName).getMultiLineStartPattern().pattern(),
                 eventuallyEval(is(multiLineStartPatternNew), Duration.ofSeconds(30)));
     }
 
     /**
-     * From version 2.3.1 the LM supports storing multiple currently processing active files on the runtime configuration
+     * From version 2.3.1 the LM supports storing multiple currently processing active files on the runtime
+     * configuration
      * as follows:
-     *
+     * <p>
      * currentComponentFileProcessingInformationV2:
-     *   [componentName]:
-     *      [fileOneHash]:
-     *        currentProcessingFileName: ...
-     *        currentProcessingFileHash: ...
-     *        currentProcessingFileStartPosition: ...
-     *        componentLastFileProcessedTimeStamp: ...
-     *      [fileTwoHash]:
-     *        currentProcessingFileName: ...
-     *        currentProcessingFileHash: ...
-     *        currentProcessingFileStartPosition: ...
-     *        componentLastFileProcessedTimeStamp: ...
+     * [componentName]:
+     * [fileOneHash]:
+     * currentProcessingFileName: ...
+     * currentProcessingFileHash: ...
+     * currentProcessingFileStartPosition: ...
+     * componentLastFileProcessedTimeStamp: ...
+     * [fileTwoHash]:
+     * currentProcessingFileName: ...
+     * currentProcessingFileHash: ...
+     * currentProcessingFileStartPosition: ...
+     * componentLastFileProcessedTimeStamp: ...
      */
     @Test
     void GIVEN_runtimeAConfiguration_withMultipleCurrentProcessingFiles_WHEN_onStartUp_THEN_loadsConfiguration()
@@ -408,11 +410,11 @@ class LogManagerConfigTest extends BaseITCase {
         ProcessingFiles processingFiles = new ProcessingFiles(2);
         LogManagerService.CurrentProcessingFileInformation infoOne =
                 LogManagerService.CurrentProcessingFileInformation.builder()
-                .fileName("test.log")
-                .fileHash(UUID.randomUUID().toString())
-                .startPosition(1000)
-                .lastModifiedTime(Instant.now().toEpochMilli())
-                .build();
+                        .fileName("test.log")
+                        .fileHash(UUID.randomUUID().toString())
+                        .startPosition(1000)
+                        .lastModifiedTime(Instant.now().toEpochMilli())
+                        .build();
         processingFiles.put(infoOne);
         LogManagerService.CurrentProcessingFileInformation infoTwo =
                 LogManagerService.CurrentProcessingFileInformation.builder()
@@ -429,10 +431,9 @@ class LogManagerConfigTest extends BaseITCase {
         // When
         setupKernel();
 
-
         // Then - Assert configuration loaded
         processingFiles = logManagerService.processingFilesInformation.get(componentName);
-        Map<String, Object> expected = new HashMap<String, Object>(){{
+        Map<String, Object> expected = new HashMap<String, Object>() {{
             put(infoOne.getFileHash(), infoOne.convertToMapOfObjects());
             put(infoTwo.getFileHash(), infoTwo.convertToMapOfObjects());
         }};
@@ -442,13 +443,13 @@ class LogManagerConfigTest extends BaseITCase {
     /**
      * On version 2.3.0 and lower each component configuration only supported tracking a single currently processing
      * file. It was stored on the runtime config as follows:
-     *
+     * <p>
      * currentComponentFileProcessingInformation:
-     *   [componentName]:
-     *      currentProcessingFileName: ...
-     *      currentProcessingFileHash: ...
-     *      currentProcessingFileStartPosition: ...
-     *      componentLastFileProcessedTimeStamp: ...
+     * [componentName]:
+     * currentProcessingFileName: ...
+     * currentProcessingFileHash: ...
+     * currentProcessingFileStartPosition: ...
+     * componentLastFileProcessedTimeStamp: ...
      *
      * @throws Exception
      */
@@ -463,12 +464,15 @@ class LogManagerConfigTest extends BaseITCase {
                 PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION,
                 componentName);
 
+        long now = Instant.now().toEpochMilli();
+
         LogManagerService.CurrentProcessingFileInformation infoOne =
                 LogManagerService.CurrentProcessingFileInformation.builder()
                         .fileName("test.log")
                         .fileHash(UUID.randomUUID().toString())
                         .startPosition(1000)
-                        .lastModifiedTime(Instant.now().toEpochMilli())
+                        .lastAccessedTime(now)
+                        .lastModifiedTime(now)
                         .build();
 
         componentTopics.updateFromMap(infoOne.convertToMapOfObjects(),
@@ -480,7 +484,7 @@ class LogManagerConfigTest extends BaseITCase {
 
         // Then - Assert configuration loaded
         ProcessingFiles processingFiles = logManagerService.processingFilesInformation.get(componentName);
-        Map<String, Object> expected = new HashMap<String, Object>(){{
+        Map<String, Object> expected = new HashMap<String, Object>() {{
             put(infoOne.getFileHash(), infoOne.convertToMapOfObjects());
         }};
         assertEquals(expected, processingFiles.toMap());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
@@ -180,6 +180,9 @@ class SpaceManagementTest extends BaseITCase {
             throws Exception {
         // Given
 
+        lenient().when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
+                .thenReturn(PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
+
         tempDirectoryPath = Files.createDirectory(tempRootDir.resolve("IntegrationTestsTemporaryLogFiles"));
         // This method configures the LogManager to get logs with the pattern ^integTestRandomLogFiles.log\w* inside
         // then tempDirectoryPath with a diskSpaceLimit of 105kb

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/doNotDeleteFilesAfterUpload.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/doNotDeleteFilesAfterUpload.yaml
@@ -1,0 +1,17 @@
+---
+services:
+  aws.greengrass.LogManager:
+    configuration:
+      periodicUploadIntervalSec: 10
+      logsUploaderConfiguration:
+        componentLogsConfiguration:
+          - componentName: 'UserComponentA'
+            logFileRegex: '^integTestRandomLogFiles.log\w*'
+            logFileDirectoryPath: '{{logFileDirectoryPath}}'
+            deleteLogFileAfterCloudUpload: 'false'
+  main:
+    lifecycle:
+      install:
+        all: echo All installed
+    dependencies:
+      - aws.greengrass.LogManager

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/doNotDeleteFilesAfterUpload.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/doNotDeleteFilesAfterUpload.yaml
@@ -4,11 +4,12 @@ services:
     configuration:
       periodicUploadIntervalSec: 10
       logsUploaderConfiguration:
-        componentLogsConfiguration:
-          - componentName: 'UserComponentA'
+        componentLogsConfigurationMap:
+          UserComponentA:
             logFileRegex: '^integTestRandomLogFiles.log\w*'
             logFileDirectoryPath: '{{logFileDirectoryPath}}'
             deleteLogFileAfterCloudUpload: 'false'
+
   main:
     lifecycle:
       install:

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -89,7 +89,7 @@ public class LogManagerService extends PluginService {
     public static final String PERSISTED_CURRENT_PROCESSING_FILE_LAST_MODIFIED_TIME =
             "currentProcessingFileLastModified";
     public static final String PERSISTED_CURRENT_PROCESSING_FILE_LAST_ACCESSED_TIME =
-            "currentProcessingFileLastAccessed";
+            "lastAccessed";
     public static final String DEFAULT_FILE_REGEX = "^%s\\w*.log";
     public static final String COMPONENT_LOGS_CONFIG_TOPIC_NAME = "componentLogsConfiguration";
     public static final String COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME = "componentLogsConfigurationMap";

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -31,7 +31,6 @@ import com.aws.greengrass.logmanager.services.DiskSpaceManagementService;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.Utils;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
@@ -794,15 +793,11 @@ public class LogManagerService extends PluginService {
     public static class CurrentProcessingFileInformation {
         //This is deprecated value in versions greater than 2.2, but keep it here to avoid
         // upgrade-downgrade issues.
-        @JsonProperty(PERSISTED_CURRENT_PROCESSING_FILE_NAME)
         private String fileName;
-        @JsonProperty(PERSISTED_CURRENT_PROCESSING_FILE_START_POSITION)
         private long startPosition;
-        @JsonProperty(PERSISTED_CURRENT_PROCESSING_FILE_LAST_MODIFIED_TIME)
         private long lastModifiedTime;
-        @JsonProperty(PERSISTED_CURRENT_PROCESSING_FILE_LAST_ACCESSED_TIME)
-        private long lastAccessedTime = Instant.EPOCH.toEpochMilli();
-        @JsonProperty(PERSISTED_CURRENT_PROCESSING_FILE_HASH)
+        @Builder.Default
+        private long lastAccessedTime = Instant.now().toEpochMilli();
         private String fileHash;
         private static final Logger logger = LogManager.getLogger(CurrentProcessingFileInformation.class);
 

--- a/src/main/java/com/aws/greengrass/logmanager/model/ProcessingFiles.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/ProcessingFiles.java
@@ -53,6 +53,10 @@ public class ProcessingFiles  {
      * @param fileHash - A file hash.
      */
     public void remove(String fileHash) {
+        if (fileHash == null) {
+            return;
+        }
+
         Node node = cache.remove(fileHash);
 
         if (node != null) {

--- a/src/main/java/com/aws/greengrass/logmanager/model/ProcessingFiles.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/ProcessingFiles.java
@@ -56,15 +56,8 @@ public class ProcessingFiles {
      * @param value - currently processing file information
      */
     public void put(LogManagerService.CurrentProcessingFileInformation value) {
-        long lastAccessed = value.getLastAccessedTime();
-
-        if (lastAccessed == Instant.EPOCH.toEpochMilli()) {
-            lastAccessed = Instant.now().toEpochMilli();
-            value.setLastAccessedTime(lastAccessed);
-        }
-
-        mostRecentlyUsed = Node.builder().lastAccessed(lastAccessed).info(value).build();
-        cache.put(value.getFileHash(), mostRecentlyUsed);
+        this.mostRecentlyUsed = Node.builder().lastAccessed(value.getLastAccessedTime()).info(value).build();
+        cache.put(value.getFileHash(), this.mostRecentlyUsed);
         evictStaleEntries();
     }
 

--- a/src/main/java/com/aws/greengrass/logmanager/services/DiskSpaceManagementService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/services/DiskSpaceManagementService.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.logmanager.services;
 import com.aws.greengrass.logmanager.model.LogFile;
 import com.aws.greengrass.logmanager.model.LogFileGroup;
 
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -19,18 +20,19 @@ public class DiskSpaceManagementService {
      *
      * @param group - a Log File group
      */
-    public void freeDiskSpace(LogFileGroup group) {
+    public List<String> freeDiskSpace(LogFileGroup group) {
         if (!group.hasExceededDiskUsage()) {
-            return;
+            return null;
         }
 
         if (!group.getMaxBytes().isPresent()) {
-            return;
+            return null;
         }
 
         long bytesDeleted = 0;
         long minimumBytesToBeDeleted = Math.max(group.totalSizeInBytes() - group.getMaxBytes().get(), 0);
         List<LogFile> deletableFiles = group.getProcessedLogFiles();
+        List<String> deletedHashes = new ArrayList<>();
 
         for (LogFile logFile: deletableFiles) {
             if (bytesDeleted >= minimumBytesToBeDeleted) {
@@ -39,8 +41,11 @@ public class DiskSpaceManagementService {
             long filesSize = logFile.length();
 
             if (group.remove(logFile)) {
+                deletedHashes.add(logFile.hashString());
                 bytesDeleted += filesSize;
             }
         }
+
+        return deletedHashes;
     }
 }

--- a/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/LogManagerServiceTest.java
@@ -22,7 +22,6 @@ import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.NucleusPaths;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.IsNot;
 import org.junit.jupiter.api.AfterAll;
@@ -44,18 +43,14 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -226,15 +221,17 @@ class LogManagerServiceTest extends GGServiceTestUtil {
 
         // 2.3.0 and prior
         lenient().when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
-                .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION, SYSTEM_LOGS_COMPONENT_NAME))
+                        .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION,
+                                SYSTEM_LOGS_COMPONENT_NAME))
                 .thenReturn(currentProcessingComponentTopics1);
         // 2.3.1 and after
         lenient().when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
-                        .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION_V2, SYSTEM_LOGS_COMPONENT_NAME))
+                        .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION_V2,
+                                SYSTEM_LOGS_COMPONENT_NAME))
                 .thenReturn(currentProcessingComponentTopics1);
         // 2.3.0 and prior
         lenient().when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
-                .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION, "UserComponentA"))
+                        .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION, "UserComponentA"))
                 .thenReturn(currentProcessingComponentTopics2);
         // 2.3.1 and after
         lenient().when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
@@ -242,10 +239,10 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .thenReturn(currentProcessingComponentTopics2);
         // 2.3.0 and prior
         lenient().when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
-                .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION, "UserComponentB"))
+                        .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION, "UserComponentB"))
                 .thenReturn(currentProcessingComponentTopics3);
         lenient().when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
-                .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION_V2, "UserComponentB"))
+                        .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION_V2, "UserComponentB"))
                 .thenReturn(currentProcessingComponentTopics3);
 
         Topics allLastFileProcessedComponentTopics =
@@ -258,13 +255,13 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 Topics.of(context, "UserComponentB", allLastFileProcessedComponentTopics);
 
         lenient().when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
-                .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, SYSTEM_LOGS_COMPONENT_NAME))
+                        .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, SYSTEM_LOGS_COMPONENT_NAME))
                 .thenReturn(lastFileProcessedComponentTopics1);
         lenient().when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
-                .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, "UserComponentA"))
+                        .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, "UserComponentA"))
                 .thenReturn(lastFileProcessedComponentTopics2);
         lenient().when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
-                .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, "UserComponentB"))
+                        .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, "UserComponentB"))
                 .thenReturn(lastFileProcessedComponentTopics3);
     }
 
@@ -292,7 +289,8 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
         Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
-        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics componentConfigTopics =
+                logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^log.txt\\\\w*");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
@@ -398,7 +396,8 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
         Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
-        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics componentConfigTopics =
+                logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
         componentATopic.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("DEBUG");
@@ -449,7 +448,8 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
         Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
-        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics componentConfigTopics =
+                logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^UserComponentA\\w*\\.log");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
@@ -501,7 +501,8 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
         Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
-        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics componentConfigTopics =
+                logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^log.txt\\\\w*");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
@@ -676,7 +677,8 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                         .build());
 
         Map<String, CloudWatchAttemptLogFileInformation> processingAttemptLogFileInformationMap2 = new HashMap<>();
-        processingAttemptLogFileInformationMap2.put(processingFile.hashString(), CloudWatchAttemptLogFileInformation.builder()
+        processingAttemptLogFileInformationMap2.put(processingFile.hashString(),
+                CloudWatchAttemptLogFileInformation.builder()
                 .startPosition(0)
                 .bytesRead(1061)
                 .lastModifiedTime(processingFile.lastModified())
@@ -712,7 +714,8 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         List<Map<String, Object>> partiallyReadComponentLogFileInformation = updateFromMapCaptor.getAllValues();
         assertEquals(1, completedComponentLastProcessedFileInformation.size());
         assertEquals(2, partiallyReadComponentLogFileInformation.size());
-        assertEquals(lastProcessedFile.lastModified(), Coerce.toLong(completedComponentLastProcessedFileInformation.get(0)));
+        assertEquals(lastProcessedFile.lastModified(),
+                Coerce.toLong(completedComponentLastProcessedFileInformation.get(0)));
 
         LogManagerService.CurrentProcessingFileInformation currentProcessingFileInformation =
                 LogManagerService.CurrentProcessingFileInformation.convertFromMapOfObjects(
@@ -722,9 +725,11 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         assertEquals(processingFile.lastModified(), currentProcessingFileInformation.getLastModifiedTime());
 
         assertNotNull(logsUploaderService.lastComponentUploadedLogFileInstantMap);
-        assertThat(logsUploaderService.lastComponentUploadedLogFileInstantMap.entrySet(), IsNot.not(IsEmptyCollection.empty()));
+        assertThat(logsUploaderService.lastComponentUploadedLogFileInstantMap.entrySet(),
+                IsNot.not(IsEmptyCollection.empty()));
         assertTrue(logsUploaderService.lastComponentUploadedLogFileInstantMap.containsKey("TestComponent"));
-        assertEquals(Instant.ofEpochMilli(lastProcessedFile.lastModified()), logsUploaderService.lastComponentUploadedLogFileInstantMap.get("TestComponent"));
+        assertEquals(Instant.ofEpochMilli(lastProcessedFile.lastModified()),
+                logsUploaderService.lastComponentUploadedLogFileInstantMap.get("TestComponent"));
         assertNotNull(logsUploaderService.processingFilesInformation);
         assertThat(logsUploaderService.processingFilesInformation.entrySet(), IsNot.not(IsEmptyCollection.empty()));
         assertTrue(logsUploaderService.processingFilesInformation.containsKey("TestComponent2"));
@@ -792,114 +797,6 @@ class LogManagerServiceTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_user_component_logs_delete_file_after_upload_set_WHEN_upload_logs_THEN_deletes_uploaded_log_files(
-            ExtensionContext ec)
-            throws InterruptedException, IOException, InvalidLogGroupException {
-        ignoreExceptionOfType(ec, NoSuchFileException.class);
-        mockDefaultPersistedState();
-        Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
-                .thenReturn(periodicUpdateIntervalMsTopic);
-
-        Topics configTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
-        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
-        Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
-
-        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
-        Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
-        componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^log2.txt\\w*");
-        componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());
-        componentATopic.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("DEBUG");
-        componentATopic.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
-        componentATopic.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("KB");
-        componentATopic.createLeafChild(DELETE_LOG_FILES_AFTER_UPLOAD_CONFIG_TOPIC_NAME).withValue("true");
-
-        Topics systemConfigTopics = logsUploaderConfigTopics.createInteriorChild(SYSTEM_LOGS_CONFIG_TOPIC_NAME);
-        systemConfigTopics.createLeafChild(UPLOAD_TO_CW_CONFIG_TOPIC_NAME).withValue("true");
-        systemConfigTopics.createLeafChild(MIN_LOG_LEVEL_CONFIG_TOPIC_NAME).withValue("INFO");
-        systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_CONFIG_TOPIC_NAME).withValue("25");
-        systemConfigTopics.createLeafChild(DISK_SPACE_LIMIT_UNIT_CONFIG_TOPIC_NAME).withValue("KB");
-        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_CONFIGURATION_TOPIC))
-                .thenReturn(logsUploaderConfigTopics);
-
-        List<String> fileNames = new ArrayList<>();
-        Instant instant = Instant.EPOCH;
-        for (int i = 0; i < 5; i++) {
-            Path fileNamePath = directoryPath.resolve("log2.txt_" + UUID.randomUUID());
-            fileNames.add(fileNamePath.toAbsolutePath().toString());
-            File file1 = new File(fileNamePath.toUri());
-
-            if (Files.notExists(file1.toPath())) {
-                assertTrue(file1.createNewFile());
-            }
-            assertTrue(file1.setReadable(true));
-            assertTrue(file1.setWritable(true));
-
-            try (OutputStream fileOutputStream = Files.newOutputStream(file1.toPath())) {
-                String generatedString = RandomStringUtils.randomAlphabetic(1024);
-                fileOutputStream.write(generatedString.getBytes(StandardCharsets.UTF_8));
-            }
-            TimeUnit.SECONDS.sleep(1);
-        }
-
-        CloudWatchAttempt attempt = new CloudWatchAttempt();
-        Map<String, CloudWatchAttemptLogInformation> logStreamsToLogInformationMap = new HashMap<>();
-        LogFile file1 = new LogFile(directoryPath.resolve(fileNames.get(0)).toUri());
-        LogFile file2 = new LogFile(directoryPath.resolve(fileNames.get(1)).toUri());
-
-        Pattern pattern = Pattern.compile("^log2.txt\\w*");
-        ComponentLogConfiguration compLogInfo = ComponentLogConfiguration.builder()
-                .directoryPath(directoryPath)
-                .fileNameRegex(pattern).name("UserComponentA").build();
-        LogFileGroup logFileGroup = LogFileGroup.create( compLogInfo, instant, workdirectory);
-        Map<String, CloudWatchAttemptLogFileInformation> attemptLogFileInformationMap1 = new HashMap<>();
-        attemptLogFileInformationMap1.put(file1.hashString(), CloudWatchAttemptLogFileInformation.builder()
-                .startPosition(0)
-                .bytesRead(file1.length())
-                .lastModifiedTime(file1.lastModified())
-                .fileHash(file1.hashString())
-                .build());
-        attemptLogFileInformationMap1.put(file2.hashString(), CloudWatchAttemptLogFileInformation.builder()
-                .startPosition(0)
-                .bytesRead(file2.length())
-                .lastModifiedTime(file2.lastModified())
-                .fileHash(file2.hashString())
-                .build());
-
-        CloudWatchAttemptLogInformation attemptLogInformation1 = CloudWatchAttemptLogInformation.builder()
-                .componentName("UserComponentA")
-                .attemptLogFileInformationMap(attemptLogFileInformationMap1)
-                .logFileGroup(logFileGroup)
-                .build();
-        logStreamsToLogInformationMap.put("testStream", attemptLogInformation1);
-        attempt.setLogStreamsToLogEventsMap(logStreamsToLogInformationMap);
-        attempt.setLogStreamUploadedSet(new HashSet<>(Collections.singletonList("testStream")));
-        doNothing().when(mockUploader).registerAttemptStatus(anyString(), callbackCaptor.capture());
-        Topics componentTopics1 = mock(Topics.class);
-        Topic lastFileProcessedTimeStampTopics = mock(Topic.class);
-        when(componentTopics1.createLeafChild(any())).thenReturn(lastFileProcessedTimeStampTopics);
-        when(lastFileProcessedTimeStampTopics.withValue(any(Number.class)))
-                .thenReturn(lastFileProcessedTimeStampTopics);
-        when(config.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC)
-                .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, "UserComponentA"))
-                .thenReturn(componentTopics1);
-
-        logsUploaderService = new LogManagerService(config, mockUploader, mockMerger, nucleusPaths);
-        startServiceOnAnotherThread();
-
-        callbackCaptor.getValue().accept(attempt);
-
-        TimeUnit.SECONDS.sleep(5);
-
-        for (int i = 0; i < 2; i++) {
-            assertTrue(Files.notExists(Paths.get(fileNames.get(i))));
-        }
-        for (int i = 2; i < 5; i++) {
-            assertTrue(Files.exists(Paths.get(fileNames.get(i))));
-        }
-    }
-
-    @Test
     void GIVEN_a_partially_uploaded_file_but_rotated_WHEN_merger_merges_THEN_sets_the_start_position_correctly()
             throws InterruptedException, IOException {
         mockDefaultPersistedState();
@@ -933,7 +830,7 @@ class LogManagerServiceTest extends GGServiceTestUtil {
                 .lastModifiedTime(currentProcessingFile.lastModified() - 1000)
                 .startPosition(2)
                 .build());
-        logsUploaderService.processingFilesInformation .put(SYSTEM_LOGS_COMPONENT_NAME, processingFiles);
+        logsUploaderService.processingFilesInformation.put(SYSTEM_LOGS_COMPONENT_NAME, processingFiles);
 
         TimeUnit.SECONDS.sleep(5);
 
@@ -952,7 +849,8 @@ class LogManagerServiceTest extends GGServiceTestUtil {
     }
 
     @Test
-    void GIVEN_persisted_data_WHEN_log_uploader_initialises_THEN_correctly_sets_the_persisted_data() throws IOException {
+    void GIVEN_persisted_data_WHEN_log_uploader_initialises_THEN_correctly_sets_the_persisted_data() throws
+            IOException {
         Topic periodicUpdateIntervalMsTopic = Topic.of(context, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, "3");
         when(config.lookup(CONFIGURATION_CONFIG_KEY, LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC))
                 .thenReturn(periodicUpdateIntervalMsTopic);
@@ -960,7 +858,8 @@ class LogManagerServiceTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
         Topics logsUploaderConfigTopics = Topics.of(context, LOGS_UPLOADER_CONFIGURATION_TOPIC, null);
 
-        Topics componentConfigTopics = logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
+        Topics componentConfigTopics =
+                logsUploaderConfigTopics.createInteriorChild(COMPONENT_LOGS_CONFIG_MAP_TOPIC_NAME);
         Topics componentATopic = componentConfigTopics.createInteriorChild("UserComponentA");
         componentATopic.createLeafChild(FILE_REGEX_CONFIG_TOPIC_NAME).withValue("^log.txt\\w*");
         componentATopic.createLeafChild(FILE_DIRECTORY_PATH_CONFIG_TOPIC_NAME).withValue(directoryPath.toAbsolutePath().toString());


### PR DESCRIPTION
**Issue #, if available:**
To fix an issue where customer wrote to multiple active files within a same group we started tracking all the files on a cache that is written into disk. Items get evicted based on time, if the entry has not been modified in more that one day we evict it.

We are not removing entries from the cache once files get deleted though. This PR makes it so that entries for files that have been deleted get removed from the cache, resulting in less memory and disk space consumption.

**Why is this change necessary:**
Avoid memory consumption spikes and potential OOM errors for high write frequency use cases.

**How was this change tested:**
Integration tests. Will follow up with a UAT

