### PR TITLE
fix: catch ClosedByInterruptException and handle it at debug/info

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
+++ b/src/main/java/com/aws/greengrass/logmanager/LogManagerService.java
@@ -681,9 +681,9 @@ public class LogManagerService extends PluginService {
      *     It will then get all the log files which have not yet been uploaded to the cloud. This is done by checking
      *     the last uploaded log file time for that component.
      */
-    @SuppressWarnings("PMD.CollapsibleIfStatements")
+    @SuppressWarnings({"PMD.CollapsibleIfStatements", "PMD.PrematureDeclaration"})
     private void processLogsAndUpload() throws InterruptedException {
-        while (true) {
+        while (!Thread.currentThread().isInterrupted()) {
             //TODO: this is only done for passing the current text. But in practise, we don`t need to intentionally
             // sleep here.
             if (!isCurrentlyUploading.compareAndSet(false, true)) {
@@ -702,6 +702,9 @@ public class LogManagerService extends PluginService {
                 try {
                     LogFileGroup logFileGroup = LogFileGroup.create(componentLogConfiguration,
                             lastUploadedLogFileTimeMs, workDir);
+                    if (Thread.currentThread().isInterrupted()) {
+                        return;
+                    }
 
                     if (logFileGroup.getLogFiles().isEmpty()) {
                         continue;

--- a/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
+++ b/src/main/java/com/aws/greengrass/logmanager/model/LogFile.java
@@ -11,6 +11,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -89,6 +90,9 @@ public class LogFile extends File {
         } catch (FileNotFoundException e) {
             // The file may be deleted as expected.
             logger.atDebug().cause(e).log("The file {} does not exist", this.getAbsolutePath());
+        } catch (ClosedByInterruptException e) {
+            Thread.currentThread().interrupt();
+            logger.atDebug().log("Interrupted while getting log file hash");
         } catch (IOException e) {
             // File may not exist
             logger.atError().cause(e).log("Unable to read file {}", this.getAbsolutePath());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Handle `ClosedByInterruptException` instead of only `IOException` to avoid unhelpful logs at too high of a level.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
