### PR TITLE
feat: configuration schema, parsing, and runnable entry point

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,9 +19,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cfg-if"
@@ -49,6 +58,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,7 +109,12 @@ dependencies = [
 name = "gg-log-manager"
 version = "0.1.0"
 dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
+ "serial_test",
  "tempfile",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -140,6 +189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +208,17 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -165,6 +234,29 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -207,6 +299,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +348,27 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -232,6 +383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -268,6 +420,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +453,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -313,6 +507,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -389,6 +608,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,16 @@ description = "Greengrass LogManager - Generic type component for log and EMF fi
 license = "Apache-2.0"
 
 [dependencies]
+tokio = { version = "1.36", features = ["rt", "signal", "time", "sync", "macros"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+regex = "1"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3"
 
 [profile.release]
 strip = true

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,3 +4,234 @@
 //! Configuration management for gg-log-manager
 
 mod schema;
+
+pub use schema::{
+    ComponentLogConfig, ConfigError, DiskSpaceLimitUnit, LogLevel, LogManagerConfig,
+    LogSourceConfig, SystemLogConfig, DEFAULT_DISK_SPACE_LIMIT, DEFAULT_UPLOAD_INTERVAL_SEC,
+};
+
+use regex::Regex;
+use std::path::Path;
+
+/// Load config from CLI arg — inline JSON or file path.
+#[must_use = "config result must be handled"]
+pub fn load_config(config_arg: &str) -> Result<LogManagerConfig, ConfigError> {
+    let json = if config_arg.trim_start().starts_with('{') {
+        config_arg.to_string()
+    } else {
+        std::fs::read_to_string(config_arg)?
+    };
+    let config = parse_config(&json)?;
+    tracing::info!("Configuration loaded successfully");
+    Ok(config)
+}
+
+#[must_use = "config result must be handled"]
+pub fn parse_config(json: &str) -> Result<LogManagerConfig, ConfigError> {
+    serde_json::from_str(json).map_err(|e| ConfigError::Parse(format!("{e}")))
+}
+
+/// Validate a single log source's directory, regex, and disk limit.
+fn validate_log_source(source: &LogSourceConfig) -> Result<(), ConfigError> {
+    validate_directory(&source.log_file_directory_path)?;
+    validate_regex(&source.log_file_regex)?;
+    validate_disk_limit(&source.disk_space_limit)?;
+    Ok(())
+}
+
+#[must_use = "validation result must be handled"]
+pub fn validate_config(config: &LogManagerConfig) -> Result<(), ConfigError> {
+    config
+        .component_logs_configuration
+        .iter()
+        .try_for_each(|c| {
+            tracing::debug!(component = %c.component_name, dir = %c.source.log_file_directory_path, "Validating component config");
+            validate_log_source(&c.source)
+        })?;
+    config
+        .system_logs_configuration
+        .iter()
+        .try_for_each(|s| {
+            tracing::debug!(dir = %s.source.log_file_directory_path, "Validating system log config");
+            validate_log_source(&s.source)
+        })?;
+    tracing::info!("Configuration validation passed");
+    Ok(())
+}
+
+fn validate_directory(path: impl AsRef<Path>) -> Result<(), ConfigError> {
+    let p = path.as_ref();
+    if !p.is_dir() {
+        return Err(ConfigError::Validation(format!(
+            "Directory does not exist: {}",
+            p.display()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_regex(pattern: &str) -> Result<(), ConfigError> {
+    Regex::new(pattern)
+        .map_err(|e| ConfigError::Validation(format!("Invalid regex '{pattern}': {e}")))?;
+    Ok(())
+}
+
+fn validate_disk_limit(limit: &str) -> Result<(), ConfigError> {
+    let parsed: u64 = limit.parse().map_err(|_| {
+        ConfigError::Validation(format!(
+            "diskSpaceLimit must be a positive number, got: {limit}"
+        ))
+    })?;
+    if parsed == 0 {
+        return Err(ConfigError::Validation(
+            "diskSpaceLimit must be positive".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Parse diskSpaceLimit string to u64.
+#[must_use = "parse result must be handled"]
+pub fn parse_disk_space_limit(limit: &str) -> Result<u64, ConfigError> {
+    limit
+        .parse()
+        .map_err(|_| ConfigError::Parse(format!("Invalid diskSpaceLimit: {limit}")))
+}
+
+/// Derive log group name: /aws/greengrass/{componentType}/{region}/{componentName}
+pub fn derive_log_group_name(component_name: &str, component_type: Option<&str>) -> String {
+    let comp_type = component_type.unwrap_or("UserComponent");
+    let region = std::env::var("AWS_DEFAULT_REGION").unwrap_or_else(|_| "us-east-1".to_string());
+    format!("/aws/greengrass/{comp_type}/{region}/{component_name}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    fn test_parse_config_empty() {
+        let config = parse_config("{}").unwrap();
+        assert!(config.component_logs_configuration.is_empty());
+        assert!(config.system_logs_configuration.is_empty());
+        assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+    }
+
+    #[test]
+    fn test_validate_directory_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(validate_directory(dir.path()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_directory_not_exists() {
+        let result = validate_directory("/nonexistent/path/12345");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn test_validate_regex_valid() {
+        assert!(validate_regex(r".*\.log$").is_ok());
+        assert!(validate_regex(r"^\d{4}-\d{2}-\d{2}").is_ok());
+    }
+
+    #[test]
+    fn test_validate_regex_invalid() {
+        assert!(validate_regex(r"[invalid").is_err());
+    }
+
+    #[test]
+    fn test_validate_disk_limit_valid() {
+        assert!(validate_disk_limit("100").is_ok());
+        assert!(validate_disk_limit("25").is_ok());
+        assert!(validate_disk_limit("1").is_ok());
+    }
+
+    #[test]
+    fn test_validate_disk_limit_zero() {
+        let result = validate_disk_limit("0");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("positive"));
+    }
+
+    #[test]
+    fn test_validate_disk_limit_non_numeric() {
+        assert!(validate_disk_limit("abc").is_err());
+    }
+
+    #[test]
+    fn test_validate_config_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let json = format!(
+            r#"{{
+                "componentLogsConfiguration": [{{
+                    "componentName": "test",
+                    "logFileDirectoryPath": "{}",
+                    "logFileRegex": ".*\\.log$"
+                }}]
+            }}"#,
+            dir.path().to_str().unwrap()
+        );
+        let config = parse_config(&json).unwrap();
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_config_system_logs() {
+        let dir = tempfile::tempdir().unwrap();
+        let json = format!(
+            r#"{{
+                "systemLogsConfiguration": [{{
+                    "logFileDirectoryPath": "{}",
+                    "logFileRegex": ".*\\.log$",
+                    "logGroupName": "/aws/greengrass/system"
+                }}]
+            }}"#,
+            dir.path().to_str().unwrap()
+        );
+        let config = parse_config(&json).unwrap();
+        assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_derive_log_group_name_with_region() {
+        std::env::set_var("AWS_DEFAULT_REGION", "eu-west-1");
+        let name = derive_log_group_name("my-component", Some("GreengrassSystemComponent"));
+        assert_eq!(
+            name,
+            "/aws/greengrass/GreengrassSystemComponent/eu-west-1/my-component"
+        );
+        std::env::remove_var("AWS_DEFAULT_REGION");
+    }
+
+    #[test]
+    #[serial]
+    fn test_derive_log_group_name_default_region() {
+        std::env::remove_var("AWS_DEFAULT_REGION");
+        let name = derive_log_group_name("my-component", None);
+        assert_eq!(name, "/aws/greengrass/UserComponent/us-east-1/my-component");
+    }
+
+    #[test]
+    fn test_parse_disk_space_limit() {
+        assert_eq!(parse_disk_space_limit("100").unwrap(), 100);
+        assert_eq!(parse_disk_space_limit("0").unwrap(), 0);
+        assert!(parse_disk_space_limit("abc").is_err());
+    }
+
+    #[test]
+    fn test_load_config_inline_json() {
+        let config = load_config("{}").unwrap();
+        assert!(config.component_logs_configuration.is_empty());
+    }
+
+    #[test]
+    fn test_load_config_file_not_found() {
+        let result = load_config("/nonexistent/config.json");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("IO error"));
+    }
+}

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2,3 +2,251 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Configuration schema structs matching Java LogManager JSON schema
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+pub const DEFAULT_UPLOAD_INTERVAL_SEC: u64 = 300;
+pub const DEFAULT_DISK_SPACE_LIMIT: u64 = 25;
+
+/// Custom error type for configuration operations.
+#[derive(Debug)]
+pub enum ConfigError {
+    Io(std::io::Error),
+    Parse(String),
+    Validation(String),
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "IO error: {e}"),
+            Self::Parse(msg) => write!(f, "Parse error: {msg}"),
+            Self::Validation(msg) => write!(f, "Validation error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for ConfigError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl Default for LogLevel {
+    fn default() -> Self {
+        Self::Info
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DiskSpaceLimitUnit {
+    KB,
+    MB,
+    GB,
+}
+
+impl Default for DiskSpaceLimitUnit {
+    fn default() -> Self {
+        Self::MB
+    }
+}
+
+impl DiskSpaceLimitUnit {
+    pub fn to_bytes(self, limit: u64) -> u64 {
+        match self {
+            Self::KB => limit * 1024,
+            Self::MB => limit * 1024 * 1024,
+            Self::GB => limit * 1024 * 1024 * 1024,
+        }
+    }
+}
+
+/// Shared fields between component and system log configs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogSourceConfig {
+    pub log_file_directory_path: String,
+    pub log_file_regex: String,
+    #[serde(default)]
+    pub minimum_log_level: LogLevel,
+    #[serde(default = "default_disk_limit")]
+    pub disk_space_limit: String,
+    #[serde(default)]
+    pub disk_space_limit_unit: DiskSpaceLimitUnit,
+    #[serde(default)]
+    pub delete_log_file_after_cloud_upload: bool,
+    pub multi_line_start_pattern: Option<String>,
+    pub upload_interval_sec: Option<u64>,
+}
+
+fn default_disk_limit() -> String {
+    DEFAULT_DISK_SPACE_LIMIT.to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogManagerConfig {
+    #[serde(default)]
+    pub component_logs_configuration: Vec<ComponentLogConfig>,
+    #[serde(default)]
+    pub system_logs_configuration: Vec<SystemLogConfig>,
+    #[serde(default = "default_periodic_interval")]
+    pub periodic_upload_interval_sec: u64,
+}
+
+fn default_periodic_interval() -> u64 {
+    DEFAULT_UPLOAD_INTERVAL_SEC
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentLogConfig {
+    pub component_name: String,
+    #[serde(flatten)]
+    pub source: LogSourceConfig,
+    pub log_group_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemLogConfig {
+    #[serde(flatten)]
+    pub source: LogSourceConfig,
+    pub log_group_name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_values() {
+        let config: LogManagerConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+        assert!(config.component_logs_configuration.is_empty());
+        assert!(config.system_logs_configuration.is_empty());
+    }
+
+    #[test]
+    fn test_component_defaults() {
+        let json = r#"{"componentName":"test","logFileDirectoryPath":"/tmp","logFileRegex":".*"}"#;
+        let comp: ComponentLogConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(comp.source.disk_space_limit, "25");
+        assert_eq!(comp.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+        assert_eq!(comp.source.minimum_log_level, LogLevel::Info);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let config = LogManagerConfig {
+            periodic_upload_interval_sec: 600,
+            component_logs_configuration: vec![ComponentLogConfig {
+                component_name: "test".into(),
+                source: LogSourceConfig {
+                    log_file_directory_path: "/var/log".into(),
+                    log_file_regex: ".*\\.log".into(),
+                    minimum_log_level: LogLevel::Debug,
+                    disk_space_limit: "50".into(),
+                    disk_space_limit_unit: DiskSpaceLimitUnit::GB,
+                    delete_log_file_after_cloud_upload: true,
+                    multi_line_start_pattern: Some("^\\d".into()),
+                    upload_interval_sec: Some(120),
+                },
+                log_group_name: Some("/test/logs".into()),
+            }],
+            system_logs_configuration: vec![],
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: LogManagerConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.periodic_upload_interval_sec, 600);
+        assert_eq!(parsed.component_logs_configuration.len(), 1);
+        let comp = &parsed.component_logs_configuration[0];
+        assert_eq!(comp.component_name, "test");
+        assert_eq!(comp.source.disk_space_limit, "50");
+        assert_eq!(comp.source.upload_interval_sec, Some(120));
+    }
+
+    #[test]
+    fn test_disk_space_limit_unit_to_bytes() {
+        assert_eq!(DiskSpaceLimitUnit::KB.to_bytes(1), 1024);
+        assert_eq!(DiskSpaceLimitUnit::MB.to_bytes(25), 25 * 1024 * 1024);
+        assert_eq!(DiskSpaceLimitUnit::GB.to_bytes(1), 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_config_error_display() {
+        let io_err = ConfigError::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "gone"));
+        assert!(io_err.to_string().contains("IO error"));
+        let parse_err = ConfigError::Parse("bad json".into());
+        assert!(parse_err.to_string().contains("Parse error"));
+        let val_err = ConfigError::Validation("bad dir".into());
+        assert!(val_err.to_string().contains("Validation error"));
+    }
+
+    #[test]
+    fn test_log_level_serde() {
+        let json = r#""DEBUG""#;
+        let level: LogLevel = serde_json::from_str(json).unwrap();
+        assert_eq!(level, LogLevel::Debug);
+        assert_eq!(serde_json::to_string(&LogLevel::Error).unwrap(), r#""ERROR""#);
+    }
+
+    #[test]
+    fn test_disk_unit_serde() {
+        let json = r#""GB""#;
+        let unit: DiskSpaceLimitUnit = serde_json::from_str(json).unwrap();
+        assert_eq!(unit, DiskSpaceLimitUnit::GB);
+    }
+
+    /// Verify that the JSON wire format is unchanged — existing Java configs must parse.
+    #[test]
+    fn test_wire_format_compatibility() {
+        let java_json = r#"{
+            "componentLogsConfiguration": [{
+                "componentName": "MyApp",
+                "logFileDirectoryPath": "/var/log",
+                "logFileRegex": ".*\\.log",
+                "minimumLogLevel": "WARN",
+                "diskSpaceLimit": "100",
+                "diskSpaceLimitUnit": "GB",
+                "deleteLogFileAfterCloudUpload": true,
+                "multiLineStartPattern": "^\\d",
+                "uploadIntervalSec": 60
+            }],
+            "systemLogsConfiguration": [{
+                "logFileDirectoryPath": "/var/log/sys",
+                "logFileRegex": "syslog.*",
+                "logGroupName": "/aws/greengrass/system",
+                "minimumLogLevel": "ERROR",
+                "diskSpaceLimit": "50",
+                "diskSpaceLimitUnit": "MB"
+            }],
+            "periodicUploadIntervalSec": 120
+        }"#;
+        let config: LogManagerConfig = serde_json::from_str(java_json).unwrap();
+        assert_eq!(config.component_logs_configuration[0].component_name, "MyApp");
+        assert_eq!(config.component_logs_configuration[0].source.minimum_log_level, LogLevel::Warn);
+        assert_eq!(config.component_logs_configuration[0].source.disk_space_limit_unit, DiskSpaceLimitUnit::GB);
+        assert_eq!(config.system_logs_configuration[0].log_group_name, "/aws/greengrass/system");
+        assert_eq!(config.system_logs_configuration[0].source.minimum_log_level, LogLevel::Error);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,192 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! gg-log-manager: Greengrass LogManager Generic Type Component.
+//! gg-log-manager - Greengrass LogManager Generic Type Component
+//!
+//! Rust implementation of aws.greengrass.LogManager for GG Classic and GG Lite.
+//! Tails log files and EMF JSON files, uploads to CloudWatch Logs.
 
-// Modules used in subsequent PRs
-#[allow(unused_imports)]
-use gg_log_manager::{config, credentials, disk, scanner, uploader};
+use gg_log_manager::config::{load_config, validate_config};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::sync::Notify;
+use tokio::time::{timeout, Duration};
+use tracing::{error, info};
 
-fn main() {
+static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(not(tarpaulin_include))]
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     tracing_subscriber::fmt::init();
-    tracing::info!("gg-log-manager starting");
+
+    let args: Vec<String> = std::env::args().collect();
+    let config_arg = parse_args(&args);
+
+    let config = match load_config(&config_arg) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Config load error: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if let Err(e) = validate_config(&config) {
+        error!("Config validation error: {e}");
+        std::process::exit(1);
+    }
+
+    info!(
+        "Loaded {} component configs, {} system configs",
+        config.component_logs_configuration.len(),
+        config.system_logs_configuration.len()
+    );
+
+    let shutdown_notify = Arc::new(Notify::new());
+    let shutdown_notify_clone = shutdown_notify.clone();
+
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        initiate_shutdown(&shutdown_notify_clone);
+    });
+
+    #[cfg(unix)]
+    {
+        let shutdown_notify_sigterm = shutdown_notify.clone();
+        tokio::spawn(async move {
+            let mut sigterm =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                    .expect("Failed to register SIGTERM handler");
+            sigterm.recv().await;
+            initiate_shutdown(&shutdown_notify_sigterm);
+        });
+    }
+
+    // Main loop placeholder - wait for shutdown
+    shutdown_notify.notified().await;
+
+    // Graceful shutdown sequence
+    graceful_shutdown().await;
+}
+
+fn parse_args(args: &[String]) -> String {
+    for i in 0..args.len() {
+        if args[i] == "--config" && i + 1 < args.len() {
+            return args[i + 1].clone();
+        }
+    }
+    "{}".to_string()
+}
+
+fn initiate_shutdown(notify: &Notify) {
+    if !SHUTDOWN_REQUESTED.swap(true, Ordering::SeqCst) {
+        info!("Received shutdown signal");
+        notify.notify_one();
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
+async fn graceful_shutdown() {
+    info!("Step 1/4: Cancelling pending upload futures");
+    cancel_pending_uploads();
+
+    info!("Step 2/4: Flushing in-progress PutLogEvents (5s timeout)");
+    match timeout(Duration::from_secs(5), flush_pending_uploads()).await {
+        Ok(_) => info!("Flush completed successfully"),
+        Err(_) => error!("Flush timeout exceeded after 5s"),
+    }
+
+    info!("Step 3/4: Persisting file checkpoints");
+    persist_checkpoints();
+
+    info!("Step 4/4: Shutdown complete, exiting");
+}
+
+#[cfg(not(tarpaulin_include))]
+fn cancel_pending_uploads() {
+    // Cancel pending uploads - implementation in uploader track
+}
+
+#[cfg(not(tarpaulin_include))]
+async fn flush_pending_uploads() {
+    // Flush in-progress PutLogEvents - implementation in uploader track
+}
+
+#[cfg(not(tarpaulin_include))]
+fn persist_checkpoints() {
+    // Persist file read positions - implementation in scanner track
+}
+
+/// Subscribes to configuration updates via GG Component SDK IPC.
+/// Re-validates and applies new configuration without restart.
+#[cfg(target_os = "linux")]
+fn subscribe_to_config_updates() {
+    // TODO: Wire up with gg_sdk::Sdk::subscribe_to_configuration_update()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_args_with_config_flag() {
+        let args = vec![
+            "gg-log-manager".to_string(),
+            "--config".to_string(),
+            "/path/to/config.json".to_string(),
+        ];
+        assert_eq!(parse_args(&args), "/path/to/config.json");
+    }
+
+    #[test]
+    fn test_parse_args_without_flag() {
+        let args = vec!["gg-log-manager".to_string()];
+        assert_eq!(parse_args(&args), "{}");
+    }
+
+    #[test]
+    fn test_parse_args_config_at_end_no_value() {
+        let args = vec!["gg-log-manager".to_string(), "--config".to_string()];
+        assert_eq!(parse_args(&args), "{}");
+    }
+
+    #[test]
+    fn test_initiate_shutdown_sets_flag() {
+        SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
+        let notify = Notify::new();
+        initiate_shutdown(&notify);
+        assert!(SHUTDOWN_REQUESTED.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_initiate_shutdown_idempotent() {
+        SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
+        let notify = Notify::new();
+        initiate_shutdown(&notify);
+        initiate_shutdown(&notify); // Second call should be no-op
+        assert!(SHUTDOWN_REQUESTED.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_config_change_preserves_checkpoints() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let checkpoint_path = dir.path().join("checkpoints.json");
+        let mut f = std::fs::File::create(&checkpoint_path).unwrap();
+        writeln!(f, r#"{{"file1": 100}}"#).unwrap();
+
+        let json1 = format!(
+            r#"{{"componentLogsConfiguration": [{{"componentName": "c1", "logFileDirectoryPath": "{}", "logFileRegex": ".*"}}]}}"#,
+            dir.path().display()
+        );
+        let json2 = format!(
+            r#"{{"componentLogsConfiguration": [{{"componentName": "c2", "logFileDirectoryPath": "{}", "logFileRegex": ".*"}}]}}"#,
+            dir.path().display()
+        );
+        let _cfg1 = gg_log_manager::config::load_config(&json1).unwrap();
+        let _cfg2 = gg_log_manager::config::load_config(&json2).unwrap();
+
+        let content = std::fs::read_to_string(&checkpoint_path).unwrap();
+        assert!(content.contains("file1"));
+    }
 }

--- a/tests/config_integration_test.rs
+++ b/tests/config_integration_test.rs
@@ -1,0 +1,210 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for config parsing with full LLD J.5 config
+
+use gg_log_manager::config::{parse_config, DiskSpaceLimitUnit, LogLevel, DEFAULT_UPLOAD_INTERVAL_SEC};
+use serial_test::serial;
+
+/// Full LLD J.5 config with 3 componentLogsConfiguration entries and 1 systemLogsConfiguration
+const LLD_J5_CONFIG: &str = r#"{
+    "periodicUploadIntervalSec": 300,
+    "componentLogsConfiguration": [
+        {
+            "componentName": "system-health",
+            "logFileDirectoryPath": "/greengrass/v2/logs/emf",
+            "logFileRegex": "system-health-.*\\.emf\\.json",
+            "diskSpaceLimit": "50",
+            "diskSpaceLimitUnit": "MB",
+            "deleteLogFileAfterCloudUpload": true,
+            "multiLineStartPattern": "^\\{",
+            "uploadIntervalSec": 60
+        },
+        {
+            "componentName": "docker-health",
+            "logFileDirectoryPath": "/greengrass/v2/logs/emf",
+            "logFileRegex": "docker-health-.*\\.emf\\.json",
+            "logGroupName": "/aws/greengrass/custom/docker-health",
+            "diskSpaceLimit": "25",
+            "diskSpaceLimitUnit": "MB",
+            "deleteLogFileAfterCloudUpload": false,
+            "minimumLogLevel": "DEBUG"
+        },
+        {
+            "componentName": "DeviceBridge",
+            "logFileDirectoryPath": "/greengrass/v2/logs/bridge",
+            "logFileRegex": "bridge-.*\\.log",
+            "diskSpaceLimit": "100",
+            "diskSpaceLimitUnit": "MB"
+        }
+    ],
+    "systemLogsConfiguration": [
+        {
+            "logFileDirectoryPath": "/greengrass/v2/logs/insights",
+            "logFileRegex": "insights-.*\\.json",
+            "logGroupName": "/aws/greengrass/system/insights",
+            "diskSpaceLimit": "200",
+            "diskSpaceLimitUnit": "MB",
+            "deleteLogFileAfterCloudUpload": true,
+            "minimumLogLevel": "WARN",
+            "uploadIntervalSec": 120
+        }
+    ]
+}"#;
+
+#[test]
+fn test_lld_j5_config_parses_all_entries() {
+    let config = parse_config(LLD_J5_CONFIG).expect("Should parse LLD J.5 config");
+
+    assert_eq!(config.component_logs_configuration.len(), 3);
+    assert_eq!(config.system_logs_configuration.len(), 1);
+}
+
+#[test]
+fn test_lld_j5_global_periodic_interval() {
+    let config = parse_config(LLD_J5_CONFIG).unwrap();
+    assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+}
+
+#[test]
+fn test_lld_j5_system_health_component() {
+    let config = parse_config(LLD_J5_CONFIG).unwrap();
+    let system_health = &config.component_logs_configuration[0];
+
+    assert_eq!(system_health.component_name, "system-health");
+    assert_eq!(
+        system_health.source.log_file_directory_path,
+        "/greengrass/v2/logs/emf"
+    );
+    assert_eq!(
+        system_health.source.log_file_regex,
+        "system-health-.*\\.emf\\.json"
+    );
+    assert_eq!(system_health.source.disk_space_limit, "50");
+    assert_eq!(system_health.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert!(system_health.source.delete_log_file_after_cloud_upload);
+    assert_eq!(
+        system_health.source.multi_line_start_pattern,
+        Some("^\\{".to_string())
+    );
+    assert_eq!(system_health.source.upload_interval_sec, Some(60));
+    assert!(system_health.log_group_name.is_none());
+}
+
+#[test]
+fn test_lld_j5_upload_interval_override() {
+    let config = parse_config(LLD_J5_CONFIG).unwrap();
+    let system_health = &config.component_logs_configuration[0];
+
+    assert_eq!(system_health.source.upload_interval_sec, Some(60));
+    assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+}
+
+#[test]
+fn test_lld_j5_docker_health_component() {
+    let config = parse_config(LLD_J5_CONFIG).unwrap();
+    let docker_health = &config.component_logs_configuration[1];
+
+    assert_eq!(docker_health.component_name, "docker-health");
+    assert_eq!(
+        docker_health.source.log_file_directory_path,
+        "/greengrass/v2/logs/emf"
+    );
+    assert_eq!(
+        docker_health.source.log_file_regex,
+        "docker-health-.*\\.emf\\.json"
+    );
+    assert_eq!(
+        docker_health.log_group_name,
+        Some("/aws/greengrass/custom/docker-health".to_string())
+    );
+    assert_eq!(docker_health.source.disk_space_limit, "25");
+    assert_eq!(docker_health.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert!(!docker_health.source.delete_log_file_after_cloud_upload);
+    assert_eq!(docker_health.source.minimum_log_level, LogLevel::Debug);
+    assert!(docker_health.source.upload_interval_sec.is_none());
+}
+
+#[test]
+fn test_lld_j5_device_bridge_component_defaults() {
+    let config = parse_config(LLD_J5_CONFIG).unwrap();
+    let device_bridge = &config.component_logs_configuration[2];
+
+    assert_eq!(device_bridge.component_name, "DeviceBridge");
+    assert_eq!(
+        device_bridge.source.log_file_directory_path,
+        "/greengrass/v2/logs/bridge"
+    );
+    assert_eq!(device_bridge.source.log_file_regex, "bridge-.*\\.log");
+    assert_eq!(device_bridge.source.disk_space_limit, "100");
+    assert_eq!(device_bridge.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert!(!device_bridge.source.delete_log_file_after_cloud_upload);
+    assert_eq!(device_bridge.source.minimum_log_level, LogLevel::Info);
+    assert!(device_bridge.log_group_name.is_none());
+    assert!(device_bridge.source.multi_line_start_pattern.is_none());
+    assert!(device_bridge.source.upload_interval_sec.is_none());
+}
+
+#[test]
+fn test_lld_j5_insights_system_config() {
+    let config = parse_config(LLD_J5_CONFIG).unwrap();
+    let insights = &config.system_logs_configuration[0];
+
+    assert_eq!(
+        insights.source.log_file_directory_path,
+        "/greengrass/v2/logs/insights"
+    );
+    assert_eq!(insights.source.log_file_regex, "insights-.*\\.json");
+    assert_eq!(insights.log_group_name, "/aws/greengrass/system/insights");
+    assert_eq!(insights.source.disk_space_limit, "200");
+    assert_eq!(insights.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert!(insights.source.delete_log_file_after_cloud_upload);
+    assert_eq!(insights.source.minimum_log_level, LogLevel::Warn);
+    assert_eq!(insights.source.upload_interval_sec, Some(120));
+}
+
+#[test]
+#[serial]
+fn test_auto_derived_log_group_name() {
+    use gg_log_manager::config::derive_log_group_name;
+
+    std::env::set_var("AWS_DEFAULT_REGION", "us-east-1");
+
+    let derived = derive_log_group_name("system-health", Some("UserComponent"));
+    assert_eq!(
+        derived,
+        "/aws/greengrass/UserComponent/us-east-1/system-health"
+    );
+
+    let derived_default = derive_log_group_name("DeviceBridge", None);
+    assert_eq!(
+        derived_default,
+        "/aws/greengrass/UserComponent/us-east-1/DeviceBridge"
+    );
+
+    std::env::remove_var("AWS_DEFAULT_REGION");
+}
+
+#[test]
+fn test_missing_optional_fields_get_defaults() {
+    let minimal_json = r#"{
+        "componentLogsConfiguration": [{
+            "componentName": "minimal",
+            "logFileDirectoryPath": "/tmp",
+            "logFileRegex": ".*\\.log",
+            "diskSpaceLimit": "10"
+        }]
+    }"#;
+
+    let config = parse_config(minimal_json).unwrap();
+    let comp = &config.component_logs_configuration[0];
+
+    assert_eq!(comp.source.minimum_log_level, LogLevel::Info);
+    assert_eq!(comp.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert!(!comp.source.delete_log_file_after_cloud_upload);
+    assert!(comp.log_group_name.is_none());
+    assert!(comp.source.multi_line_start_pattern.is_none());
+    assert!(comp.source.upload_interval_sec.is_none());
+
+    assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+}

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -1,0 +1,216 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Config parsing tests
+
+use gg_log_manager::config::{
+    derive_log_group_name, load_config, parse_config, parse_disk_space_limit,
+    validate_config, DiskSpaceLimitUnit, LogLevel, DEFAULT_UPLOAD_INTERVAL_SEC,
+};
+use serial_test::serial;
+use std::io::Write;
+
+const TEST_CONFIG_JSON: &str = r#"{
+    "periodicUploadIntervalSec": 300,
+    "componentLogsConfiguration": [
+        {
+            "componentName": "com.example.MyApp",
+            "logFileDirectoryPath": "/tmp",
+            "logFileRegex": "app\\.log.*",
+            "diskSpaceLimit": "25",
+            "diskSpaceLimitUnit": "MB",
+            "deleteLogFileAfterCloudUpload": false
+        },
+        {
+            "componentName": "aws.greengrass.Nucleus",
+            "logFileDirectoryPath": "/tmp",
+            "logFileRegex": "greengrass\\.log.*",
+            "logGroupName": "/custom/nucleus/logs",
+            "minimumLogLevel": "DEBUG",
+            "diskSpaceLimit": "100",
+            "diskSpaceLimitUnit": "MB",
+            "uploadIntervalSec": 60
+        },
+        {
+            "componentName": "com.example.EMFApp",
+            "logFileDirectoryPath": "/tmp",
+            "logFileRegex": "emf-.*\\.json",
+            "diskSpaceLimit": "10",
+            "multiLineStartPattern": "^\\{"
+        }
+    ],
+    "systemLogsConfiguration": [
+        {
+            "logFileDirectoryPath": "/tmp",
+            "logFileRegex": "syslog.*",
+            "logGroupName": "/aws/greengrass/system/syslog",
+            "diskSpaceLimit": "50",
+            "diskSpaceLimitUnit": "GB"
+        }
+    ]
+}"#;
+
+#[test]
+fn test_parse_config_fields() {
+    let config = parse_config(TEST_CONFIG_JSON).expect("Should parse valid config");
+
+    assert_eq!(config.periodic_upload_interval_sec, 300);
+    assert_eq!(config.component_logs_configuration.len(), 3);
+    assert_eq!(config.system_logs_configuration.len(), 1);
+}
+
+#[test]
+fn test_component_config_fields() {
+    let config = parse_config(TEST_CONFIG_JSON).unwrap();
+    let comp = &config.component_logs_configuration[0];
+
+    assert_eq!(comp.component_name, "com.example.MyApp");
+    assert_eq!(comp.source.log_file_directory_path, "/tmp");
+    assert_eq!(comp.source.log_file_regex, "app\\.log.*");
+    assert_eq!(comp.source.disk_space_limit, "25");
+    assert_eq!(comp.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert!(!comp.source.delete_log_file_after_cloud_upload);
+    assert!(comp.log_group_name.is_none());
+}
+
+#[test]
+fn test_upload_interval_override() {
+    let config = parse_config(TEST_CONFIG_JSON).unwrap();
+    let nucleus = &config.component_logs_configuration[1];
+
+    assert_eq!(nucleus.source.upload_interval_sec, Some(60));
+    assert_eq!(
+        nucleus.log_group_name,
+        Some("/custom/nucleus/logs".to_string())
+    );
+    assert_eq!(nucleus.source.minimum_log_level, LogLevel::Debug);
+}
+
+#[test]
+fn test_defaults_applied() {
+    let config = parse_config(TEST_CONFIG_JSON).unwrap();
+    let emf = &config.component_logs_configuration[2];
+
+    assert_eq!(emf.source.minimum_log_level, LogLevel::Info);
+    assert_eq!(emf.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert!(!emf.source.delete_log_file_after_cloud_upload);
+    assert_eq!(emf.source.multi_line_start_pattern, Some("^\\{".to_string()));
+}
+
+#[test]
+fn test_system_config_fields() {
+    let config = parse_config(TEST_CONFIG_JSON).unwrap();
+    let sys = &config.system_logs_configuration[0];
+
+    assert_eq!(sys.log_group_name, "/aws/greengrass/system/syslog");
+    assert_eq!(sys.source.disk_space_limit, "50");
+    assert_eq!(sys.source.disk_space_limit_unit, DiskSpaceLimitUnit::GB);
+}
+
+#[test]
+#[serial]
+fn test_derive_log_group_name() {
+    std::env::set_var("AWS_DEFAULT_REGION", "us-west-2");
+    let name = derive_log_group_name("MyComponent", Some("GreengrassSystemComponent"));
+    assert_eq!(
+        name,
+        "/aws/greengrass/GreengrassSystemComponent/us-west-2/MyComponent"
+    );
+
+    let name_default = derive_log_group_name("MyComponent", None);
+    assert_eq!(
+        name_default,
+        "/aws/greengrass/UserComponent/us-west-2/MyComponent"
+    );
+    std::env::remove_var("AWS_DEFAULT_REGION");
+}
+
+#[test]
+fn test_default_periodic_interval() {
+    let config = parse_config("{}").unwrap();
+    assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+    assert!(config.component_logs_configuration.is_empty());
+    assert!(config.system_logs_configuration.is_empty());
+}
+
+#[test]
+fn test_disk_space_limit_string_parsing() {
+    assert_eq!(parse_disk_space_limit("100").unwrap(), 100);
+    assert_eq!(parse_disk_space_limit("0").unwrap(), 0);
+    assert!(parse_disk_space_limit("abc").is_err());
+    assert!(parse_disk_space_limit("-5").is_err());
+}
+
+#[test]
+fn test_load_config_inline_json() {
+    let config = load_config(r#"{"periodicUploadIntervalSec": 120}"#).unwrap();
+    assert_eq!(config.periodic_upload_interval_sec, 120);
+}
+
+#[test]
+fn test_load_config_from_file() {
+    let dir = std::env::temp_dir();
+    let path = dir.join("test_config.json");
+    let mut file = std::fs::File::create(&path).unwrap();
+    writeln!(file, r#"{{"periodicUploadIntervalSec": 180}}"#).unwrap();
+
+    let config = load_config(path.to_str().unwrap()).unwrap();
+    assert_eq!(config.periodic_upload_interval_sec, 180);
+
+    std::fs::remove_file(path).ok();
+}
+
+#[test]
+fn test_load_config_file_not_found() {
+    let result = load_config("/nonexistent/path/config.json");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("IO error"));
+}
+
+#[test]
+fn test_validate_config_invalid_disk_limit() {
+    let json = r#"{
+        "componentLogsConfiguration": [{
+            "componentName": "test",
+            "logFileDirectoryPath": "/tmp",
+            "logFileRegex": ".*",
+            "diskSpaceLimit": "abc"
+        }]
+    }"#;
+    let config = parse_config(json).unwrap();
+    let result = validate_config(&config);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("diskSpaceLimit"));
+}
+
+#[test]
+fn test_validate_config_invalid_regex() {
+    let json = r#"{
+        "componentLogsConfiguration": [{
+            "componentName": "test",
+            "logFileDirectoryPath": "/tmp",
+            "logFileRegex": "[invalid",
+            "diskSpaceLimit": "100"
+        }]
+    }"#;
+    let config = parse_config(json).unwrap();
+    let result = validate_config(&config);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("Invalid regex"));
+}
+
+#[test]
+fn test_validate_config_zero_disk_limit() {
+    let json = r#"{
+        "componentLogsConfiguration": [{
+            "componentName": "test",
+            "logFileDirectoryPath": "/tmp",
+            "logFileRegex": ".*",
+            "diskSpaceLimit": "0"
+        }]
+    }"#;
+    let config = parse_config(json).unwrap();
+    let result = validate_config(&config);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("positive"));
+}


### PR DESCRIPTION
**Issue #, if available:**


N/A — PR 2 of 10 for Rust v2 LogManager


**Description of changes:**


Configuration schema, parsing, validation, and a runnable entry point with graceful shutdown. After this PR, the component starts, reads config, handles SIGTERM, and exits cleanly.


- `config/schema.rs` — `LogManagerConfig`, `ComponentLogConfig`, `SystemLogConfig` with shared `LogSourceConfig` (DRY via `#[serde(flatten)]`). Serde camelCase for Java compatibility.

- `config/mod.rs` — `load_config()` (inline JSON or file path), `parse_config()`, `validate_config()` (directory, regex, disk limits), `derive_log_group_name()`.

- `main.rs` — imports from lib crate, CLI arg parsing, single-thread tokio runtime (`current_thread`), `SIGTERM`/`SIGINT` handler, 4-step graceful shutdown (cancel futures → flush uploads → persist checkpoints → exit).

- Adds: `tokio` (rt, signal, time, sync), `serde`, `serde_json`, `regex`, `serial_test` (dev)


**Why is this change necessary:**


Config + lifecycle is the foundation — every subsequent PR reads config and relies on the shutdown path. The JSON schema matches the Java LogManager for backward compatibility. E2E validated on EC2 with GG Nucleus — binary starts, reads config, handles SIGTERM with clean 4-step shutdown.


**How was this change tested:**


- 52 tests: unit (inline in config/mod.rs, schema.rs, main.rs) + integration (config_integration_test.rs)

- `cargo clippy` ✅ (clean)

- `cargo zigbuild --target aarch64-unknown-linux-musl` ✅

- E2E on EC2 (AL2023 + GG Nucleus): binary starts, reads config from file, handles SIGTERM gracefully ✅


**Checklist:**

- [ ] Updated the README if applicable

- [x] Updated or added new unit tests

- [x] Updated or added new integration tests

- [x] Updated or added new end-to-end tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.