### PR TITLE
feat(log-manager): Add configurable buffer interval for writting upload action to tlog

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerPeriodicBufferIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/logmanager/LogManagerPeriodicBufferIntegrationTest.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.logmanager;
+
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
+import com.aws.greengrass.integrationtests.BaseITCase;
+import com.aws.greengrass.integrationtests.util.ConfigPlatformResolver;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.logmanager.LogManagerService;
+import com.aws.greengrass.logmanager.model.ProcessingFiles;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.exceptions.TLSAuthException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.time.format.DateTimeParseException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.crt.CrtRuntimeException;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsResponse;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.aws.greengrass.integrationtests.logmanager.util.LogFileHelper.createTempFileAndWriteData;
+import static com.aws.greengrass.logmanager.LogManagerService.BUFFER_INTERVAL_SEC;
+import static com.aws.greengrass.logmanager.LogManagerService.LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC;
+import static com.aws.greengrass.logmanager.LogManagerService.LOGS_UPLOADER_SERVICE_TOPICS;
+import static com.aws.greengrass.logmanager.LogManagerService.PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION_V2;
+import static com.aws.greengrass.logmanager.LogManagerService.PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({GGExtension.class, MockitoExtension.class})
+class LogManagerPeriodicBufferIntegrationTest extends BaseITCase {
+    private static Kernel kernel;
+    private static DeviceConfiguration deviceConfiguration;
+    private LogManagerService logManagerService;
+    private Path tempDirectoryPath;
+    private final static ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    @Mock
+    private CloudWatchLogsClient cloudWatchLogsClient;
+    @Captor
+    private ArgumentCaptor<PutLogEventsRequest> captor;
+
+    void setupKernel(Path storeDirectory, String configFileName)
+            throws InterruptedException, URISyntaxException, IOException, DeviceConfigurationException {
+
+        System.setProperty("root", tempRootDir.toAbsolutePath().toString());
+        CountDownLatch logManagerRunning = new CountDownLatch(1);
+
+        Path testRecipePath = Paths.get(LogManagerTest.class.getResource(configFileName).toURI());
+        String content = new String(Files.readAllBytes(testRecipePath), StandardCharsets.UTF_8);
+        content = content.replaceAll("\\{\\{logFileDirectoryPath}}",
+                storeDirectory.toAbsolutePath().toString());
+
+        Map<String, Object> objectMap = YAML_OBJECT_MAPPER.readValue(content, Map.class);
+
+        kernel.parseArgs();
+        kernel.getConfig().mergeMap(System.currentTimeMillis(), ConfigPlatformResolver.resolvePlatformMap(objectMap));
+
+        kernel.getContext().addGlobalStateChangeListener((service, oldState, newState) -> {
+            if (service.getName().equals(LOGS_UPLOADER_SERVICE_TOPICS)
+                    && newState.equals(State.RUNNING)) {
+                logManagerService = (LogManagerService) service;
+                logManagerService.getUploader().getCloudWatchWrapper().setClient(cloudWatchLogsClient);
+                logManagerRunning.countDown();
+            }
+        });
+        deviceConfiguration = new DeviceConfiguration(kernel, "ThingName", "xxxxxx-ats.iot.us-east-1.amazonaws.com",
+                "xxxxxx.credentials.iot.us-east-1.amazonaws.com", "privKeyFilePath",
+                "certFilePath", "caFilePath", "us-east-1", "roleAliasName");
+
+        kernel.getContext().put(DeviceConfiguration.class, deviceConfiguration);
+        kernel.launch();
+        assertTrue(logManagerRunning.await(30, TimeUnit.SECONDS));
+    }
+
+    @BeforeEach
+    void beforeEach(ExtensionContext context) {
+        kernel = new Kernel();
+        ignoreExceptionOfType(context, TLSAuthException.class);
+        ignoreExceptionOfType(context, InterruptedException.class);
+        ignoreExceptionOfType(context, DateTimeParseException.class);
+        ignoreExceptionOfType(context, CrtRuntimeException.class);
+    }
+
+    @AfterEach
+    void afterEach() {
+        kernel.shutdown();
+    }
+
+    @Test
+    void GIVEN_user_component_config_with_periodic_interval_and_buffer_inverval_time_THEN_config_update_by_buffer() throws Exception {
+        // Given randomly generated logs
+        tempDirectoryPath = Files.createTempDirectory(tempRootDir, "IntegrationTestsTemporaryLogFiles");
+        for (int i = 0; i < 5; i++) {
+            createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log_", Coerce.toString(i));
+        }
+        setupKernel(tempDirectoryPath, "smallPeriodicIntervalUserComponentConfig.yaml");
+
+        // When
+        String componentName = "UserComponentA";
+        
+        // Track how many times CloudWatch upload is called
+        AtomicInteger uploadCount = new AtomicInteger(0);
+        CountDownLatch uploadLatch = new CountDownLatch(2);
+        CountDownLatch firstUploadLatch = new CountDownLatch(1);
+        
+        // Buffer flush countdown mechanism for each component map
+        Map<String, AtomicInteger> bufferFlushCountdown = new HashMap<>();
+        bufferFlushCountdown.put(componentName, new AtomicInteger(2)); // Expect 2 buffer flushes
+        CountDownLatch bufferFlushLatch = new CountDownLatch(2);
+
+
+        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenAnswer(invocation -> {
+            uploadCount.incrementAndGet();
+            firstUploadLatch.countDown();
+            uploadLatch.countDown();
+            return PutLogEventsResponse.builder().nextSequenceToken("nextToken").build();
+        });
+
+        // Subscribe to buffer flush events for countdown tracking and by this time, buffer shouldn't flush
+        logManagerService.getRuntimeConfig()
+                .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, componentName)
+                .subscribe((why, node) -> {
+                    if (node != null && bufferFlushCountdown.containsKey(componentName)) {
+                        int remaining = bufferFlushCountdown.get(componentName).decrementAndGet();
+                        bufferFlushLatch.countDown();
+                        System.out.println("Buffer flush countdown for " + componentName + ": " + remaining + " remaining");
+                    }
+                });
+
+        // Check initial state of runtime config. should be 0 since no flush has been performed by buffer
+        Topics initialComponentTopics = logManagerService.getRuntimeConfig()
+                .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, componentName);
+        assertEquals(0, initialComponentTopics.size());
+
+        // Wait for first upload to ensure log manager is processing
+        assertTrue(firstUploadLatch.await(15, TimeUnit.SECONDS),
+                "Expected first CloudWatch upload within 15 seconds");
+
+        // Then write more logs and wait for the log manager to upload log
+        for (int i = 5; i < 10; i++) {
+            createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log_", Coerce.toString(i));
+        }
+        assertTrue(uploadLatch.await(15, TimeUnit.SECONDS),
+                "Expected 2 CloudWatch uploads within 15 seconds");
+
+        // Wait for buffer flushes
+        assertTrue(bufferFlushLatch.await(10, TimeUnit.SECONDS),
+                "Expected buffer flush countdown to complete within 10 seconds");
+
+        // Verify countdown reached zero, this includes the flush action for both maps
+        assertEquals(0, bufferFlushCountdown.get(componentName).get(),
+                "Buffer flush countdown should reach zero");
+
+        // Verify processing files information is correctly persisted
+        ProcessingFiles processingFiles = logManagerService.processingFilesInformation.get(componentName);
+        assertNotNull(processingFiles);
+        assertEquals(processingFiles.size(), 1);
+
+        // Verify buffer has flushed exactly once by checking runtime config
+        Topics afterFlushComponentTopics = logManagerService.getRuntimeConfig()
+                .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, componentName);
+        assertEquals(afterFlushComponentTopics.size(), 1);
+
+        // Verify last uploaded timestamp is also persisted
+        Topics lastFileProcessedTopics = logManagerService.getRuntimeConfig()
+                .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, componentName);
+        assertEquals(lastFileProcessedTopics.size(), 1);
+    }
+
+    @Test
+    void testLogManagerShutdownFlushesBuffer() throws Exception {
+        tempDirectoryPath = Files.createTempDirectory(tempRootDir, "IntegrationTestsTemporaryLogFiles");
+        
+        // Create initial test files
+        for (int i = 0; i < 5; i++) {
+            createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log_", Coerce.toString(i));
+        }
+        
+        setupKernel(tempDirectoryPath, "smallPeriodicIntervalUserComponentConfig.yaml");
+
+        String componentName = "UserComponentA";
+        
+        // STEP 1: Track buffer flushes - we will verify a scheduled flush happens first
+        AtomicInteger bufferFlushCount = new AtomicInteger(0);
+        AtomicReference<Long> lastScheduledFlushTime = new AtomicReference<>(0L);
+        CountDownLatch scheduledFlushLatch = new CountDownLatch(1);
+        
+        // Track CloudWatch uploads
+        AtomicInteger uploadCount = new AtomicInteger(0);
+        CountDownLatch firstUploadLatch = new CountDownLatch(1);
+        CountDownLatch secondUploadLatch = new CountDownLatch(2);
+        
+        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenAnswer(invocation -> {
+            uploadCount.incrementAndGet();
+            firstUploadLatch.countDown();
+            secondUploadLatch.countDown();
+            return PutLogEventsResponse.builder().nextSequenceToken("nextToken").build();
+        });
+        
+        // Subscribe to runtime config changes to detect buffer flushes
+        logManagerService.getRuntimeConfig()
+                .lookupTopics(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP, componentName)
+                .subscribe((why, node) -> {
+                    if (node != null && node.childOf(PERSISTED_COMPONENT_LAST_FILE_PROCESSED_TIMESTAMP)) {
+                        int flushNum = bufferFlushCount.incrementAndGet();
+                        long flushTime = System.currentTimeMillis();
+                        
+                        // Record the timestamp of the first flush (scheduled flush)
+                        if (flushNum == 1) {
+                            lastScheduledFlushTime.set(flushTime);
+                            scheduledFlushLatch.countDown();
+                            System.out.println("First scheduled buffer flush detected at: " + flushTime);
+                        } else {
+                            System.out.println("Additional buffer flush detected at: " + flushTime);
+                        }
+                    }
+                });
+        
+        // Wait for initial data to be processed and first scheduled flush to happen
+        assertTrue(firstUploadLatch.await(10, TimeUnit.SECONDS),
+                "Expected first CloudWatch upload within 10 seconds");
+        assertTrue(scheduledFlushLatch.await(20, TimeUnit.SECONDS),
+                "Expected the first scheduled buffer flush within 20 seconds");
+        
+        // STEP 2: Verify the first scheduled flush happened
+        assertEquals(1, bufferFlushCount.get(), 
+                "Should have exactly one buffer flush at this point (the scheduled flush)");
+
+        // Now add more files to ensure buffer has new data that hasn't been flushed yet
+        for (int i = 5; i < 10; i++) {
+            createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log_", Coerce.toString(i));
+        }
+        
+        // Wait briefly for log manager to process the new files
+        // but not long enough for another scheduled flush to happen
+        assertTrue(secondUploadLatch.await(10, TimeUnit.SECONDS),
+                "Expected second CloudWatch upload within 10 seconds");
+        // Verify we have pending data in buffer
+        ProcessingFiles processingFiles = logManagerService.processingFilesInformation.get(componentName);
+        assertNotNull(processingFiles, "Processing files should exist for the component");
+        // Buffer should contain data waiting to be flushed
+        assertThat(processingFiles.size(), greaterThan(0));
+        
+        // Record the number of flushes before shutdown
+        int flushesBeforeShutdown = bufferFlushCount.get();
+        
+        // STEP 3: Shutdown LogManagerService before next scheduled flush
+        // This should trigger a manual flush during shutdown
+        kernel.shutdown();
+        
+        // Wait briefly for shutdown to complete
+        Thread.sleep(2000);
+        
+        // STEP 4: Verify that an additional flush happened during shutdown
+        // An additional flush should have occurred during shutdown
+        assertThat(bufferFlushCount.get(), greaterThan(flushesBeforeShutdown));
+    }
+
+    @Test
+    void testBufferAccumulatesUpdatesCorrectly() throws Exception {
+        // Given
+        tempDirectoryPath = Files.createTempDirectory(tempRootDir, "IntegrationTestsTemporaryLogFiles");
+
+        // Create initial test files
+        for (int i = 0; i < 3; i++) {
+            createTempFileAndWriteData(tempDirectoryPath, "integTestRandomLogFiles.log_", "");
+        }
+
+        // Configure with short intervals for faster testing
+        Map<String, Object> additionalConfig = new HashMap<>();
+        additionalConfig.put(LOGS_UPLOADER_PERIODIC_UPDATE_INTERVAL_SEC, 1);
+        additionalConfig.put(BUFFER_INTERVAL_SEC, 3);
+
+        setupKernel(tempDirectoryPath, "smallPeriodicIntervalUserComponentConfig.yaml");
+
+        // When
+        String componentName = "UserComponentA";
+        
+        // Track CloudWatch uploads and buffer flushes
+        AtomicInteger uploadCount = new AtomicInteger(0);
+        AtomicInteger bufferFlushCount = new AtomicInteger(0);
+        CountDownLatch firstBufferFlush = new CountDownLatch(1);
+        
+        when(cloudWatchLogsClient.putLogEvents(any(PutLogEventsRequest.class))).thenAnswer(invocation -> {
+            uploadCount.incrementAndGet();
+            return PutLogEventsResponse.builder().nextSequenceToken("nextToken").build();
+        });
+
+        // Subscribe to detect buffer flushes
+        logManagerService.getRuntimeConfig()
+                .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION_V2, componentName)
+                .subscribe((why, node) -> {
+                    if (node != null && node.childOf(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION_V2)) {
+                        Topics currentTopics = logManagerService.getRuntimeConfig()
+                                .lookupTopics(PERSISTED_COMPONENT_CURRENT_PROCESSING_FILE_INFORMATION_V2, componentName);
+                        if (currentTopics.size() > 0) {
+                            bufferFlushCount.incrementAndGet();
+                            firstBufferFlush.countDown();
+                        }
+                    }
+                });
+
+        // Wait for first buffer flush
+        assertTrue(firstBufferFlush.await(10, TimeUnit.SECONDS), 
+                "Expected first buffer flush within 10 seconds");
+
+        // Then
+        // Verify that multiple uploads happened before buffer flush
+        assertThat(uploadCount.get(), greaterThanOrEqualTo(2));
+        
+        // Verify buffer flush happened
+        assertThat(bufferFlushCount.get(), greaterThanOrEqualTo(1));
+        
+        // Verify CloudWatch uploads happened more frequently than buffer flushes
+        assertTrue(uploadCount.get() > bufferFlushCount.get(), 
+                "Upload count should be greater than buffer flush count");
+    }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallPeriodicIntervalUserComponentConfig.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallPeriodicIntervalUserComponentConfig.yaml
@@ -3,6 +3,7 @@ services:
   aws.greengrass.LogManager:
     configuration:
       periodicUploadIntervalSec: 10
