### PR TITLE
fix: add client wrapper

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerTest.java
@@ -151,7 +151,7 @@ class LogManagerTest extends BaseITCase {
             if (service.getName().equals(LogManagerService.LOGS_UPLOADER_SERVICE_TOPICS)
                     && newState.equals(State.RUNNING)) {
                 logManagerService = (LogManagerService) service;
-                logManagerService.getUploader().setCloudWatchLogsClient(cloudWatchLogsClient);
+                logManagerService.getUploader().getCloudWatchWrapper().setClient(cloudWatchLogsClient);
                 logManagerRunning.countDown();
             }
         });

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/SpaceManagementTest.java
@@ -172,7 +172,7 @@ class SpaceManagementTest extends BaseITCase {
         // set required instances from context
         kernel.launch();
         assertTrue(logManagerRunning.await(10, TimeUnit.SECONDS));
-        logManagerService.getUploader().setCloudWatchLogsClient(cloudWatchLogsClient);
+        logManagerService.getUploader().getCloudWatchWrapper().setClient(cloudWatchLogsClient);
     }
 
     @Test

--- a/src/main/java/com/aws/greengrass/logmanager/util/SdkClientWrapper.java
+++ b/src/main/java/com/aws/greengrass/logmanager/util/SdkClientWrapper.java
@@ -1,0 +1,88 @@
+package com.aws.greengrass.logmanager.util;
+
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.http.NoHttpResponseException;
+import software.amazon.awssdk.core.SdkClient;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+import java.net.SocketException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public final class SdkClientWrapper<T extends SdkClient> {
+    private static final Logger logger = LogManager.getLogger(SdkClientWrapper.class);
+    @Getter
+    // Setter only for unit testing purpose
+    @Setter
+    private volatile T client;
+    private final Supplier<T> clientFactory;
+
+    public SdkClientWrapper(Supplier<T> clientFactory) {
+        this.clientFactory = clientFactory;
+        this.client = clientFactory.get();
+    }
+
+    /**
+     * Executes the given operation on the client, handling potential SDK client exceptions.
+     *
+     * <p>This method applies the provided operation to the client. If an {@link SdkClientException}
+     * occurs and the client needs refreshing (as determined by {@link #shouldRefreshClient(SdkClientException)}),
+     * it will attempt to refresh the client and retry the operation once.</p>
+     *
+     * @param <R> The return type of the operation
+     * @param operation A function that takes the client of type T and returns a result of type R
+     * @return The result of the operation
+     * @throws SdkClientException If the operation fails and the client cannot be refreshed or fails after refresh
+     * @throws RuntimeException If an unexpected error occurs during execution
+     */
+    public <R> R execute(final Function<T, R> operation) {
+        try {
+            return operation.apply(client);
+        } catch (SdkClientException e) {
+            if (shouldRefreshClient(e)) {
+                logger.atDebug().log("Client needs refresh due to: {}", e.getMessage());
+                try {
+                    refreshClient();
+                    return operation.apply(client);
+                } catch (SdkClientException retryException) {
+                    logger.atError().log("Failed to execute operation after client refresh", retryException);
+                    throw retryException;
+                }
+            }
+            logger.atError().log("SDK client operation failed", e);
+            throw e;
+        }
+    }
+
+    private void refreshClient() {
+        synchronized (this) {
+            if (client != null) {
+                try {
+                    client.close();
+                } catch (SdkClientException e) {
+                    logger.atError().log("Error closing client: " + e.getMessage());
+                }
+            }
+            // Creates new client when refresh needed
+            client = clientFactory.get();
+        }
+    }
+
+    private boolean shouldRefreshClient(SdkClientException e) {
+        Throwable cause = e;
+        while (cause != null) {
+            if (cause instanceof SocketException && "Connection reset".equals(cause.getMessage())) {
+                return true;
+            }
+            if (cause instanceof NoHttpResponseException) {
+                return true;
+            }
+            // Add other conditions that should trigger a client refresh here
+            cause = cause.getCause();
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add sdk client wrapper for all API calls through cloudwatch sdk client
**Why is this change necessary:**
Under network unstable, the sdk client retried an http call, however, some of the times the client will try to use a connection which already being closed but the connection was not aware which makes the retry happens infinitely even after the network becomes stable. To address this, we would like to create a mechanism to force refresh the client when certain exceptions got thrown
**How was this change tested:**
Unit test
**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
