### PR TITLE
test: add a UAT to verify max log event limit

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -150,6 +150,7 @@ class LogManagerTest extends BaseITCase {
                     && newState.equals(State.RUNNING)) {
                 logManagerRunning.countDown();
                 logManagerService = (LogManagerService) service;
+                logManagerService.getUploader().setCloudWatchLogsClient(cloudWatchLogsClient);
             }
         });
         deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
@@ -159,9 +160,8 @@ class LogManagerTest extends BaseITCase {
         kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
         // set required instances from context
         kernel.launch();
-        assertTrue(logManagerRunning.await(10, TimeUnit.SECONDS));
+        assertTrue(logManagerRunning.await(30, TimeUnit.SECONDS));
 
-        logManagerService.getUploader().setCloudWatchLogsClient(cloudWatchLogsClient);
     }
 
     @BeforeEach
@@ -302,25 +302,20 @@ class LogManagerTest extends BaseITCase {
     void GIVEN_log_manager_in_errored_state_WHEN_restarted_THEN_logs_upload_is_reattempted(ExtensionContext context)
             throws Exception {
         ignoreExceptionWithMessage(context, "Forcing error to trigger restart");
-
+        CountDownLatch logManagerErrored = new CountDownLatch(1);
+        CountDownLatch logManagerRunning = new CountDownLatch(1);
         when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class)))
-                .thenThrow(new RuntimeException("Forcing error to trigger restart"))
-                .thenReturn(PutLogEventsResponse.builder().nextSequenceToken("nextToken").build());
+                .thenAnswer((x)->{
+                    logManagerErrored.countDown();
+                    throw new RuntimeException("Forcing error to trigger restart");
+                })
+                .thenAnswer((x)->{
+                    logManagerRunning.countDown();
+                    return PutLogEventsResponse.builder().nextSequenceToken("nextToken").build();
+                });
 
         tempDirectoryPath = Files.createTempDirectory(tempRootDir, "IntegrationTestsTemporaryLogFiles");
 
