### PR TITLE
Fix script injection GitHub actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -56,13 +56,16 @@ jobs:
       - name: Convert Jacoco integ test report to Cobertura
         run: python3 .github/scripts/cover2cover.py target/jacoco-report/jacoco-it/jacoco.xml src/main/java > target/jacoco-report/cobertura-it.xml
       - name: Save PR number
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-          PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           mkdir -p ./pr/jacoco-report
-          echo "$PR_NUMBER" | tr -cd '0-9' > ./pr/NR
-          echo "$PR_SHA" | tr -cd 'a-fA-F0-9' > ./pr/SHA
+
+          # Safely extract and sanitize PR number using GITHUB_EVENT_PATH
+          PR_NUMBER=$(jq -r '.number // empty' "$GITHUB_EVENT_PATH" | tr -cd '0-9')
+          echo "$PR_NUMBER" > ./pr/NR
+
+          # Safely extract and sanitize PR SHA using GITHUB_EVENT_PATH
+          PR_SHA=$(jq -r '.pull_request.head.sha // empty' "$GITHUB_EVENT_PATH" | tr -cd 'a-fA-F0-9')
+          echo "$PR_SHA" > ./pr/SHA
 
           cp target/jacoco-report/cobertura.xml ./pr/jacoco-report/cobertura.xml
           cp target/jacoco-report/cobertura-it.xml ./pr/jacoco-report/cobertura-it.xml


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This commit fixes a script injection vulnerability in the GitHub Actions workflow by changing how PR number and SHA are extracted. Instead of directly interpolating `${{ github.event.* }}` expressions (which can be exploited by malicious input), it now safely reads from the `$GITHUB_EVENT_PATH` JSON file using `jq`. The values are still sanitized with `tr` to strip unwanted characters before being written to files.

**Why is this change necessary:**
When GitHub Actions expressions like `${{ github.event.pull_request.head.sha }}` are interpolated directly into shell scripts or environment variables, an attacker who controls the value (e.g., via a crafted PR branch name or title) could inject malicious shell commands that execute during the workflow run. This is a well-known GitHub Actions vulnerability called "script injection."

By reading from `$GITHUB_EVENT_PATH` and parsing with `jq`, the data is treated as a literal string rather than being interpreted by the shell—preventing any embedded commands from executing. This is the recommended mitigation from GitHub's security documentation for handling untrusted input in workflows.
**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
