### PR TITLE
feat: add configurable buffered config update persistence for cloud w…

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallPeriodicIntervalUserComponentConfig.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/logmanager/smallPeriodicIntervalUserComponentConfig.yaml
@@ -3,6 +3,7 @@ services:
   aws.greengrass.LogManager:
     configuration:
       periodicUploadIntervalSec: 10
+      updateToTlogIntervalSec: 20
       logsUploaderConfiguration:
         componentLogsConfiguration:
           - componentName: 'UserComponentA'


### PR DESCRIPTION
…atch upload

**Issue #, if available:**

**Description of changes:**
Before, we update the config map right after each cloudwatch upload, each config map update will result a config tlog write operation, which causes a lot of disk I/O usage
With this implementation, we added a timer before each config map update and only update the config map once the timer is up. The timer is configurable.

1. Added new configurable parameter to control the timer interval
2. Update the configuration map during shutdown

**Why is this change necessary:**
This change provides a more flexible way to update the config map and further reduce the disk I/O usage

**How was this change tested:**
Integration test

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [X] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
