### PR TITLE
fix: update default multiline pattern to properly collect stacktraces

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/util/LogFileHelper.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/util/LogFileHelper.java
@@ -5,6 +5,11 @@
 
 package com.aws.greengrass.integrationtests.logmanager.util;
 
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.logging.impl.config.LogStore;
+import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -54,8 +59,20 @@ public final class LogFileHelper {
         for (String messageBytes : randomMessages) {
             addDataToFile(messageBytes, file.toPath());
         }
-
         return file;
+    }
+
+    public static void writeExampleLogs(Path tempDirectoryPath, String fileNamePrefix)
+            throws IOException {
+        Logger l = LogManager.getLogger(fileNamePrefix,
+                LogConfigUpdate.builder().fileName(fileNamePrefix)
+                        .outputDirectory(tempDirectoryPath.toString()).outputType(LogStore.FILE).build());
+        List<String> randomMessages = generateRandomMessages();
+        for (String messageBytes : randomMessages) {
+            l.info(messageBytes);
+        }
+        l.error("this is an error", new RuntimeException("known"));
+        l.info("after error");
     }
 
     public static void createFileAndWriteData(Path tempDirectoryPath, String fileName)

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallPeriodicIntervalOnlyReqUserComponentConfig.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallPeriodicIntervalOnlyReqUserComponentConfig.yaml
@@ -10,6 +10,7 @@ services:
             diskSpaceLimit: '25'
             diskSpaceLimitUnit: 'MB'
             deleteLogFileAfterCloudUpload: 'true'
+            multiLineStartPattern: "[^\\s]"
   main:
     lifecycle:
       install:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallPeriodicIntervalSystemComponentConfig.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallPeriodicIntervalSystemComponentConfig.yaml
@@ -10,6 +10,7 @@ services:
           diskSpaceLimit: '25'
           diskSpaceLimitUnit: 'MB'
           deleteLogFileAfterCloudUpload: 'true'
+          multiLineStartPattern: "[^\\s]"
   main:
     lifecycle:
       install:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallPeriodicIntervalUserComponentConfigNoMultiline.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallPeriodicIntervalUserComponentConfigNoMultiline.yaml
@@ -12,7 +12,6 @@ services:
             diskSpaceLimit: '25'
             diskSpaceLimitUnit: 'MB'
             deleteLogFileAfterCloudUpload: 'true'
-            multiLineStartPattern: "[^\\s]"
   main:
     lifecycle:
       install:

--- a/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
+++ b/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
@@ -312,6 +312,10 @@ public class CloudWatchAttemptLogsProcessor {
      * @return a structuredLogMessage if the deserialization is successful, else an empty optional object.
      */
     private Optional<GreengrassLogMessage> tryGetStructuredLogMessage(String data) {
+        // Fail fast as Jackson will take longer to fail. This is roughly 1000x times faster.
+        if (data == null || !data.startsWith("{")) {
+            return Optional.empty();
+        }
         try {
             return Optional.ofNullable(DESERIALIZER.readValue(data, GreengrassLogMessage.class));
         } catch (JsonProcessingException ignored) {

--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -228,8 +228,13 @@ public class LogManagerService extends PluginService {
                             Pattern.quote(LogManager.getRootLogConfiguration().getFileName()))))
                     .directoryPath(logsDirectoryPath)
                     .name(SYSTEM_LOGS_COMPONENT_NAME)
-                    .componentType(ComponentType.GreengrassSystemComponent)
-                    .build();
+                    .componentType(ComponentType.GreengrassSystemComponent).build();
+
+            String multiLineStartPatternString =
+                    Coerce.toString(systemConfigMap.get(MULTILINE_PATTERN_CONFIG_TOPIC_NAME));
+            if (Utils.isNotEmpty(multiLineStartPatternString)) {
+                systemConfiguration.setMultiLineStartPattern(Pattern.compile(multiLineStartPatternString));
+            }
 
             setCommonComponentConfiguration(systemConfigMap, systemConfiguration);
             newComponentLogConfigurations.put(systemConfiguration.getName(), systemConfiguration);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Performance: skip json parsing if the log line doesn't start with `{`
- Update the multiline pattern to split by date stamp so that stacktraces will be correctly associated with the log that emitted them.

**Why is this change necessary:**

**How was this change tested:**
Adds proper testing for stacktrace collection which didn't exist before.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