+      bufferIntervalSec: 20
       logsUploaderConfiguration:
         componentLogsConfiguration:
           - componentName: 'UserComponentA'

--- a/src/main/java/com/aws/greengrass/logmanager/util/PeriodicBuffer.java
+++ b/src/main/java/com/aws/greengrass/logmanager/util/PeriodicBuffer.java
@@ -11,9 +11,13 @@ import com.aws.greengrass.logging.impl.LogManager;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 /**
@@ -27,12 +31,15 @@ import java.util.function.Consumer;
 public class PeriodicBuffer<K, V> {
     private static final Logger logger = LogManager.getLogger(PeriodicBuffer.class);
 
-    private final Map<K, V> buffer = new ConcurrentHashMap<>();
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private Map<K, V> buffer = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService scheduler;
     private final Consumer<Map<K, V>> flushHandler;
     private final long intervalSeconds;
     private final String bufferName;
     private final Object bufferLock = new Object();
+    private final AtomicLong flushSuccessCount = new AtomicLong(0);
+    private final AtomicLong flushFailureCount = new AtomicLong(0);
+    private final AtomicInteger flushInProgress = new AtomicInteger(0);
 
     private ScheduledFuture<?> flushTask;
     private volatile boolean isShutdown = false;
@@ -48,6 +55,15 @@ public class PeriodicBuffer<K, V> {
         this.bufferName = bufferName;
         this.intervalSeconds = intervalSeconds;
         this.flushHandler = flushHandler;
+        
+        // Create a named thread factory for better debugging
+        ThreadFactory namedThreadFactory = runnable -> {
+            Thread thread = new Thread(runnable, "PeriodicBuffer-" + bufferName + "-Flusher");
+            thread.setDaemon(true);
+            return thread;
+        };
+        
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(namedThreadFactory);
     }
 
     /**
@@ -85,6 +101,8 @@ public class PeriodicBuffer<K, V> {
 
         synchronized (bufferLock) {
             buffer.put(key, value);
+            logger.atTrace().kv("key", key).kv("bufferSize", buffer.size())
+                    .log("Added item to buffer '{}'", bufferName);
         }
     }
 
@@ -96,6 +114,8 @@ public class PeriodicBuffer<K, V> {
     public void remove(K key) {
         synchronized (bufferLock) {
             buffer.remove(key);
+            logger.atTrace().kv("key", key).kv("bufferSize", buffer.size())
+                    .log("Removed item from buffer '{}'", bufferName);
         }
     }
 
@@ -103,25 +123,109 @@ public class PeriodicBuffer<K, V> {
      * Manually triggers a flush of the buffer.
      */
     public void flush() {
+        flush(false);
+    }
+
+    /**
+     * Triggers a flush of the buffer with option to wait for any in-progress flush.
+     * 
+     * @param waitForInProgress if true, waits for any in-progress flush to complete before proceeding
+     */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private void flush(boolean waitForInProgress) {
+        // Early check for empty buffer to avoid unnecessary locking
         synchronized (bufferLock) {
             if (buffer.isEmpty()) {
+                logger.atDebug().log("Buffer '{}' is empty, nothing to flush", bufferName);
                 return;
             }
+        }
 
-            logger.atInfo().log("Flushing buffer '{}' with {} items", bufferName, buffer.size());
-
-            try {
-                // Create a copy to pass to the handler
-                Map<K, V> bufferCopy = new ConcurrentHashMap<>(buffer);
-                flushHandler.accept(bufferCopy);
-
-                // Clear the buffer after successful flush
-                buffer.clear();
-
-                logger.atDebug().log("Successfully flushed buffer '{}'", bufferName);
-            } catch (Exception e) {
-                logger.atError().cause(e).log("Failed to flush buffer '{}'", bufferName);
+        // Check if another flush is already in progress
+        if (!flushInProgress.compareAndSet(0, 1)) {
+            if (waitForInProgress) {
+                logger.atDebug().log("Flush already in progress for buffer '{}', waiting for completion", bufferName);
+                // Wait for the current flush to complete
+                while (flushInProgress.get() != 0) {
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        logger.atWarn().log("Interrupted while waiting for flush to complete in buffer '{}'",
+                                bufferName);
+                        return;
+                    }
+                }
+                // Try again after the previous flush completed
+                flush(waitForInProgress);
+            } else {
+                logger.atDebug().log("Flush already in progress for buffer '{}', skipping", bufferName);
             }
+            return;
+        }
+
+        try {
+            Map<K, V> bufferToFlush;
+            boolean shouldFlush;
+            synchronized (bufferLock) {
+                // Double-check if buffer is still non-empty
+                if (buffer.isEmpty()) {
+                    logger.atDebug().log("Buffer '{}' became empty, nothing to flush", bufferName);
+                    // Don't return here - we need to go through finally block
+                    bufferToFlush = new ConcurrentHashMap<>();
+                    shouldFlush = false;
+                } else {
+                    logger.atInfo().log("Flushing buffer '{}' with {} items", bufferName, buffer.size());
+
+                    // Swap the buffer instead of copying for better performance
+                    bufferToFlush = buffer;
+                    buffer = new ConcurrentHashMap<>();
+                    shouldFlush = true;
+                }
+            }
+
+            // Only proceed with flush if we have data
+            if (shouldFlush) {
+                long startTime = System.currentTimeMillis();
+                try {
+                    flushHandler.accept(bufferToFlush);
+                    
+                    long duration = System.currentTimeMillis() - startTime;
+                    flushSuccessCount.incrementAndGet();
+                    
+                    logger.atDebug()
+                            .kv("itemCount", bufferToFlush.size())
+                            .kv("durationMs", duration)
+                            .kv("successCount", flushSuccessCount.get())
+                            .log("Successfully flushed buffer '{}'", bufferName);
+                            
+                } catch (RejectedExecutionException e) {
+                    // Put the items back if flush was rejected
+                    synchronized (bufferLock) {
+                        bufferToFlush.forEach(buffer::putIfAbsent);
+                    }
+                    flushFailureCount.incrementAndGet();
+                    logger.atError().cause(e)
+                            .kv("failureCount", flushFailureCount.get())
+                            .log("Flush rejected for buffer '{}', items restored", bufferName);
+                } catch (RuntimeException e) {
+                    // Catching RuntimeException because the flushHandler is a Consumer<Map<K, V>> that
+                    // can throw any unchecked exception. We need to handle all possible runtime exceptions
+                    // to ensure the buffer continues to function properly.
+                    // CHECKSTYLE:OFF - We need to catch all runtime exceptions from user-provided handler
+                    // PMD:OFF:AvoidCatchingGenericException - The flushHandler is a user-provided Consumer
+                    // that can throw any unchecked exception, and we must ensure the buffer continues to
+                    // function even if the handler fails. This is a valid use case for catching RuntimeException.
+                    flushFailureCount.incrementAndGet();
+                    logger.atError().cause(e)
+                            .kv("failureCount", flushFailureCount.get())
+                            .log("Failed to flush buffer '{}'. Items lost.", bufferName);
+                    // CHECKSTYLE:ON
+                    // PMD:ON:AvoidCatchingGenericException
+                }
+            }
+        } finally {
+            flushInProgress.set(0);
         }
     }
 
