### PR TITLE
test(uat): add test for upload speed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,6 +357,7 @@
                         </goals>
                         <configuration>
                             <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                            <skip>${skipTests}</skip>
                             <rules>
                                 <rule>
                                     <element>BUNDLE</element>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add scenario T6 to test our upload speed over 200,000 log events for a single component.

This test shows that the current main branch can achieve ~1.6MBps which is compared to ~0.4MBps on the current release branch, proving that the changes are quite meaningful.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
