### PR TITLE
perf: only write actually changed values to config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,16 @@
             <!-- CloudFront url fronting the device sdk,logging library and component common in S3-->
             <url>https://d2jrmugq4soldf.cloudfront.net/snapshots</url>
         </repository>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
     </repositories>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/com/aws/greengrass/logmanager/util/ConfigUtil.java
+++ b/src/main/java/com/aws/greengrass/logmanager/util/ConfigUtil.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.logmanager.util;
+
+import com.aws.greengrass.config.CaseInsensitiveString;
+import com.aws.greengrass.config.Node;
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.config.UnsupportedInputTypeException;
+import com.aws.greengrass.config.UpdateBehaviorTree;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class ConfigUtil {
+    private static final Logger logger = LogManager.getLogger(ConfigUtil.class);
+
+    private ConfigUtil() {
+    }
+
+    /**
+     * Same as topics.updateFromMap, but only makes the update when the value actually changes, skipping any unnecessary
+     * timestampUpdated events. Ideally this code would exist in Topics, but it isn't, so we need to do this in order to
+     * maintain compatibility.
+     *
+     * @param topics    Topics to update with values from the map
+     * @param newValues the new value to apply
+     * @param ubt       update behavior tree
+     */
+    public static void updateFromMapWhenChanged(Topics topics, Map<String, Object> newValues, UpdateBehaviorTree ubt) {
+        Set<CaseInsensitiveString> childrenToRemove = new HashSet<>(topics.children.keySet());
+
+        newValues.forEach((okey, value) -> {
+            CaseInsensitiveString key = new CaseInsensitiveString(okey);
+            childrenToRemove.remove(key);
+            updateChild(topics, key, value, ubt);
+        });
+
+        childrenToRemove.forEach(childName -> {
+            UpdateBehaviorTree childMergeBehavior = ubt.getChildBehavior(childName.toString());
+
+            // remove the existing child if its merge behavior is REPLACE
+            if (childMergeBehavior.getBehavior() == UpdateBehaviorTree.UpdateBehavior.REPLACE) {
+                topics.remove(topics.children.get(childName));
+            }
+        });
+    }
+
+    private static void updateChild(Topics t, CaseInsensitiveString key, Object value,
+                                    @NonNull UpdateBehaviorTree mergeBehavior) {
+        UpdateBehaviorTree childMergeBehavior = mergeBehavior.getChildBehavior(key.toString());
+
+        Node existingChild = t.children.get(key);
+        // if new node is a container node
+        if (value instanceof Map) {
+            // if existing child is a container node
+            if (existingChild == null || existingChild instanceof Topics) {
+                updateFromMapWhenChanged(t.createInteriorChild(key.toString()), (Map) value, childMergeBehavior);
+            } else {
+                t.remove(existingChild);
+                Topics newNode = t.createInteriorChild(key.toString(), mergeBehavior.getTimestampToUse());
+                updateFromMapWhenChanged(newNode, (Map) value, childMergeBehavior);
+            }
+            // if new node is a leaf node
+        } else {
+            try {
+                if (existingChild == null || existingChild instanceof Topic) {
+                    Topic node = t.createLeafChild(key.toString());
+                    if (!Objects.equals(node.getOnce(), value)) {
+                        node.withValueChecked(childMergeBehavior.getTimestampToUse(), value);
+                    }
+                } else {
+                    t.remove(existingChild);
+                    Topic newNode = t.createLeafChild(key.toString());
+                    newNode.withValueChecked(childMergeBehavior.getTimestampToUse(), value);
+                }
+            } catch (UnsupportedInputTypeException e) {
+                logger.error("Should never fail in updateChild", e);
+            }
+        }
+    }
+}

--- a/src/test/java/com/aws/greengrass/logmanager/util/ConfigUtilTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/util/ConfigUtilTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.logmanager.util;
+
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.config.UpdateBehaviorTree;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.util.Utils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConfigUtilTest {
+    private final Context context = new Context();
+
+    @AfterEach()
+    void after() {
+        context.shutdown();
+    }
+
+    @Test
+    public void update_from_map_updates_when_changes_exist() {
+        Topics root = Topics.of(context, "a", null);
+        AtomicInteger callbackCount = new AtomicInteger();
+        root.subscribe((w, n) -> {
+            callbackCount.incrementAndGet();
+        });
+
+        Map<String, Object> map1 = Utils.immutableMap("B", 1, "C", 2);
+        long now = System.currentTimeMillis();
+        root.updateFromMap(map1, new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, now));
+        context.waitForPublishQueueToClear();
+
+        assertEquals(5, callbackCount.get());
+
+        ConfigUtil.updateFromMapWhenChanged(root, map1,
+                new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, now));
+
+        // Nothing should have changed
+        context.waitForPublishQueueToClear();
+        assertEquals(5, callbackCount.get());
+
+        Map<String, Object> map2 = Utils.immutableMap("C", 1);
+        ConfigUtil.updateFromMapWhenChanged(root, map2,
+                new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, now));
+
+        // 2 events to remove B and update the value of C
+        context.waitForPublishQueueToClear();
+        assertEquals(7, callbackCount.get());
+
+        // Try pushing timestamp forward
+        ConfigUtil.updateFromMapWhenChanged(root, map2,
+                new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, now+10));
+
+        // Nothing should have changed
+        context.waitForPublishQueueToClear();
+        assertEquals(7, callbackCount.get());
+
+        // Add in some nesting
+        Map<String, Object> map3 = Utils.immutableMap("C", Utils.immutableMap("A", 2));
+        ConfigUtil.updateFromMapWhenChanged(root, map3,
+                new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, now+10));
+
+        // 4 events more. remove C, add C as Topics, add A, update A
+        context.waitForPublishQueueToClear();
+        assertEquals(11, callbackCount.get());
+
+        ConfigUtil.updateFromMapWhenChanged(root, map3,
+                new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, now+20));
+
+        // Nothing should have changed
+        context.waitForPublishQueueToClear();
+        assertEquals(11, callbackCount.get());
+
+        Map<String, Object> map4 = Utils.immutableMap("C", Utils.immutableMap("A", 1));
+        ConfigUtil.updateFromMapWhenChanged(root, map4,
+                new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, now+20));
+
+        // A changed
+        context.waitForPublishQueueToClear();
+        assertEquals(12, callbackCount.get());
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Add new config option "deprecatedVersionSupport" which will prevent log manager from loading and writing the deprecated currently processing file information. This helps with performance because we don't need to write the same information to both the V2 section and the deprecated section. The default is to keep supporting the old version, set it to "false" to stop it.
2. Add a new ConfigUtil which allows updating config from a map, but ignoring when nothing actually changes. Currently a large portion of config updates are just "timestampUpdated" which we really don't care about.


Utilizing both of these changes, we're up to ~1.8MBps upload rate.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