@@ -146,24 +250,59 @@ public class PeriodicBuffer<K, V> {
     /**
      * Shuts down the buffer, flushing any remaining items.
      */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void shutdown() {
         if (isShutdown) {
             return;
         }
 
         isShutdown = true;
+        logger.atInfo().log("Shutting down buffer '{}'", bufferName);
 
         // Cancel the scheduled task
         if (flushTask != null) {
             flushTask.cancel(false);
         }
 
-        // Flush any remaining items
-        flush();
+        // Flush any remaining items, waiting for any in-progress flush to complete
+        try {
+            flush(true);
+        } catch (RuntimeException e) {
+            // Catching RuntimeException because the flush method can throw any unchecked exception
+            // from the flushHandler. We need to ensure shutdown completes even if the final flush fails.
+            // CHECKSTYLE:OFF - We need to catch all runtime exceptions from user-provided handler
+            // PMD:OFF:AvoidCatchingGenericException - The flushHandler called via flush(true) can throw
+            // any unchecked exception. We must ensure shutdown completes successfully even if the final
+            // flush operation fails. This is a valid use case for catching RuntimeException.
+            logger.atError().cause(e).log("Error during final flush");
+            // CHECKSTYLE:ON
+            // PMD:ON:AvoidCatchingGenericException
+        }
 
         // Shutdown the scheduler
-        scheduler.shutdown();
+        scheduler.shutdownNow();
 
-        logger.atInfo().log("Shutdown buffer '{}'", bufferName);
+        logger.atInfo()
+                .kv("successfulFlushes", flushSuccessCount.get())
+                .kv("failedFlushes", flushFailureCount.get())
+                .log("Shutdown complete for buffer '{}'", bufferName);
+    }
+
+    /**
+     * Gets the number of successful flushes.
+     *
+     * @return the number of successful flushes
+     */
+    public long getFlushSuccessCount() {
+        return flushSuccessCount.get();
+    }
+
+    /**
+     * Gets the number of failed flushes.
+     *
+     * @return the number of failed flushes
+     */
+    public long getFlushFailureCount() {
+        return flushFailureCount.get();
     }
 }