-        CountDownLatch logManagerErrored = new CountDownLatch(1);
-        CountDownLatch logManagerRunning = new CountDownLatch(2);
-        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
-            if (service.getName().equals(LogManagerService.LOGS_UPLOADER_SERVICE_TOPICS)) {
-                if (newState.equals(State.ERRORED)) {
-                    logManagerErrored.countDown();
-                }
-                if (newState.equals(State.RUNNING)) {
-                    logManagerRunning.countDown();
-                }
-            }
-        });
 
         for (int i = 0; i < testFileNumber - 1; i++) {
             createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log_", "");
@@ -329,8 +324,8 @@ class LogManagerTest extends BaseITCase {
 
         setupKernel(tempDirectoryPath, "smallPeriodicIntervalUserComponentConfig.yaml");
         TimeUnit.SECONDS.sleep(30);
-        assertTrue(logManagerErrored.await(15, TimeUnit.SECONDS));
-        assertTrue(logManagerRunning.await(15, TimeUnit.SECONDS));
+        assertTrue(logManagerErrored.await(60, TimeUnit.SECONDS));
+        assertTrue(logManagerRunning.await(60, TimeUnit.SECONDS));
         verify(cloudWatchLogsClient, times(2)).putLogEvents(captor.capture());
 
         List<PutLogEventsRequest> putLogEventsRequests = captor.getAllValues();

--- a/uat/custom-components/src/main/java/com/aws/greengrass/artifacts/LogGenerator.java
+++ b/uat/custom-components/src/main/java/com/aws/greengrass/artifacts/LogGenerator.java
@@ -59,8 +59,8 @@ public class LogGenerator implements Consumer<String[]> {
         Logger logger = configureLogger();
 
         for (int i = 1; i <= numberOfLogs; i++) {
-            String logLine = String.format("(seq: %d, name: %s)", i, logFileName);
-            logger.info(logLine);
+            String logLine = String.format("(seq: %d)", i);
+            logger.info(logLine); // INFO LogGenerator (seq: 1)
             TimeUnit.MILLISECONDS.sleep(writeFreqMs);
         }
     }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/CloudWatchSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/CloudWatchSteps.java
@@ -173,7 +173,7 @@ public class CloudWatchSteps {
 
         // Logs written by the log generator append a sequence number per log line along with the component name
         for (int i = 1; i <= expectedLogLines; i++) {
-            String expected = String.format("(seq: %d, name: %s)", i, componentName);
+            String expected = String.format("(seq: %d)", i, componentName);
             OutputLogEvent event = events.get(i - 1);
 
             if (!event.message().contains(expected)) {

--- a/uat/testing-features/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/log-manager-1.feature
@@ -38,7 +38,7 @@ Feature: Greengrass V2 LogManager
         }
         """
         And I deploy the Greengrass deployment configuration
-        And the Greengrass deployment is COMPLETED on the device after 2 minutes
+        And the Greengrass deployment is COMPLETED on the device after 3 minutes
         Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         And I install the component LogGenerator from local store with configuration
         """
@@ -51,7 +51,7 @@ Feature: Greengrass V2 LogManager
            }
         }
         """
-        And the local Greengrass deployment is SUCCEEDED on the device after 60 seconds
+        And the local Greengrass deployment is SUCCEEDED on the device after 180 seconds
         Then I verify that it created a log group of type GreengrassSystemComponent for component System, with streams within 60 seconds in CloudWatch
         And I verify that it created a log group of type UserComponent for component UserComponentM, with streams within 60 seconds in CloudWatch
         And I verify 20 logs for UserComponentM of type UserComponent have been uploaded to Cloudwatch within 60 seconds
@@ -87,7 +87,7 @@ Feature: Greengrass V2 LogManager
         }
         """
         And I deploy the Greengrass deployment configuration
-        And the Greengrass deployment is COMPLETED on the device after 2 minutes
+        And the Greengrass deployment is COMPLETED on the device after 3 minutes
         Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         And I install the component LogGenerator from local store with configuration
         """
@@ -100,7 +100,7 @@ Feature: Greengrass V2 LogManager
            }
         }
         """
-        And the local Greengrass deployment is SUCCEEDED on the device after 60 seconds
+        And the local Greengrass deployment is SUCCEEDED on the device after 180 seconds
         Then I verify that it created a log group of type GreengrassSystemComponent for component System, with streams within 60 seconds in CloudWatch
         And I verify that it created a log group of type UserComponent for component UserComponentW, with streams within 60 seconds in CloudWatch
         And I verify 20 logs for UserComponentW of type UserComponent have been uploaded to Cloudwatch within 60 seconds
@@ -128,7 +128,7 @@ Feature: Greengrass V2 LogManager
         }
         """
         And I deploy the Greengrass deployment configuration
-        Then the Greengrass deployment is COMPLETED on the device after 2 minutes
+        Then the Greengrass deployment is COMPLETED on the device after 3 minutes
         Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         And I install the component LogGenerator from local store with configuration
         """
@@ -143,7 +143,7 @@ Feature: Greengrass V2 LogManager
            }
         }
         """
-        And the local Greengrass deployment is SUCCEEDED on the device after 60 seconds
+        And the local Greengrass deployment is SUCCEEDED on the device after 180 seconds
         Then I verify that it created a log group of type UserComponent for component UserComponentX, with streams within 60 seconds in CloudWatch
         And I verify 100 logs for UserComponentX of type UserComponent have been uploaded to Cloudwatch within 120 seconds
         And I verify the rotated files are deleted and that the active log file is present for component UserComponentX on directory UserComponentXLogDirectory
@@ -182,7 +182,7 @@ Feature: Greengrass V2 LogManager
         }
         """
         And I deploy the Greengrass deployment configuration
-        Then the Greengrass deployment is COMPLETED on the device after 2 minutes
+        Then the Greengrass deployment is COMPLETED on the device after 3 minutes
         Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         And I wait 5 seconds
         Then I verify that 10 log files for component UserComponentB are still available
@@ -214,7 +214,7 @@ Feature: Greengrass V2 LogManager
         }
         """
         And I deploy the Greengrass deployment configuration
-        Then the Greengrass deployment is COMPLETED on the device after 2 minutes
+        Then the Greengrass deployment is COMPLETED on the device after 3 minutes
         Then I verify the aws.greengrass.LogManager component is RUNNING using the greengrass-cli
         When device network connectivity is offline
         And I install the component LogGenerator from local store with configuration
@@ -228,7 +228,7 @@ Feature: Greengrass V2 LogManager
            }
         }
         """
