### PR TITLE
fix: validate cw log events size  before uploading

### DIFF
--- a/uat/testing-features/pom.xml
+++ b/uat/testing-features/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>aws-greengrass-testing-standalone</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/uat/testing-features/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/log-manager-1.feature
@@ -233,7 +233,7 @@ Feature: Greengrass V2 LogManager
         Then I verify that it created a log group of type GreengrassSystemComponent for component System, with streams within 60 seconds in CloudWatch
         Then I verify that it created a log group of type UserComponent for component UserComponentY, with streams within 60 seconds in CloudWatch
         And I verify 20 logs for UserComponentY of type UserComponent have been uploaded to Cloudwatch within 80 seconds
-
+    @saranya
     Scenario: LogManager-1-T5: When more than 10_000 component logs are to be uploaded, then log manager uploads all
     the logs in multiple attempts where each attempt has a maximum of 10_000 log events.
 
@@ -281,4 +281,4 @@ Feature: Greengrass V2 LogManager
         And the local Greengrass deployment is SUCCEEDED on the device after 180 seconds
         Then I verify that it created a log group of type GreengrassSystemComponent for component System, with streams within 300 seconds in CloudWatch
         And I verify that it created a log group of type UserComponent for component UserComponentW, with streams within 300 seconds in CloudWatch
-        And I verify 5 logs for UserComponentW of type UserComponent have been uploaded to Cloudwatch within 80 seconds
+        And I verify 10000 logs for UserComponentW of type UserComponent have been uploaded to Cloudwatch within 120 seconds

--- a/uat/testing-features/src/main/resources/greengrass/features/log-manager-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/log-manager-1.feature
@@ -233,7 +233,7 @@ Feature: Greengrass V2 LogManager
         Then I verify that it created a log group of type GreengrassSystemComponent for component System, with streams within 60 seconds in CloudWatch
         Then I verify that it created a log group of type UserComponent for component UserComponentY, with streams within 60 seconds in CloudWatch
         And I verify 20 logs for UserComponentY of type UserComponent have been uploaded to Cloudwatch within 80 seconds
-    @saranya
+
     Scenario: LogManager-1-T5: When more than 10_000 component logs are to be uploaded, then log manager uploads all
     the logs in multiple attempts where each attempt has a maximum of 10_000 log events.
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
AWS CloudWatch PutLogEvents API has a limit of 10,000 log events per request.
Documentation link: [Array Members: Minimum number of 1 item. Maximum number of 10000 items](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html#:~:text=array%20members%3A%20minimum%20number%20of%201%20item.%20maximum%20number%20of%2010000%20items.).

Currently, log manager component tries to upload all the log events without validating their size. Adding an extra check to validate the log events size before adding a new log event. 

This is an edge case where there are more than 10,000 logs to upload, with each log event size less than the 1024*256 - 8-26 bytes limit and the total batch size less than 1024*1024 bytes. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
