### PR TITLE
perf: store log events sorted in a queue

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerConfigTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerConfigTest.java
@@ -111,6 +111,7 @@ class LogManagerConfigTest extends BaseITCase {
         kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
         kernel.launch();
         assertTrue(logManagerRunning.await(10, TimeUnit.SECONDS));
+        kernel.getContext().waitForPublishQueueToClear();
     }
 
     @BeforeEach

--- a/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
+++ b/src/main/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessor.java
@@ -40,7 +40,6 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
@@ -373,9 +372,8 @@ public class CloudWatchAttemptLogsProcessor {
         // If the earliest time + 24 hours is before the new time then we cannot insert it because the gap
         // from earliest to latest is greater than 24 hours. Otherwise we can add it.
         // Using 23 instead of 24 hours to have a bit of leeway.
-        Optional<InputLogEvent> earliestTime =
-                attemptLogInformation.getLogEvents().stream().min(Comparator.comparingLong(InputLogEvent::timestamp));
-        if (earliestTime.isPresent() && Instant.ofEpochMilli(earliestTime.get().timestamp()).plus(23, ChronoUnit.HOURS)
+        InputLogEvent earliestTime = attemptLogInformation.getLogEvents().peek();
+        if (earliestTime != null && Instant.ofEpochMilli(earliestTime.timestamp()).plus(23, ChronoUnit.HOURS)
                 .isBefore(timestamp)) {
             return new Pair<>(true, new AtomicInteger());
         }

--- a/src/main/java/com/aws/greengrass/logmanager/model/CloudWatchAttemptLogInformation.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/CloudWatchAttemptLogInformation.java
@@ -38,7 +38,10 @@ public class CloudWatchAttemptLogInformation {
      * @return sorted events
      */
     public List<InputLogEvent> getSortedLogEvents() {
-        // Sort by timestamp because CloudWatch requires that the logs are in chronological order
-        return new ArrayList<>(logEvents);
+        // Sort by timestamp because CloudWatch requires that the logs are in chronological order.
+        // Priority queue conversion to a list does NOT maintain proper ordering, so we must sort ourselves.
+        ArrayList<InputLogEvent> l = new ArrayList<>(logEvents);
+        l.sort(EVENT_COMPARATOR);
+        return l;
     }
 }

--- a/src/main/java/com/aws/greengrass/logmanager/model/CloudWatchAttemptLogInformation.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/CloudWatchAttemptLogInformation.java
@@ -16,15 +16,17 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
 
 @Builder
 @Data
 @Getter
 @Setter
 public class CloudWatchAttemptLogInformation {
-    protected static final Comparator<InputLogEvent> EVENT_COMPARATOR = Comparator.comparing(InputLogEvent::timestamp);
+    public static final Comparator<InputLogEvent> EVENT_COMPARATOR = Comparator.comparing(InputLogEvent::timestamp);
     @Builder.Default
-    private List<InputLogEvent> logEvents = new ArrayList<>();
+    private Queue<InputLogEvent> logEvents = new PriorityQueue<>(EVENT_COMPARATOR);
     @Builder.Default
     private Map<String, CloudWatchAttemptLogFileInformation> attemptLogFileInformationMap = new HashMap<>();
     private String componentName;
@@ -37,7 +39,6 @@ public class CloudWatchAttemptLogInformation {
      */
     public List<InputLogEvent> getSortedLogEvents() {
         // Sort by timestamp because CloudWatch requires that the logs are in chronological order
-        logEvents.sort(EVENT_COMPARATOR);
-        return logEvents;
+        return new ArrayList<>(logEvents);
     }
 }

--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
@@ -544,7 +544,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             CloudWatchAttemptLogInformation logEventsForStream1 = attempt.getLogStreamsToLogEventsMap().get(logStream);
             assertNotNull(logEventsForStream1.getLogEvents());
 
-            List<InputLogEvent> logEvents = logEventsForStream1.getLogEvents();
+            List<InputLogEvent> logEvents = logEventsForStream1.getSortedLogEvents();
             assertEquals(4, logEvents.size());
             // Over size log line got divided and successfully added as log events
             assertEquals(overSizeLogLine.substring(0, MAX_EVENT_LENGTH), logEvents.get(1).message());

--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchLogsUploaderTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchLogsUploaderTest.java
@@ -35,17 +35,19 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceAlreadyExist
 import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static com.aws.greengrass.logmanager.model.CloudWatchAttemptLogInformation.EVENT_COMPARATOR;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
@@ -85,7 +87,7 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
         String mockNextSequenceToken = UUID.randomUUID().toString();
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logSteamForGroup1Map = new ConcurrentHashMap<>();
-        List<InputLogEvent> inputLogEventsForStream1OfGroup1 = new ArrayList<>();
+        Queue<InputLogEvent> inputLogEventsForStream1OfGroup1 = new PriorityQueue<>(EVENT_COMPARATOR);
         inputLogEventsForStream1OfGroup1.add(InputLogEvent.builder()
                 .timestamp(Instant.now().toEpochMilli() + 5_000) // Put this in the future to show that sorting on
                 // timestamp works
@@ -106,7 +108,8 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
         logSteamForGroup1Map.put(mockStreamNameForGroup, logInfo);
 
         // Verify that log events were sorted correctly
-        assertThat(logInfo.getSortedLogEvents().get(0).timestamp(), is(lessThan(logInfo.getLogEvents().get(1).timestamp())));
+        assertThat(logInfo.getSortedLogEvents().get(0).timestamp(),
+                is(lessThan(logInfo.getSortedLogEvents().get(1).timestamp())));
 
         attempt.setLogGroupName(mockGroupName);
         attempt.setLogStreamsToLogEventsMap(logSteamForGroup1Map);
@@ -168,7 +171,7 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
         String mockNextSequenceToken = UUID.randomUUID().toString();
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logSteamForGroup1Map = new ConcurrentHashMap<>();
-        List<InputLogEvent> inputLogEventsForStream1OfGroup1 = new ArrayList<>();
+        Queue<InputLogEvent> inputLogEventsForStream1OfGroup1 = new PriorityQueue<>(EVENT_COMPARATOR);
         inputLogEventsForStream1OfGroup1.add(InputLogEvent.builder()
                 .timestamp(Instant.now().toEpochMilli())
                 .message("test")
@@ -240,7 +243,7 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
         String mockNextSequenceToken = UUID.randomUUID().toString();
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logSteamForGroup1Map = new ConcurrentHashMap<>();
-        List<InputLogEvent> inputLogEventsForStream1OfGroup1 = new ArrayList<>();
+        Queue<InputLogEvent> inputLogEventsForStream1OfGroup1 = new PriorityQueue<>(EVENT_COMPARATOR);
         inputLogEventsForStream1OfGroup1.add(InputLogEvent.builder()
                 .timestamp(Instant.now().toEpochMilli())
                 .message("test")
@@ -316,7 +319,7 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
         String mockNextSequenceToken2 = UUID.randomUUID().toString();
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logSteamForGroup1Map = new ConcurrentHashMap<>();
-        List<InputLogEvent> inputLogEventsForStream1OfGroup1 = new ArrayList<>();
+        Queue<InputLogEvent> inputLogEventsForStream1OfGroup1 = new PriorityQueue<>(EVENT_COMPARATOR);
         inputLogEventsForStream1OfGroup1.add(InputLogEvent.builder()
                 .timestamp(Instant.now().toEpochMilli())
                 .message("test")
@@ -387,7 +390,7 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
         String mockSequenceToken = UUID.randomUUID().toString();
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logSteamForGroup1Map = new ConcurrentHashMap<>();
-        List<InputLogEvent> inputLogEventsForStream1OfGroup1 = new ArrayList<>();
+        Queue<InputLogEvent> inputLogEventsForStream1OfGroup1 = new PriorityQueue<>(EVENT_COMPARATOR);
         inputLogEventsForStream1OfGroup1.add(InputLogEvent.builder()
                 .timestamp(Instant.now().toEpochMilli())
                 .message("test")
@@ -433,7 +436,7 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
         String mockSequenceToken = UUID.randomUUID().toString();
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logSteamForGroup1Map = new ConcurrentHashMap<>();
-        List<InputLogEvent> inputLogEventsForStream1OfGroup1 = new ArrayList<>();
+        Queue<InputLogEvent> inputLogEventsForStream1OfGroup1 = new PriorityQueue<>(EVENT_COMPARATOR);
         inputLogEventsForStream1OfGroup1.add(InputLogEvent.builder()
                 .timestamp(Instant.now().toEpochMilli())
                 .message("test")
@@ -478,7 +481,7 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
         String mockSequenceToken = UUID.randomUUID().toString();
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logSteamForGroup1Map = new ConcurrentHashMap<>();
-        List<InputLogEvent> inputLogEventsForStream1OfGroup1 = new ArrayList<>();
+        Queue<InputLogEvent> inputLogEventsForStream1OfGroup1 = new PriorityQueue<>(EVENT_COMPARATOR);
         inputLogEventsForStream1OfGroup1.add(InputLogEvent.builder()
                 .timestamp(Instant.now().toEpochMilli())
                 .message("test")
@@ -522,7 +525,7 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
         String mockSequenceToken = UUID.randomUUID().toString();
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logSteamForGroup1Map = new ConcurrentHashMap<>();
-        List<InputLogEvent> inputLogEventsForStream1OfGroup1 = new ArrayList<>();
+        Queue<InputLogEvent> inputLogEventsForStream1OfGroup1 = new PriorityQueue<>(EVENT_COMPARATOR);
         inputLogEventsForStream1OfGroup1.add(InputLogEvent.builder()
                 .timestamp(Instant.now().toEpochMilli())
                 .message("test")
@@ -570,7 +573,7 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
         String mockSequenceToken = UUID.randomUUID().toString();
         CloudWatchAttempt attempt = new CloudWatchAttempt();
         Map<String, CloudWatchAttemptLogInformation> logSteamForGroup1Map = new ConcurrentHashMap<>();
-        List<InputLogEvent> inputLogEventsForStream1OfGroup1 = new ArrayList<>();
+        Queue<InputLogEvent> inputLogEventsForStream1OfGroup1 = new PriorityQueue<>(EVENT_COMPARATOR);
         inputLogEventsForStream1OfGroup1.add(InputLogEvent.builder()
                 .timestamp(Instant.now().toEpochMilli())
                 .message("test")
@@ -625,7 +628,7 @@ public class CloudWatchLogsUploaderTest extends GGServiceTestUtil {
                 .build());
         logSteamForGroup1Map.put(mockStreamNameForGroup,
                 CloudWatchAttemptLogInformation.builder()
-                        .logEvents(new ArrayList<>())
+                        .logEvents(new PriorityQueue<>(EVENT_COMPARATOR))
                         .attemptLogFileInformationMap(attemptLogFileInformationMap)
                         .build());
         attempt.setLogGroupName(mockGroupName);

--- a/uat/testing-features/src/main/java/com/aws/greengrass/resources/CloudWatchLogsLifecycle.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/resources/CloudWatchLogsLifecycle.java
@@ -8,12 +8,11 @@ package com.aws.greengrass.resources;
 import com.aws.greengrass.testing.resources.AWSResourceLifecycle;
 import com.aws.greengrass.testing.resources.AbstractAWSResourceLifecycle;
 import com.google.auto.service.AutoService;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogStreamsRequest;
-import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogStreamsResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.LogStream;
 
-import java.util.List;
 import javax.inject.Inject;
 
 @AutoService(AWSResourceLifecycle.class)
@@ -29,14 +28,13 @@ public class CloudWatchLogsLifecycle extends AbstractAWSResourceLifecycle<CloudW
      * @param groupName   name of the CloudWatch group
      * @param logStreamNamePattern name of the log CloudWatch log stream
      */
-    public List<LogStream> findStream(String groupName, String logStreamNamePattern) {
+    public SdkIterable<LogStream> findStream(String groupName, String logStreamNamePattern) {
         DescribeLogStreamsRequest request = DescribeLogStreamsRequest.builder()
                 .logGroupName(groupName)
                 .logStreamNamePrefix(logStreamNamePattern)
                 .descending(true)
                 .build();
 
-        DescribeLogStreamsResponse response = client.describeLogStreams(request);
-        return response.logStreams();
+        return client.describeLogStreamsPaginator(request).logStreams();
     }
 }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/CloudWatchSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/CloudWatchSteps.java
@@ -16,9 +16,8 @@ import io.cucumber.guice.ScenarioScoped;
 import io.cucumber.java.en.Then;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
-import software.amazon.awssdk.services.cloudwatchlogs.model.DeleteLogGroupRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.GetLogEventsRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.GetLogEventsResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.LogStream;
@@ -195,7 +194,7 @@ public class CloudWatchSteps {
             // The OTF watch steps check evey 100ms this to avoids hammering the api. Ideally OTF
             // can allow us to configure the check interval rate
             Thread.sleep(VERIFICATION_RATE_MILLISECONDS);
-            List<LogStream> streams = logsLifecycle.findStream(logGroupName, streamName);
+            SdkIterable<LogStream> streams = logsLifecycle.findStream(logGroupName, streamName);
             boolean exists = streams.stream().anyMatch(stream -> stream.logStreamName().matches(streamName));
 
             if (exists) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
We need the log events to be sorted at the end to upload and we're checking ever time we insert into the log batch that the batch is all within 24 hours which requires us to get the earliest time from the batch. This turned out to be very costly in the real world, so now using a queue which will keep the data sorted for us on insertion and we can check the earliest timestamp with constant time.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