--- a/src/main/java/com/aws/greengrass/logmanager/util/PeriodicBuffer.java
+++ b/src/main/java/com/aws/greengrass/logmanager/util/PeriodicBuffer.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.logmanager.util;
+
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.Map;
+
+/**
+ * Generic buffer that accumulates updates and flushes them periodically.
+ * This can be used for batching configuration updates or other operations
+ * that benefit from being grouped together.
+ *
+ * @param <K> Key type for the buffered items
+ * @param <V> Value type for the buffered items
+ */
+public class PeriodicBuffer<K, V> {
+    private static final Logger logger = LogManager.getLogger(PeriodicBuffer.class);
+
+    private final Map<K, V> buffer = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private final Consumer<Map<K, V>> flushHandler;
+    private final long intervalSeconds;
+    private final String bufferName;
+    private final Object bufferLock = new Object();
+
+    private ScheduledFuture<?> flushTask;
+    private volatile boolean isShutdown = false;
+
+    /**
+     * Creates a new periodic buffer.
+     *
+     * @param bufferName Name for logging purposes
+     * @param intervalSeconds How often to flush the buffer
+     * @param flushHandler Function to handle flushing buffered items
+     */
+    public PeriodicBuffer(String bufferName, long intervalSeconds, Consumer<Map<K, V>> flushHandler) {
+        this.bufferName = bufferName;
+        this.intervalSeconds = intervalSeconds;
+        this.flushHandler = flushHandler;
+    }
+
+    /**
+     * Starts the periodic flushing.
+     */
+    public void start() {
+        if (isShutdown) {
+            throw new IllegalStateException("Buffer has been shutdown");
+        }
+
+        flushTask = scheduler.scheduleAtFixedRate(
+                this::flush,
+                intervalSeconds,
+                intervalSeconds,
+                TimeUnit.SECONDS
+        );
+
+        logger.atInfo().log("Started periodic buffer '{}' with {}-second interval", bufferName, intervalSeconds);
+    }
+
+    /**
+     * Adds an item to the buffer.
+     *
+     * @param key The key
+     * @param value The value
+     */
+    public void put(K key, V value) {
+        if (isShutdown) {
+            logger.atWarn().log("Attempted to add to shutdown buffer '{}'", bufferName);
+            return;
+        }
+
+        synchronized (bufferLock) {
+            buffer.put(key, value);
+        }
+    }
+
+    /**
+     * Removes an item from the buffer.
+     *
+     * @param key The key to remove
+     */
+    public void remove(K key) {
+        synchronized (bufferLock) {
+            buffer.remove(key);
+        }
+    }
+
+    /**
+     * Manually triggers a flush of the buffer.
+     */
+    public void flush() {
+        synchronized (bufferLock) {
+            if (buffer.isEmpty()) {
+                return;
+            }
+
+            logger.atInfo().log("Flushing buffer '{}' with {} items", bufferName, buffer.size());
+
+            try {
+                // Create a copy to pass to the handler
+                Map<K, V> bufferCopy = new ConcurrentHashMap<>(buffer);
+                flushHandler.accept(bufferCopy);
+
+                // Clear the buffer after successful flush
+                buffer.clear();
+
+                logger.atDebug().log("Successfully flushed buffer '{}'", bufferName);
+            } catch (Exception e) {
+                logger.atError().cause(e).log("Failed to flush buffer '{}'", bufferName);
+            }
+        }
+    }
+
+    /**
+     * Returns the current size of the buffer.
+     */
+    public int size() {
+        synchronized (bufferLock) {
+            return buffer.size();
+        }
+    }
+
+    /**
+     * Checks if the buffer is empty.
+     */
+    public boolean isEmpty() {
+        synchronized (bufferLock) {
+            return buffer.isEmpty();
+        }
+    }
+
+    /**
+     * Shuts down the buffer, flushing any remaining items.
+     */
+    public void shutdown() {
+        if (isShutdown) {
+            return;
+        }
+
+        isShutdown = true;
+
+        // Cancel the scheduled task
+        if (flushTask != null) {
+            flushTask.cancel(false);
+        }
+
+        // Flush any remaining items
+        flush();
+
+        // Shutdown the scheduler
+        scheduler.shutdown();
+
+        logger.atInfo().log("Shutdown buffer '{}'", bufferName);
+    }
+}