-        And the local Greengrass deployment is SUCCEEDED on the device after 60 seconds
+        And the local Greengrass deployment is SUCCEEDED on the device after 180 seconds
         When device network connectivity is online
         Then I verify that it created a log group of type GreengrassSystemComponent for component System, with streams within 60 seconds in CloudWatch
         Then I verify that it created a log group of type UserComponent for component UserComponentY, with streams within 60 seconds in CloudWatch
@@ -266,7 +266,7 @@ Feature: Greengrass V2 LogManager
         }
         """
         And I deploy the Greengrass deployment configuration
-        And the Greengrass deployment is COMPLETED on the device after 2 minutes
+        And the Greengrass deployment is COMPLETED on the device after 3 minutes
         And I install the component LogGenerator from local store with configuration
         """
         {
@@ -278,7 +278,7 @@ Feature: Greengrass V2 LogManager
            }
         }
         """
-        And the local Greengrass deployment is SUCCEEDED on the device after 60 seconds
+        And the local Greengrass deployment is SUCCEEDED on the device after 180 seconds
         Then I verify that it created a log group of type GreengrassSystemComponent for component System, with streams within 300 seconds in CloudWatch
         And I verify that it created a log group of type UserComponent for component UserComponentW, with streams within 300 seconds in CloudWatch
         And I verify 5 logs for UserComponentW of type UserComponent have been uploaded to Cloudwatch within 80 seconds

--- a/uat/testing-features/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/log-manager-1.feature
@@ -234,3 +234,51 @@ Feature: Greengrass V2 LogManager
         Then I verify that it created a log group of type UserComponent for component UserComponentY, with streams within 60 seconds in CloudWatch
         And I verify 20 logs for UserComponentY of type UserComponent have been uploaded to Cloudwatch within 80 seconds
 
+    Scenario: LogManager-1-T5: When more than 10_000 component logs are to be uploaded, then log manager uploads all
+    the logs in multiple attempts where each attempt has a maximum of 10_000 log events.
+
+        Given I create a log directory for component called UserComponentWLogDirectory
+        And I create a Greengrass deployment with components
+            | aws.greengrass.Cli        | LATEST                                    |
+            | aws.greengrass.LogManager | classpath:/greengrass/recipes/recipe.yaml |
+        When I update my Greengrass deployment configuration, setting the component aws.greengrass.LogManager configuration to:
+        """
+        {
+            "MERGE": {
+                "logsUploaderConfiguration": {
+                    "componentLogsConfiguration": [
+                        {
+                            "logFileRegex": "UserComponentW(.*).log",
+                            "logFileDirectoryPath": "${UserComponentWLogDirectory}",
+                            "componentName": "UserComponentW"
+                        }
+                    ],
+                    "systemLogsConfiguration": {
+                        "uploadToCloudWatch": "true",
+                        "minimumLogLevel": "INFO",
+                        "diskSpaceLimit": "25",
+                        "diskSpaceLimitUnit": "MB",
+                        "deleteLogFileAfterCloudUpload": "true"
+                    }
+                },
+                "periodicUploadIntervalSec": "300"
+            }
+        }
+        """
+        And I deploy the Greengrass deployment configuration
+        And the Greengrass deployment is COMPLETED on the device after 2 minutes
+        And I install the component LogGenerator from local store with configuration
+        """
+        {
+           "MERGE":{
+                "LogFileName": "UserComponentW",
+                "WriteFrequencyMs": "0",
+                "LogsDirectory": "${UserComponentWLogDirectory}",
+                "NumberOfLogLines": "10005"
+           }
+        }
+        """
+        And the local Greengrass deployment is SUCCEEDED on the device after 60 seconds
+        Then I verify that it created a log group of type GreengrassSystemComponent for component System, with streams within 300 seconds in CloudWatch
+        And I verify that it created a log group of type UserComponent for component UserComponentW, with streams within 300 seconds in CloudWatch
+        And I verify 5 logs for UserComponentW of type UserComponent have been uploaded to Cloudwatch within 80 seconds


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When there are more than 10000 logs to upload, then log manager uploads those logs in multiple attempts where each attempt uploads a maximum of 10000 logs. (CW limit for max log events per API is 10000)

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