--- a/src/main/java/com/aws/greengrass/logmanager/util/PeriodicBuffer.java
+++ b/src/main/java/com/aws/greengrass/logmanager/util/PeriodicBuffer.java
@@ -8,13 +8,13 @@ package com.aws.greengrass.logmanager.util;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.Map;
 
 /**
  * Generic buffer that accumulates updates and flushes them periodically.
@@ -51,7 +51,10 @@ public class PeriodicBuffer<K, V> {
     }
 
     /**
-     * Starts the periodic flushing.
+     * Starts the periodic buffer flushing operation.
+     * Initializes a scheduled task that flushes the buffer at fixed intervals.
+     *
+     * @throws IllegalStateException if the buffer has already been shutdown
      */
     public void start() {
         if (isShutdown) {

--- a/src/test/java/com/aws/greengrass/logmanager/util/PeriodicBufferTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/util/PeriodicBufferTest.java
@@ -1,0 +1,594 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.logmanager.util;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class PeriodicBufferTest {
+    
+    private PeriodicBuffer<String, String> buffer;
+    private final List<Map<String, String>> flushedData = Collections.synchronizedList(new ArrayList<>());
+    private final AtomicInteger flushCount = new AtomicInteger(0);
+    private final AtomicBoolean flushHandlerThrowsException = new AtomicBoolean(false);
+    private final AtomicBoolean flushHandlerThrowsRejectedExecutionException = new AtomicBoolean(false);
+    private Consumer<Map<String, String>> defaultFlushHandler;
+
+    @BeforeEach
+    void setUp() {
+        flushedData.clear();
+        flushCount.set(0);
+        flushHandlerThrowsException.set(false);
+        flushHandlerThrowsRejectedExecutionException.set(false);
+        
+        defaultFlushHandler = data -> {
+            if (flushHandlerThrowsRejectedExecutionException.get()) {
+                throw new RejectedExecutionException("Test rejected execution");
+            }
+            if (flushHandlerThrowsException.get()) {
+                throw new RuntimeException("Test exception");
+            }
+            flushedData.add(new ConcurrentHashMap<>(data));
+            flushCount.incrementAndGet();
+        };
+    }
+
+    @AfterEach
+    void shutDown() {
+        if (buffer != null) {
+            buffer.shutdown();
+        }
+    }
+
+    @Test
+    void testPutAndSize() {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        assertEquals(0, buffer.size());
+        assertTrue(buffer.isEmpty());
+
+        buffer.put("key1", "value1");
+        assertEquals(1, buffer.size());
+        assertFalse(buffer.isEmpty());
+
+        buffer.put("key2", "value2");
+        assertEquals(2, buffer.size());
+
+        buffer.put("key1", "updatedValue1");
+        assertEquals(2, buffer.size()); // Size should remain same after update
+    }
+
+    @Test
+    void testRemove() {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        buffer.put("key1", "value1");
+        buffer.put("key2", "value2");
+        assertEquals(2, buffer.size());
+
+        buffer.remove("key1");
+        assertEquals(1, buffer.size());
+
+        buffer.remove("nonExistentKey");
+        assertEquals(1, buffer.size());
+
+        buffer.remove("key2");
+        assertEquals(0, buffer.size());
+        assertTrue(buffer.isEmpty());
+    }
+
+    @Test
+    void testManualFlush() throws InterruptedException {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        buffer.put("key1", "value1");
+        buffer.put("key2", "value2");
+
+        buffer.flush();
+        
+        // Wait for flush to complete
+        Thread.sleep(100);
+
+        assertEquals(1, flushCount.get());
+        assertEquals(1, flushedData.size());
+        assertEquals(2, flushedData.get(0).size());
+        assertEquals("value1", flushedData.get(0).get("key1"));
+        assertEquals("value2", flushedData.get(0).get("key2"));
+
+        // Buffer should be empty after flush
+        assertEquals(0, buffer.size());
+    }
+
+    @Test
+    void testFlushEmptyBuffer() throws InterruptedException {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        buffer.flush();
+        
+        Thread.sleep(100);
+
+        // Flush handler should not be called for empty buffer
+        assertEquals(0, flushCount.get());
+        assertEquals(0, flushedData.size());
+    }
+
+    @Test
+    @Timeout(5)
+    void testPeriodicFlush() throws InterruptedException {
+        CountDownLatch flushLatch = new CountDownLatch(1);
+        Consumer<Map<String, String>> latchFlushHandler = data -> {
+            defaultFlushHandler.accept(data);
+            flushLatch.countDown();
+        };
+
+        buffer = new PeriodicBuffer<>("TestBuffer", 1, latchFlushHandler);
+        buffer.start();
+
+        buffer.put("key1", "value1");
+
+        // Wait for periodic flush (1 second)
+        assertTrue(flushLatch.await(2, TimeUnit.SECONDS));
+
+        assertEquals(1, flushCount.get());
+        assertEquals(1, flushedData.size());
+        assertEquals("value1", flushedData.get(0).get("key1"));
+    }
+
+    @Test
+    void testFlushHandlerRuntimeException() throws InterruptedException {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        buffer.put("key1", "value1");
+        flushHandlerThrowsException.set(true);
+
+        buffer.flush();
+        Thread.sleep(100);
+
+        // Items should be lost after runtime exception
+        assertEquals(0, buffer.size());
+        assertEquals(1, buffer.getFlushFailureCount());
+        assertEquals(0, buffer.getFlushSuccessCount());
+    }
+
+    @Test
+    void testFlushHandlerRejectedExecutionException() throws InterruptedException {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        buffer.put("key1", "value1");
+        buffer.put("key2", "value2");
+        flushHandlerThrowsRejectedExecutionException.set(true);
+
+        buffer.flush();
+        Thread.sleep(100);
+
+        // Items should be restored after RejectedExecutionException
+        assertEquals(2, buffer.size());
+        assertEquals(1, buffer.getFlushFailureCount());
+        assertEquals(0, buffer.getFlushSuccessCount());
+
+        // Verify items can be flushed successfully later
+        flushHandlerThrowsRejectedExecutionException.set(false);
+        buffer.flush();
+        Thread.sleep(100);
+
+        assertEquals(0, buffer.size());
+        assertEquals(1, buffer.getFlushSuccessCount());
+    }
+
+    @Test
+    void testShutdownFlushesRemainingItems() throws InterruptedException {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        buffer.put("key1", "value1");
+        buffer.put("key2", "value2");
+
+        buffer.shutdown();
+
+        // Shutdown should flush remaining items
+        assertEquals(1, flushCount.get());
+        assertEquals(1, flushedData.size());
+        assertEquals(2, flushedData.get(0).size());
+    }
+
+    @Test
+    void testShutdownPreventsNewItems() {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        buffer.shutdown();
+
+        // Should not throw but should not add item either
+        buffer.put("key1", "value1");
+        
+        // Manual flush after shutdown should not do anything
+        buffer.flush();
+        
+        assertEquals(0, flushCount.get());
+    }
+
+    @Test
+    void testMultipleShutdownCalls() {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        buffer.put("key1", "value1");
+
+        buffer.shutdown();
+        int firstFlushCount = flushCount.get();
+
+        // Second shutdown should be idempotent
+        buffer.shutdown();
+        assertEquals(firstFlushCount, flushCount.get());
+    }
+
+    @Test
+    void testStartAfterShutdown() {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+        buffer.shutdown();
+
+        assertThrows(IllegalStateException.class, () -> buffer.start());
+    }
+
+    @Test
+    void testConcurrentPutOperations() throws InterruptedException {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        int threadCount = 10;
+        int itemsPerThread = 100;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch completeLatch = new CountDownLatch(threadCount);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    for (int j = 0; j < itemsPerThread; j++) {
+                        buffer.put("thread" + threadId + "-key" + j, "value" + j);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    completeLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue(completeLatch.await(5, TimeUnit.SECONDS));
+
+        buffer.flush();
+        Thread.sleep(100);
+
+        // All items should be flushed
+        assertEquals(1, flushCount.get());
+        assertEquals(threadCount * itemsPerThread, flushedData.get(0).size());
+
+        executor.shutdown();
+    }
+
+    @Test
+    void testConcurrentPutAndRemove() throws InterruptedException {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        int operationCount = 1000;
+        CountDownLatch completeLatch = new CountDownLatch(2);
+
+        Thread putThread = new Thread(() -> {
+            for (int i = 0; i < operationCount; i++) {
+                buffer.put("key" + (i % 10), "value" + i);
+            }
+            completeLatch.countDown();
+        });
+
+        Thread removeThread = new Thread(() -> {
+            for (int i = 0; i < operationCount; i++) {
+                buffer.remove("key" + (i % 10));
+            }
+            completeLatch.countDown();
+        });
+
+        putThread.start();
+        removeThread.start();
+
+        assertTrue(completeLatch.await(5, TimeUnit.SECONDS));
+
+        // Size should be small due to constant put/remove on same keys
+        assertTrue(buffer.size() <= 10);
+    }
+
+    @Test
+    void testFlushDuringConcurrentModification() throws InterruptedException {
+        AtomicReference<Exception> flushException = new AtomicReference<>();
+        Consumer<Map<String, String>> safeFlushHandler = data -> {
+            try {
+                // Simulate processing time
+                Thread.sleep(50);
+                defaultFlushHandler.accept(data);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                flushException.set(e);
+            }
+        };
+
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, safeFlushHandler);
+        buffer.start();
+
+        // Pre-populate buffer
+        for (int i = 0; i < 100; i++) {
+            buffer.put("key" + i, "value" + i);
+        }
+
+        CountDownLatch flushStarted = new CountDownLatch(1);
+        CountDownLatch modificationComplete = new CountDownLatch(1);
+
+        Thread flushThread = new Thread(() -> {
+            flushStarted.countDown();
+            buffer.flush();
+        });
+
+        Thread modificationThread = new Thread(() -> {
+            try {
+                flushStarted.await();
+                // Try to modify buffer during flush
+                for (int i = 100; i < 200; i++) {
+                    buffer.put("key" + i, "value" + i);
+                    if (i % 10 == 0) {
+                        buffer.remove("key" + (i - 50));
+                    }
+                }
+                modificationComplete.countDown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        flushThread.start();
+        modificationThread.start();
+
+        flushThread.join(5000);
+        assertTrue(modificationComplete.await(5, TimeUnit.SECONDS));
+
+        // Verify no exceptions occurred
+        if (flushException.get() != null) {
+            fail("Exception during flush: " + flushException.get());
+        }
+
+        // First flush should have the original 100 items
+        assertEquals(1, flushedData.size());
+        assertEquals(100, flushedData.get(0).size());
+
+        // Buffer should contain new items added during flush
+        assertTrue(buffer.size() > 0);
+    }
+
+    @Test
+    void testFlushStatistics() throws InterruptedException {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        assertEquals(0, buffer.getFlushSuccessCount());
+        assertEquals(0, buffer.getFlushFailureCount());
+
+        // Successful flush
+        buffer.put("key1", "value1");
+        buffer.flush();
+        Thread.sleep(100);
+        assertEquals(1, buffer.getFlushSuccessCount());
+        assertEquals(0, buffer.getFlushFailureCount());
+
+        // Failed flush
+        buffer.put("key2", "value2");
+        flushHandlerThrowsException.set(true);
+        buffer.flush();
+        Thread.sleep(100);
+        assertEquals(1, buffer.getFlushSuccessCount());
+        assertEquals(1, buffer.getFlushFailureCount());
+
+        // Another successful flush
+        flushHandlerThrowsException.set(false);
+        buffer.put("key3", "value3");
+        buffer.flush();
+        Thread.sleep(100);
+        assertEquals(2, buffer.getFlushSuccessCount());
+        assertEquals(1, buffer.getFlushFailureCount());
+    }
+
+    @Test
+    void testConcurrentFlushSkipping() throws InterruptedException {
+        CountDownLatch flushInProgress = new CountDownLatch(1);
+        CountDownLatch secondFlushAttempted = new CountDownLatch(1);
+        AtomicInteger actualFlushCount = new AtomicInteger(0);
+        
+        Consumer<Map<String, String>> slowFlushHandler = data -> {
+            try {
+                actualFlushCount.incrementAndGet();
+                flushInProgress.countDown();
+                Thread.sleep(500); // Simulate slow flush
+                defaultFlushHandler.accept(data);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, slowFlushHandler);
+        buffer.start();
+
+        buffer.put("key1", "value1");
+
+        // Start first flush in separate thread
+        Thread firstFlush = new Thread(() -> buffer.flush());
+        firstFlush.start();
+
+        // Wait for first flush to start
+        assertTrue(flushInProgress.await(1, TimeUnit.SECONDS));
+
+        // Try second flush while first is in progress
+        Thread secondFlush = new Thread(() -> {
+            buffer.flush();
+            secondFlushAttempted.countDown();
+        });
+        secondFlush.start();
+
+        assertTrue(secondFlushAttempted.await(1, TimeUnit.SECONDS));
+        firstFlush.join(2000);
+        secondFlush.join(2000);
+
+        // Only one actual flush should have occurred
+        assertEquals(1, actualFlushCount.get());
+        assertEquals(1, flushCount.get());
+    }
+
+    @Test
+    void testBufferSwapping() throws InterruptedException {
+        CountDownLatch flushStarted = new CountDownLatch(1);
+        CountDownLatch continueFlush = new CountDownLatch(1);
+        AtomicReference<Map<String, String>> capturedBuffer = new AtomicReference<>();
+
+        Consumer<Map<String, String>> capturingFlushHandler = data -> {
+            capturedBuffer.set(new ConcurrentHashMap<>(data)); // Make a copy to avoid reference issues
+            flushStarted.countDown(); // Signal that flush has started and buffer is captured
+            try {
+                // Wait for test thread to add new items
+                assertTrue(continueFlush.await(2, TimeUnit.SECONDS));
+                Thread.sleep(50); // Brief processing time
+                defaultFlushHandler.accept(data);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted during flush", e);
+            }
+        };
+
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, capturingFlushHandler);
+        buffer.start();
+
+        buffer.put("key1", "value1");
+
+        Thread flushThread = new Thread(() -> buffer.flush());
+        flushThread.start();
+
+        // Wait for flush to start and capture the buffer
+        assertTrue(flushStarted.await(2, TimeUnit.SECONDS));
+
+        // Add new items while flush is processing old buffer
+        buffer.put("key2", "value2");
+        assertEquals(1, buffer.size()); // New buffer should have the new item
+
+        // Allow flush to continue
+        continueFlush.countDown();
+        
+        flushThread.join(3000);
+
+        // Verify the flushed data only contains the old item
+        assertNotNull(capturedBuffer.get());
+        assertEquals(1, capturedBuffer.get().size());
+        assertTrue(capturedBuffer.get().containsKey("key1"));
+        assertFalse(capturedBuffer.get().containsKey("key2"));
+
+        // Verify buffer still contains the new item
+        assertEquals(1, buffer.size());
+    }
+
+    @Test
+    @Timeout(5)
+    void testShutdownWithEmptyBufferDoesNotDeadlock() throws InterruptedException {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        // First, trigger a flush on an empty buffer to simulate the bug
+        buffer.flush();
+        Thread.sleep(100);
+
+        // Now try to shutdown - this should not hang
+        buffer.shutdown();
+
+        // If we reach here, shutdown completed successfully
+        // The test passing without timeout is the assertion
+    }
+
+    @Test
+    @Timeout(5)
+    void testConcurrentEmptyFlushAndShutdown() throws InterruptedException {
+        buffer = new PeriodicBuffer<>("TestBuffer", 60, defaultFlushHandler);
+        buffer.start();
+
+        // Create multiple threads that will flush empty buffer
+        int threadCount = 5;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch flushLatch = new CountDownLatch(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount + 1);
+
+        // Start threads that will flush empty buffer
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    buffer.flush();
+                    flushLatch.countDown();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        // Start shutdown thread
+        executor.submit(() -> {
+            try {
+                startLatch.await();
+                Thread.sleep(200); // Let some flushes happen first
+                buffer.shutdown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        // Release all threads
+        startLatch.countDown();
+
+        // Wait for all flushes to complete
+        assertTrue(flushLatch.await(3, TimeUnit.SECONDS));
+
+        // Shutdown should also complete without hanging
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(3, TimeUnit.SECONDS));
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Buffer:
Added configurable buffer interval seconds via the `bufferIntervalSec` configuration parameter. The buffer accumulates log processing state updates and flushes them to config.tlog periodically. 

Implementation of Buffer:
PeriodicBuffer class uses ScheduledExecutorService to control the periodic flush action.

Implementation of Buffer on LogManager:
The buffer in LogManager is a duplication Map of both `lastComponentUploadedLogFileInstantMap` and `processingFilesInformation`, the buffer is initialized from the constructor, taking the default value `periodicUploadIntervalSec`. When upload logs finished, the buffer copies the value from updated maps, which stores the Log information for each component. When the times up, then flush the current buffers to config.tlog

**Why is this change necessary:**
This change improves system performance by allowing customers to control how frequently  log processing state is persisted to disk. By setting appropriate buffer intervals, customers can reduce disk I/O operations while ensuring log processing state is preserved at reasonable intervals.

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
