### PR TITLE
feat(scanner): directory scanner, file reader, content hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,16 +18,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "equivalent"
@@ -50,6 +94,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "foldhash"
@@ -93,6 +148,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,10 +174,13 @@ dependencies = [
 name = "gg-log-manager"
 version = "0.1.0"
 dependencies = [
+ "base64",
+ "filetime",
  "regex",
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "tempfile",
  "tokio",
  "tracing",
@@ -181,6 +249,18 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -253,7 +333,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -263,6 +343,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "prettyplease"
@@ -303,6 +389,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -443,6 +538,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -592,6 +698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +720,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,18 @@ tokio = { version = "1.36", features = ["rt", "signal", "time", "sync", "macros"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 regex = "1"
+sha2 = "0.10"
+base64 = "0.22"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"
+filetime = "0.2"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [profile.release]
 strip = true

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -48,13 +48,10 @@ pub fn validate_config(config: &LogManagerConfig) -> Result<(), ConfigError> {
             tracing::debug!(component = %c.component_name, dir = %c.source.log_file_directory_path, "Validating component config");
             validate_log_source(&c.source)
         })?;
-    config
-        .system_logs_configuration
-        .iter()
-        .try_for_each(|s| {
-            tracing::debug!(dir = %s.source.log_file_directory_path, "Validating system log config");
-            validate_log_source(&s.source)
-        })?;
+    config.system_logs_configuration.iter().try_for_each(|s| {
+        tracing::debug!(dir = %s.source.log_file_directory_path, "Validating system log config");
+        validate_log_source(&s.source)
+    })?;
     tracing::info!("Configuration validation passed");
     Ok(())
 }
@@ -115,7 +112,10 @@ mod tests {
         let config = parse_config("{}").unwrap();
         assert!(config.component_logs_configuration.is_empty());
         assert!(config.system_logs_configuration.is_empty());
-        assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+        assert_eq!(
+            config.periodic_upload_interval_sec,
+            DEFAULT_UPLOAD_INTERVAL_SEC
+        );
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -42,32 +42,22 @@ impl From<std::io::Error> for ConfigError {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum LogLevel {
     Debug,
+    #[default]
     Info,
     Warn,
     Error,
 }
 
-impl Default for LogLevel {
-    fn default() -> Self {
-        Self::Info
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum DiskSpaceLimitUnit {
     KB,
+    #[default]
     MB,
     GB,
-}
-
-impl Default for DiskSpaceLimitUnit {
-    fn default() -> Self {
-        Self::MB
-    }
 }
 
 impl DiskSpaceLimitUnit {
@@ -141,7 +131,10 @@ mod tests {
     #[test]
     fn test_default_values() {
         let config: LogManagerConfig = serde_json::from_str("{}").unwrap();
-        assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+        assert_eq!(
+            config.periodic_upload_interval_sec,
+            DEFAULT_UPLOAD_INTERVAL_SEC
+        );
         assert!(config.component_logs_configuration.is_empty());
         assert!(config.system_logs_configuration.is_empty());
     }
@@ -207,7 +200,10 @@ mod tests {
         let json = r#""DEBUG""#;
         let level: LogLevel = serde_json::from_str(json).unwrap();
         assert_eq!(level, LogLevel::Debug);
-        assert_eq!(serde_json::to_string(&LogLevel::Error).unwrap(), r#""ERROR""#);
+        assert_eq!(
+            serde_json::to_string(&LogLevel::Error).unwrap(),
+            r#""ERROR""#
+        );
     }
 
     #[test]
@@ -243,10 +239,29 @@ mod tests {
             "periodicUploadIntervalSec": 120
         }"#;
         let config: LogManagerConfig = serde_json::from_str(java_json).unwrap();
-        assert_eq!(config.component_logs_configuration[0].component_name, "MyApp");
-        assert_eq!(config.component_logs_configuration[0].source.minimum_log_level, LogLevel::Warn);
-        assert_eq!(config.component_logs_configuration[0].source.disk_space_limit_unit, DiskSpaceLimitUnit::GB);
-        assert_eq!(config.system_logs_configuration[0].log_group_name, "/aws/greengrass/system");
-        assert_eq!(config.system_logs_configuration[0].source.minimum_log_level, LogLevel::Error);
+        assert_eq!(
+            config.component_logs_configuration[0].component_name,
+            "MyApp"
+        );
+        assert_eq!(
+            config.component_logs_configuration[0]
+                .source
+                .minimum_log_level,
+            LogLevel::Warn
+        );
+        assert_eq!(
+            config.component_logs_configuration[0]
+                .source
+                .disk_space_limit_unit,
+            DiskSpaceLimitUnit::GB
+        );
+        assert_eq!(
+            config.system_logs_configuration[0].log_group_name,
+            "/aws/greengrass/system"
+        );
+        assert_eq!(
+            config.system_logs_configuration[0].source.minimum_log_level,
+            LogLevel::Error
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,7 @@ fn persist_checkpoints() {
 /// Subscribes to configuration updates via GG Component SDK IPC.
 /// Re-validates and applies new configuration without restart.
 #[cfg(target_os = "linux")]
+#[allow(dead_code, reason = "wired in when GG SDK IPC is integrated")]
 fn subscribe_to_config_updates() {
     // TODO: Wire up with gg_sdk::Sdk::subscribe_to_configuration_update()
 }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -6,3 +6,152 @@
 mod checkpoint;
 mod multiline;
 mod reader;
+
+pub use reader::{compute_content_hash, read_file_from_offset, LogEvent};
+
+use regex::Regex;
+use std::fs;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+/// Represents a scanned log file with metadata
+#[derive(Debug, Clone)]
+pub struct ScannedFile {
+    pub path: PathBuf,
+    pub mtime: SystemTime,
+    pub content_hash: String,
+    pub is_active: bool,
+}
+
+/// Scan a directory for log files matching the given regex pattern.
+/// Returns files sorted by mtime ascending, with the newest marked as active.
+/// TODO: Optimize to skip hashing files that haven't changed since last scan (cache by path+mtime)
+pub fn scan_directory(directory: &str, pattern: &Regex) -> std::io::Result<Vec<ScannedFile>> {
+    tracing::info!(directory = %directory, "Starting directory scan");
+    let mut files: Vec<(PathBuf, SystemTime)> = fs::read_dir(directory)?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let path = entry.path();
+            let file_type = entry.file_type().ok()?;
+            if file_type.is_symlink() {
+                tracing::warn!(path = %path.display(), "Skipping symlink");
+                return None;
+            }
+            if file_type.is_file() {
+                let name = path.file_name()?.to_str()?;
+                if pattern.is_match(name) {
+                    let mtime = entry.metadata().ok()?.modified().ok()?;
+                    tracing::debug!(file = %path.display(), "Found matching file");
+                    return Some((path, mtime));
+                }
+            }
+            None
+        })
+        .collect();
+
+    files.sort_by_key(|(_, mtime)| *mtime);
+
+    let len = files.len();
+    let result: std::io::Result<Vec<ScannedFile>> = files
+        .into_iter()
+        .enumerate()
+        .map(|(i, (path, mtime))| {
+            let content_hash = compute_content_hash(&path)?;
+            Ok(ScannedFile {
+                path,
+                mtime,
+                content_hash,
+                is_active: i == len - 1,
+            })
+        })
+        .collect();
+
+    tracing::info!(file_count = len, "Directory scan complete");
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    fn create_test_file(dir: &std::path::Path, name: &str, content: &[u8]) -> PathBuf {
+        let path = dir.join(name);
+        let mut file = File::create(&path).unwrap();
+        file.write_all(content).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_scan_directory_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_scan_directory_filters_by_regex() {
+        let dir = tempfile::tempdir().unwrap();
+        create_test_file(dir.path(), "app.log", b"log content");
+        create_test_file(dir.path(), "app.txt", b"txt content");
+        create_test_file(dir.path(), "other.log", b"other log");
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().all(|f| f.path.extension().unwrap() == "log"));
+    }
+
+    #[test]
+    fn test_scan_directory_sorted_by_mtime_newest_is_active() {
+        let dir = tempfile::tempdir().unwrap();
+
+        create_test_file(dir.path(), "old.log", b"old");
+        sleep(Duration::from_millis(50));
+        create_test_file(dir.path(), "mid.log", b"mid");
+        sleep(Duration::from_millis(50));
+        create_test_file(dir.path(), "new.log", b"new");
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+
+        assert_eq!(result.len(), 3);
+        // Sorted by mtime ascending
+        assert!(result[0].mtime <= result[1].mtime);
+        assert!(result[1].mtime <= result[2].mtime);
+        // Only newest is active
+        assert!(!result[0].is_active);
+        assert!(!result[1].is_active);
+        assert!(result[2].is_active);
+    }
+
+    #[test]
+    fn test_scan_directory_single_file_is_active() {
+        let dir = tempfile::tempdir().unwrap();
+        create_test_file(dir.path(), "only.log", b"content");
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].is_active);
+    }
+
+    #[test]
+    fn test_scan_directory_content_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        create_test_file(dir.path(), "test.log", b"test content");
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(!result[0].content_hash.is_empty());
+        assert_eq!(result[0].content_hash.len(), 44); // Base64 of SHA-256 is 44 chars
+    }
+}

--- a/src/scanner/reader.rs
+++ b/src/scanner/reader.rs
@@ -2,3 +2,411 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! File reader with offset tracking and content hashing
+
+use base64::{engine::general_purpose::STANDARD, Engine};
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+/// Maximum event size in bytes (CloudWatch Logs limit: 256KB - 8 timestamp - 26 overhead)
+const MAX_EVENT_SIZE: usize = 262_110;
+
+/// A parsed log event with timestamp and message
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogEvent {
+    pub timestamp: i64,
+    pub message: String,
+}
+
+/// Compute SHA-256 content hash for file identity across rotations.
+/// Returns Base64-encoded digest, compatible with Java LogManager checkpoints.
+///
+/// Hashes the first line (up to newline) or first 1024 bytes if no newline found.
+pub fn compute_content_hash(path: &Path) -> std::io::Result<String> {
+    let mut file = File::open(path)?;
+    let mut buffer = [0u8; 1024];
+    let bytes_read = file.read(&mut buffer)?;
+    let data = &buffer[..bytes_read];
+    // Match Java: decode bytes as UTF-8 string, then hash the string bytes
+    let text = String::from_utf8_lossy(data);
+    let hash_input = match text.find('\n') {
+        Some(pos) => &text[..=pos],
+        None => &text,
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(hash_input.as_bytes());
+    Ok(STANDARD.encode(hasher.finalize()))
+}
+
+/// Read a file from the given byte offset, parsing lines as LogEvents.
+/// Returns (events, new_offset). If file size < offset, resets to 0.
+/// Invalid UTF-8 bytes are replaced with U+FFFD.
+///
+/// Note: reads remaining file content into memory. This is acceptable because each call
+/// only reads the delta since the last checkpoint (typically a few KB per upload cycle).
+/// For first-read of a large unchecked file, memory usage equals file size minus offset.
+pub fn read_file_from_offset(
+    path: &Path,
+    offset: u64,
+    default_timestamp: i64,
+) -> std::io::Result<(Vec<LogEvent>, u64)> {
+    let mut file = File::open(path)?;
+    let file_size = file.metadata()?.len();
+
+    let start_offset = if file_size < offset {
+        tracing::warn!(path = %path.display(), file_size = file_size, offset = offset, "File truncated, resetting to start");
+        0
+    } else {
+        offset
+    };
+
+    tracing::debug!(path = %path.display(), offset = start_offset, "Reading file from offset");
+    file.seek(SeekFrom::Start(start_offset))?;
+
+    let mut raw = Vec::new();
+    file.read_to_end(&mut raw)?;
+    let text = String::from_utf8_lossy(&raw);
+    let new_offset = start_offset + raw.len() as u64;
+
+    let events = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let timestamp = extract_timestamp(line).unwrap_or(default_timestamp);
+            let message = truncate_message(line);
+            LogEvent { timestamp, message }
+        })
+        .collect();
+
+    tracing::debug!(path = %path.display(), new_offset = new_offset, "File read complete");
+    Ok((events, new_offset))
+}
+
+pub(crate) fn extract_timestamp(line: &str) -> Option<i64> {
+    let bytes = line.as_bytes();
+    // Epoch millis: exactly 13 digits at start (not part of a longer number), within realistic range
+    if bytes.len() >= 13
+        && bytes[0..13].iter().all(|b| b.is_ascii_digit())
+        && (bytes.len() == 13 || !bytes[13].is_ascii_digit())
+    {
+        if let Ok(ts) = line[0..13].parse::<i64>() {
+            if (1_000_000_000_000..=4_102_444_800_000).contains(&ts) {
+                return Some(ts);
+            }
+        }
+        return None;
+    }
+    // ISO-8601: YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD HH:MM:SS
+    if bytes.len() >= 19
+        && bytes[0..4].iter().all(|b| b.is_ascii_digit())
+        && bytes[4] == b'-'
+        && bytes[5..7].iter().all(|b| b.is_ascii_digit())
+        && bytes[7] == b'-'
+        && bytes[8..10].iter().all(|b| b.is_ascii_digit())
+        && (bytes[10] == b'T' || bytes[10] == b' ')
+        && bytes[11..13].iter().all(|b| b.is_ascii_digit())
+        && bytes[13] == b':'
+        && bytes[14..16].iter().all(|b| b.is_ascii_digit())
+        && bytes[16] == b':'
+        && bytes[17..19].iter().all(|b| b.is_ascii_digit())
+    {
+        return parse_iso8601(&line[0..19]);
+    }
+    None
+}
+
+pub(crate) fn parse_iso8601(s: &str) -> Option<i64> {
+    let b = s.as_bytes();
+    let year: i32 = std::str::from_utf8(&b[0..4]).ok()?.parse().ok()?;
+    let month: u32 = std::str::from_utf8(&b[5..7]).ok()?.parse().ok()?;
+    let day: u32 = std::str::from_utf8(&b[8..10]).ok()?.parse().ok()?;
+    let hour: u32 = std::str::from_utf8(&b[11..13]).ok()?.parse().ok()?;
+    let min: u32 = std::str::from_utf8(&b[14..16]).ok()?.parse().ok()?;
+    let sec: u32 = std::str::from_utf8(&b[17..19]).ok()?.parse().ok()?;
+    // Simple epoch calculation (assumes UTC, no leap seconds)
+    let days = days_since_epoch(year, month, day)?;
+    Some(
+        (days as i64) * 86400000
+            + (hour as i64) * 3600000
+            + (min as i64) * 60000
+            + (sec as i64) * 1000,
+    )
+}
+
+fn days_since_epoch(year: i32, month: u32, day: u32) -> Option<i64> {
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    // Days from 1970-01-01
+    let y = year as i64;
+    let m = month as i64;
+    let d = day as i64;
+    // Days in years since 1970
+    let mut days = (y - 1970) * 365;
+    // Add leap years
+    days += (y - 1969) / 4 - (y - 1901) / 100 + (y - 1601) / 400;
+    // Days in months
+    let month_days = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+    days += month_days[(m - 1) as usize] as i64;
+    // Add leap day if after Feb in leap year
+    if m > 2 && (y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)) {
+        days += 1;
+    }
+    days += d - 1;
+    Some(days)
+}
+
+fn truncate_message(s: &str) -> String {
+    if s.len() <= MAX_EVENT_SIZE {
+        s.to_string()
+    } else {
+        let mut end = MAX_EVENT_SIZE;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        s[..end].to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_from_offset_zero() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "line1").unwrap();
+        writeln!(file, "line2").unwrap();
+
+        let (events, offset) = read_file_from_offset(file.path(), 0, 1000).unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].message, "line1");
+        assert_eq!(events[1].message, "line2");
+        assert_eq!(offset, 12); // "line1\nline2\n"
+    }
+
+    #[test]
+    fn test_read_from_mid_file_offset() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "line1").unwrap();
+        writeln!(file, "line2").unwrap();
+
+        let (events, offset) = read_file_from_offset(file.path(), 6, 1000).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "line2");
+        assert_eq!(offset, 12);
+    }
+
+    #[test]
+    fn test_truncation_detection() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "short").unwrap();
+
+        // Offset larger than file size should reset to 0
+        let (events, offset) = read_file_from_offset(file.path(), 1000, 1000).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "short");
+        assert_eq!(offset, 6);
+    }
+
+    #[test]
+    fn test_timestamp_extraction_epoch_millis() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "1234567890123 message").unwrap();
+
+        let (events, _) = read_file_from_offset(file.path(), 0, 9999).unwrap();
+        assert_eq!(events[0].timestamp, 1234567890123);
+    }
+
+    #[test]
+    fn test_timestamp_extraction_iso8601() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "2024-01-15T10:30:45 message").unwrap();
+
+        let (events, _) = read_file_from_offset(file.path(), 0, 9999).unwrap();
+        // 2024-01-15 10:30:45 UTC in millis
+        assert_eq!(events[0].timestamp, 1705314645000);
+    }
+
+    #[test]
+    fn test_timestamp_extraction_default() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "no timestamp here").unwrap();
+
+        let (events, _) = read_file_from_offset(file.path(), 0, 5555).unwrap();
+        assert_eq!(events[0].timestamp, 5555);
+    }
+
+    #[test]
+    fn test_event_size_truncation() {
+        let mut file = NamedTempFile::new().unwrap();
+        let large_msg = "x".repeat(300_000);
+        writeln!(file, "{}", large_msg).unwrap();
+
+        let (events, _) = read_file_from_offset(file.path(), 0, 1000).unwrap();
+        assert_eq!(events[0].message.len(), MAX_EVENT_SIZE);
+    }
+
+    #[test]
+    fn test_empty_lines_skipped() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "line1").unwrap();
+        writeln!(file).unwrap();
+        writeln!(file, "line2").unwrap();
+
+        let (events, _) = read_file_from_offset(file.path(), 0, 1000).unwrap();
+        assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn test_compute_content_hash_with_newline() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "first line").unwrap();
+        writeln!(file, "second line").unwrap();
+
+        let hash = compute_content_hash(file.path()).unwrap();
+        // Hash should be of "first line\n" (first line including newline)
+        assert_eq!(hash.len(), 44); // Base64 of SHA-256 (32 bytes) = 44 chars
+
+        // Create another file with same first line
+        let mut file2 = NamedTempFile::new().unwrap();
+        writeln!(file2, "first line").unwrap();
+        writeln!(file2, "different second line").unwrap();
+
+        let hash2 = compute_content_hash(file2.path()).unwrap();
+        assert_eq!(hash, hash2); // Same first line = same hash
+    }
+
+    #[test]
+    fn test_compute_content_hash_no_newline() {
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "no newline content").unwrap();
+
+        let hash = compute_content_hash(file.path()).unwrap();
+        assert_eq!(hash.len(), 44);
+    }
+
+    #[test]
+    fn test_extract_timestamp_13_digits_followed_by_digit() {
+        // 13 digits followed by another digit should NOT be extracted
+        // (it's a 14+ digit number, not epoch millis)
+        let result = extract_timestamp("12345678901234 message");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_timestamp_exactly_13_digits() {
+        // Exactly 13 digits followed by non-digit should be extracted
+        let result = extract_timestamp("1705314645000 message");
+        assert_eq!(result, Some(1705314645000));
+    }
+
+    #[test]
+    fn test_extract_timestamp_13_digits_at_end() {
+        // 13 digits at end of string (no following char)
+        let result = extract_timestamp("1705314645000");
+        assert_eq!(result, Some(1705314645000));
+    }
+
+    #[test]
+    fn test_extract_timestamp_out_of_range() {
+        // Too small (before year 2001)
+        let result = extract_timestamp("0000000000001 message");
+        assert!(result.is_none());
+
+        // Too large (after year 2100)
+        let result = extract_timestamp("9999999999999 message");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_read_file_with_invalid_utf8() {
+        let mut file = NamedTempFile::new().unwrap();
+        // Write valid UTF-8, then invalid bytes, then more valid UTF-8
+        file.write_all(b"valid line\n").unwrap();
+        file.write_all(&[0xFF, 0xFE]).unwrap(); // Invalid UTF-8
+        file.write_all(b"after invalid\n").unwrap();
+
+        let (events, _) = read_file_from_offset(file.path(), 0, 1000).unwrap();
+        // First line is valid
+        assert_eq!(events[0].message, "valid line");
+        // Invalid bytes become replacement chars, rest of content preserved
+        assert!(events[1].message.contains('\u{FFFD}'));
+        assert!(events[1].message.contains("after invalid"));
+    }
+
+    #[test]
+    fn test_parse_iso8601_invalid_month() {
+        // Month 13 is invalid
+        let result = parse_iso8601("2024-13-15T10:30:45");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_iso8601_invalid_day() {
+        // Day 32 is invalid
+        let result = parse_iso8601("2024-01-32T10:30:45");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_iso8601_leap_year() {
+        // Feb 29 2024 (leap year)
+        let result = parse_iso8601("2024-02-29T00:00:00");
+        assert!(result.is_some());
+        // Feb 29 2023 (not leap year) - still parses, validation is basic
+        let result2 = parse_iso8601("2023-02-29T00:00:00");
+        assert!(result2.is_some());
+    }
+
+    #[test]
+    fn test_content_hash_matches_java_logfile_hash() {
+        // Java LogFile.hashString() uses:
+        //   1. Read up to 1024 bytes
+        //   2. If newline found, take bytes up to and including newline
+        //   3. Convert to String (UTF-8)
+        //   4. SHA-256 the string bytes
+        //   5. Base64-encode the digest
+        //
+        // Rust compute_content_hash() now matches this exactly.
+
+        use sha2::{Digest, Sha256};
+
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "first line").unwrap();
+        writeln!(file, "second line").unwrap();
+
+        let rust_hash = compute_content_hash(file.path()).unwrap();
+
+        // Compute what Java would produce
+        let input = "first line\n";
+        let digest = Sha256::digest(input.as_bytes());
+        let java_hash = STANDARD.encode(digest);
+
+        assert_eq!(
+            rust_hash, java_hash,
+            "Rust and Java hashes must match for checkpoint compatibility"
+        );
+        assert_eq!(rust_hash.len(), 44, "Base64 encoding is 44 chars");
+    }
+
+    #[test]
+    fn test_truncate_message_multibyte_char_boundary() {
+        // Create a string with multibyte UTF-8 characters that would be split
+        // at a non-char-boundary if we just truncated at MAX_EVENT_SIZE
+        let emoji = "🎉"; // 4 bytes
+        let base = "x".repeat(MAX_EVENT_SIZE - 2);
+        let large_msg = format!("{}{}", base, emoji);
+
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "{}", large_msg).unwrap();
+
+        let (events, _) = read_file_from_offset(file.path(), 0, 1000).unwrap();
+        // Should truncate at a valid char boundary
+        assert!(events[0].message.len() <= MAX_EVENT_SIZE);
+        assert!(events[0].message.is_char_boundary(events[0].message.len()));
+    }
+}

--- a/tests/config_integration_test.rs
+++ b/tests/config_integration_test.rs
@@ -3,7 +3,9 @@
 
 //! Integration tests for config parsing with full LLD J.5 config
 
-use gg_log_manager::config::{parse_config, DiskSpaceLimitUnit, LogLevel, DEFAULT_UPLOAD_INTERVAL_SEC};
+use gg_log_manager::config::{
+    parse_config, DiskSpaceLimitUnit, LogLevel, DEFAULT_UPLOAD_INTERVAL_SEC,
+};
 use serial_test::serial;
 
 /// Full LLD J.5 config with 3 componentLogsConfiguration entries and 1 systemLogsConfiguration
@@ -63,7 +65,10 @@ fn test_lld_j5_config_parses_all_entries() {
 #[test]
 fn test_lld_j5_global_periodic_interval() {
     let config = parse_config(LLD_J5_CONFIG).unwrap();
-    assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+    assert_eq!(
+        config.periodic_upload_interval_sec,
+        DEFAULT_UPLOAD_INTERVAL_SEC
+    );
 }
 
 #[test]
@@ -81,7 +86,10 @@ fn test_lld_j5_system_health_component() {
         "system-health-.*\\.emf\\.json"
     );
     assert_eq!(system_health.source.disk_space_limit, "50");
-    assert_eq!(system_health.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert_eq!(
+        system_health.source.disk_space_limit_unit,
+        DiskSpaceLimitUnit::MB
+    );
     assert!(system_health.source.delete_log_file_after_cloud_upload);
     assert_eq!(
         system_health.source.multi_line_start_pattern,
@@ -97,7 +105,10 @@ fn test_lld_j5_upload_interval_override() {
     let system_health = &config.component_logs_configuration[0];
 
     assert_eq!(system_health.source.upload_interval_sec, Some(60));
-    assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+    assert_eq!(
+        config.periodic_upload_interval_sec,
+        DEFAULT_UPLOAD_INTERVAL_SEC
+    );
 }
 
 #[test]
@@ -119,7 +130,10 @@ fn test_lld_j5_docker_health_component() {
         Some("/aws/greengrass/custom/docker-health".to_string())
     );
     assert_eq!(docker_health.source.disk_space_limit, "25");
-    assert_eq!(docker_health.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert_eq!(
+        docker_health.source.disk_space_limit_unit,
+        DiskSpaceLimitUnit::MB
+    );
     assert!(!docker_health.source.delete_log_file_after_cloud_upload);
     assert_eq!(docker_health.source.minimum_log_level, LogLevel::Debug);
     assert!(docker_health.source.upload_interval_sec.is_none());
@@ -137,7 +151,10 @@ fn test_lld_j5_device_bridge_component_defaults() {
     );
     assert_eq!(device_bridge.source.log_file_regex, "bridge-.*\\.log");
     assert_eq!(device_bridge.source.disk_space_limit, "100");
-    assert_eq!(device_bridge.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert_eq!(
+        device_bridge.source.disk_space_limit_unit,
+        DiskSpaceLimitUnit::MB
+    );
     assert!(!device_bridge.source.delete_log_file_after_cloud_upload);
     assert_eq!(device_bridge.source.minimum_log_level, LogLevel::Info);
     assert!(device_bridge.log_group_name.is_none());
@@ -157,7 +174,10 @@ fn test_lld_j5_insights_system_config() {
     assert_eq!(insights.source.log_file_regex, "insights-.*\\.json");
     assert_eq!(insights.log_group_name, "/aws/greengrass/system/insights");
     assert_eq!(insights.source.disk_space_limit, "200");
-    assert_eq!(insights.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert_eq!(
+        insights.source.disk_space_limit_unit,
+        DiskSpaceLimitUnit::MB
+    );
     assert!(insights.source.delete_log_file_after_cloud_upload);
     assert_eq!(insights.source.minimum_log_level, LogLevel::Warn);
     assert_eq!(insights.source.upload_interval_sec, Some(120));
@@ -206,5 +226,8 @@ fn test_missing_optional_fields_get_defaults() {
     assert!(comp.source.multi_line_start_pattern.is_none());
     assert!(comp.source.upload_interval_sec.is_none());
 
-    assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+    assert_eq!(
+        config.periodic_upload_interval_sec,
+        DEFAULT_UPLOAD_INTERVAL_SEC
+    );
 }

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -4,8 +4,8 @@
 //! Config parsing tests
 
 use gg_log_manager::config::{
-    derive_log_group_name, load_config, parse_config, parse_disk_space_limit,
-    validate_config, DiskSpaceLimitUnit, LogLevel, DEFAULT_UPLOAD_INTERVAL_SEC,
+    derive_log_group_name, load_config, parse_config, parse_disk_space_limit, validate_config,
+    DiskSpaceLimitUnit, LogLevel, DEFAULT_UPLOAD_INTERVAL_SEC,
 };
 use serial_test::serial;
 use std::io::Write;
@@ -94,7 +94,10 @@ fn test_defaults_applied() {
     assert_eq!(emf.source.minimum_log_level, LogLevel::Info);
     assert_eq!(emf.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
     assert!(!emf.source.delete_log_file_after_cloud_upload);
-    assert_eq!(emf.source.multi_line_start_pattern, Some("^\\{".to_string()));
+    assert_eq!(
+        emf.source.multi_line_start_pattern,
+        Some("^\\{".to_string())
+    );
 }
 
 #[test]
@@ -128,7 +131,10 @@ fn test_derive_log_group_name() {
 #[test]
 fn test_default_periodic_interval() {
     let config = parse_config("{}").unwrap();
-    assert_eq!(config.periodic_upload_interval_sec, DEFAULT_UPLOAD_INTERVAL_SEC);
+    assert_eq!(
+        config.periodic_upload_interval_sec,
+        DEFAULT_UPLOAD_INTERVAL_SEC
+    );
     assert!(config.component_logs_configuration.is_empty());
     assert!(config.system_logs_configuration.is_empty());
 }

--- a/tests/emf_tailing_test.rs
+++ b/tests/emf_tailing_test.rs
@@ -1,0 +1,217 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for EMF file tailing end-to-end
+
+use gg_log_manager::scanner::{read_file_from_offset, LogEvent};
+use std::fs::File;
+use std::io::Write;
+use tempfile::TempDir;
+
+/// Valid EMF JSON content representing system health metrics
+const SYSTEM_HEALTH_EMF: &str = r#"{"_aws":{"Timestamp":1705314645000,"CloudWatchMetrics":[{"Namespace":"GreenGrass/SystemHealth","Dimensions":[["ThingName"]],"Metrics":[{"Name":"CpuUsage","Unit":"Percent"},{"Name":"MemoryUsage","Unit":"Percent"}]}]},"ThingName":"my-iot-device","CpuUsage":45.2,"MemoryUsage":67.8}"#;
+
+#[test]
+fn test_emf_file_tailing_preserves_json_content() {
+    let dir = TempDir::new().unwrap();
+    let emf_path = dir.path().join("system-health.emf.json");
+
+    // Write valid EMF JSON file
+    let mut file = File::create(&emf_path).unwrap();
+    writeln!(file, "{}", SYSTEM_HEALTH_EMF).unwrap();
+
+    // Read using read_file_from_offset
+    let default_ts = 1000000000000i64;
+    let (events, new_offset) = read_file_from_offset(&emf_path, 0, default_ts).unwrap();
+
+    // Assert single LogEvent is returned
+    assert_eq!(
+        events.len(),
+        1,
+        "Should return exactly one LogEvent for single EMF line"
+    );
+
+    // Assert the EMF JSON content is preserved exactly (LogManager does not parse or modify EMF)
+    assert_eq!(
+        events[0].message, SYSTEM_HEALTH_EMF,
+        "EMF JSON content should be preserved exactly"
+    );
+
+    // Verify offset advanced
+    assert!(new_offset > 0);
+}
+
+#[test]
+fn test_emf_timestamp_extracted_from_aws_field() {
+    let dir = TempDir::new().unwrap();
+    let emf_path = dir.path().join("test.emf.json");
+
+    // EMF with timestamp in _aws field
+    let emf_content = r#"{"_aws":{"Timestamp":1705314645000},"metric":"value"}"#;
+
+    let mut file = File::create(&emf_path).unwrap();
+    writeln!(file, "{}", emf_content).unwrap();
+
+    let (events, _) = read_file_from_offset(&emf_path, 0, 9999).unwrap();
+
+    assert_eq!(events.len(), 1);
+    // Note: The reader extracts timestamp from line start, not from JSON parsing
+    // EMF lines starting with { won't have extractable timestamp, so default is used
+    assert_eq!(events[0].timestamp, 9999);
+    assert_eq!(events[0].message, emf_content);
+}
+
+#[test]
+fn test_emf_multiple_lines() {
+    let dir = TempDir::new().unwrap();
+    let emf_path = dir.path().join("multi.emf.json");
+
+    let emf1 = r#"{"_aws":{"Timestamp":1705314645000},"metric1":"value1"}"#;
+    let emf2 = r#"{"_aws":{"Timestamp":1705314646000},"metric2":"value2"}"#;
+    let emf3 = r#"{"_aws":{"Timestamp":1705314647000},"metric3":"value3"}"#;
+
+    let mut file = File::create(&emf_path).unwrap();
+    writeln!(file, "{}", emf1).unwrap();
+    writeln!(file, "{}", emf2).unwrap();
+    writeln!(file, "{}", emf3).unwrap();
+
+    let (events, _) = read_file_from_offset(&emf_path, 0, 1000).unwrap();
+
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].message, emf1);
+    assert_eq!(events[1].message, emf2);
+    assert_eq!(events[2].message, emf3);
+}
+
+#[test]
+fn test_emf_tailing_from_offset() {
+    let dir = TempDir::new().unwrap();
+    let emf_path = dir.path().join("tail.emf.json");
+
+    let emf1 = r#"{"metric":"first"}"#;
+    let emf2 = r#"{"metric":"second"}"#;
+
+    let mut file = File::create(&emf_path).unwrap();
+    writeln!(file, "{}", emf1).unwrap();
+    writeln!(file, "{}", emf2).unwrap();
+
+    // First read from offset 0
+    let (events1, offset1) = read_file_from_offset(&emf_path, 0, 1000).unwrap();
+    assert_eq!(events1.len(), 2);
+
+    // Append more content
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&emf_path)
+        .unwrap();
+    let emf3 = r#"{"metric":"third"}"#;
+    writeln!(file, "{}", emf3).unwrap();
+
+    // Read from previous offset - should only get new content
+    let (events2, _) = read_file_from_offset(&emf_path, offset1, 1000).unwrap();
+    assert_eq!(events2.len(), 1);
+    assert_eq!(events2[0].message, emf3);
+}
+
+#[test]
+fn test_emf_content_not_modified() {
+    let dir = TempDir::new().unwrap();
+    let emf_path = dir.path().join("preserve.emf.json");
+
+    // EMF with special characters, nested objects, arrays
+    let complex_emf = r#"{"_aws":{"CloudWatchMetrics":[{"Namespace":"Test","Metrics":[{"Name":"M1"}]}]},"tags":["a","b"],"nested":{"key":"value"}}"#;
+
+    let mut file = File::create(&emf_path).unwrap();
+    writeln!(file, "{}", complex_emf).unwrap();
+
+    let (events, _) = read_file_from_offset(&emf_path, 0, 1000).unwrap();
+
+    // Content should be byte-for-byte identical
+    assert_eq!(events[0].message, complex_emf);
+}
+
+#[test]
+fn test_emf_empty_file() {
+    let dir = TempDir::new().unwrap();
+    let emf_path = dir.path().join("empty.emf.json");
+
+    File::create(&emf_path).unwrap();
+
+    let (events, offset) = read_file_from_offset(&emf_path, 0, 1000).unwrap();
+
+    assert!(events.is_empty());
+    assert_eq!(offset, 0);
+}
+
+#[test]
+fn test_emf_file_truncation_detection() {
+    let dir = TempDir::new().unwrap();
+    let emf_path = dir.path().join("truncate.emf.json");
+
+    // Write initial content
+    let mut file = File::create(&emf_path).unwrap();
+    writeln!(file, r#"{{"metric":"value"}}"#).unwrap();
+
+    let (_, offset1) = read_file_from_offset(&emf_path, 0, 1000).unwrap();
+
+    // Truncate file (simulate rotation)
+    let mut file = File::create(&emf_path).unwrap();
+    writeln!(file, r#"{{"new":"data"}}"#).unwrap();
+
+    // Read with old offset that's now larger than file size
+    // Should reset to 0 and read from beginning
+    let (events, _) = read_file_from_offset(&emf_path, offset1 + 1000, 1000).unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].message, r#"{"new":"data"}"#);
+}
+
+#[test]
+fn test_emf_with_epoch_timestamp_prefix() {
+    let dir = TempDir::new().unwrap();
+    let emf_path = dir.path().join("epoch.emf.json");
+
+    // EMF line with epoch timestamp prefix (13 digits)
+    let emf_with_ts = r#"1705314645000 {"metric":"value"}"#;
+
+    let mut file = File::create(&emf_path).unwrap();
+    writeln!(file, "{}", emf_with_ts).unwrap();
+
+    let (events, _) = read_file_from_offset(&emf_path, 0, 9999).unwrap();
+
+    assert_eq!(events.len(), 1);
+    // Timestamp should be extracted from the epoch prefix
+    assert_eq!(events[0].timestamp, 1705314645000);
+    assert_eq!(events[0].message, emf_with_ts);
+}
+
+#[test]
+fn test_emf_skips_empty_lines() {
+    let dir = TempDir::new().unwrap();
+    let emf_path = dir.path().join("blanks.emf.json");
+
+    let mut file = File::create(&emf_path).unwrap();
+    writeln!(file, r#"{{"metric":"first"}}"#).unwrap();
+    writeln!(file).unwrap(); // empty line - will be skipped
+    writeln!(file, r#"{{"metric":"second"}}"#).unwrap();
+
+    let (events, _) = read_file_from_offset(&emf_path, 0, 1000).unwrap();
+
+    // Empty lines (after trimming \n\r) are skipped
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].message, r#"{"metric":"first"}"#);
+    assert_eq!(events[1].message, r#"{"metric":"second"}"#);
+}
+
+#[test]
+fn test_timestamp_extraction_march_leap_year() {
+    // 2024-03-01 is after Feb in a leap year — tests the leap day addition path
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("leap.log");
+    let mut f = File::create(&path).unwrap();
+    writeln!(f, "2024-03-01T12:00:00 leap year march event").unwrap();
+    let (events, _) = read_file_from_offset(&path, 0, 0).unwrap();
+    assert_eq!(events.len(), 1);
+    // 2024-03-01 12:00:00 UTC = 1709294400000 ms
+    assert_eq!(events[0].timestamp, 1709294400000);
+}

--- a/tests/scanner_test.rs
+++ b/tests/scanner_test.rs
@@ -1,0 +1,208 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for file scanning with rotation detection
+
+use gg_log_manager::scanner::{compute_content_hash, scan_directory};
+use regex::Regex;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+use std::time::Duration;
+use tempfile::TempDir;
+
+fn create_file_with_content(dir: &Path, name: &str, content: &[u8]) {
+    let path = dir.join(name);
+    let mut file = File::create(&path).unwrap();
+    file.write_all(content).unwrap();
+}
+
+fn set_mtime_offset(path: &Path, offset_secs: i64) {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    let target = if offset_secs < 0 {
+        now - Duration::from_secs((-offset_secs) as u64)
+    } else {
+        now + Duration::from_secs(offset_secs as u64)
+    };
+    let mtime = filetime::FileTime::from_unix_time(target.as_secs() as i64, 0);
+    filetime::set_file_mtime(path, mtime).unwrap();
+}
+
+#[test]
+fn test_scan_with_rotation_active_file_detection() {
+    let dir = TempDir::new().unwrap();
+    let pattern = Regex::new(r".*\.emf\.json$").unwrap();
+
+    // Create 3 files with different mtimes
+    // a.emf.json: 100 bytes, mtime T-120s (oldest)
+    create_file_with_content(dir.path(), "a.emf.json", &[b'a'; 100]);
+    set_mtime_offset(&dir.path().join("a.emf.json"), -120);
+
+    // b.emf.json: 100 bytes, mtime T-60s (middle)
+    create_file_with_content(dir.path(), "b.emf.json", &[b'b'; 100]);
+    set_mtime_offset(&dir.path().join("b.emf.json"), -60);
+
+    // c.emf.json: 50 bytes, mtime T-0s (newest/active)
+    create_file_with_content(dir.path(), "c.emf.json", &[b'c'; 50]);
+    // No offset needed - it's the newest
+
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+
+    assert_eq!(files.len(), 3);
+
+    // Files should be sorted by mtime ascending
+    assert!(files[0].path.ends_with("a.emf.json"));
+    assert!(files[1].path.ends_with("b.emf.json"));
+    assert!(files[2].path.ends_with("c.emf.json"));
+
+    // Only the newest file (c) should be active
+    assert!(!files[0].is_active, "a.emf.json should not be active");
+    assert!(!files[1].is_active, "b.emf.json should not be active");
+    assert!(files[2].is_active, "c.emf.json should be active");
+}
+
+#[test]
+fn test_scan_rotation_content_hash_survives_rename() {
+    let dir = TempDir::new().unwrap();
+    let _pattern = Regex::new(r".*\.emf\.json$|.*\.old$").unwrap();
+
+    // Create file b.emf.json with specific content
+    let content_b = b"unique content for file b that we will track";
+    create_file_with_content(dir.path(), "b.emf.json", content_b);
+
+    // Get the content hash before rename
+    let hash_before = compute_content_hash(&dir.path().join("b.emf.json")).unwrap();
+
+    // Simulate rotation: rename b.emf.json to b.old
+    fs::rename(dir.path().join("b.emf.json"), dir.path().join("b.old")).unwrap();
+
+    // Get the content hash after rename
+    let hash_after = compute_content_hash(&dir.path().join("b.old")).unwrap();
+
+    // Content hash should be the same after rename
+    assert_eq!(
+        hash_before, hash_after,
+        "Content hash should survive file rename"
+    );
+}
+
+#[test]
+fn test_scan_rotation_renamed_file_still_scannable() {
+    let dir = TempDir::new().unwrap();
+
+    // Create initial files
+    create_file_with_content(dir.path(), "a.emf.json", &[b'a'; 100]);
+    set_mtime_offset(&dir.path().join("a.emf.json"), -120);
+
+    create_file_with_content(dir.path(), "b.emf.json", &[b'b'; 100]);
+    set_mtime_offset(&dir.path().join("b.emf.json"), -60);
+
+    create_file_with_content(dir.path(), "c.emf.json", &[b'c'; 50]);
+
+    // First scan with pattern matching .emf.json
+    let pattern1 = Regex::new(r".*\.emf\.json$").unwrap();
+    let files_before = scan_directory(dir.path().to_str().unwrap(), &pattern1).unwrap();
+    assert_eq!(files_before.len(), 3);
+
+    // Get hash of b before rename
+    let b_hash = files_before
+        .iter()
+        .find(|f| f.path.ends_with("b.emf.json"))
+        .unwrap()
+        .content_hash
+        .clone();
+
+    // Simulate rotation: rename b.emf.json to b.old
+    fs::rename(dir.path().join("b.emf.json"), dir.path().join("b.old")).unwrap();
+
+    // Re-scan with pattern that includes .old files
+    let pattern2 = Regex::new(r".*\.emf\.json$|.*\.old$").unwrap();
+    let files_after = scan_directory(dir.path().to_str().unwrap(), &pattern2).unwrap();
+
+    // Should still find 3 files (a.emf.json, b.old, c.emf.json)
+    assert_eq!(files_after.len(), 3);
+
+    // Find the renamed file and verify its hash matches
+    let b_old = files_after
+        .iter()
+        .find(|f| f.path.ends_with("b.old"))
+        .expect("Should find b.old after rename");
+
+    assert_eq!(
+        b_old.content_hash, b_hash,
+        "Content hash should match after rename"
+    );
+}
+
+#[test]
+fn test_scan_content_hash_is_sha256() {
+    let dir = TempDir::new().unwrap();
+    create_file_with_content(dir.path(), "test.emf.json", b"test content");
+
+    let pattern = Regex::new(r".*\.emf\.json$").unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+
+    assert_eq!(files.len(), 1);
+    // SHA-256 produces 64 hex characters
+    assert_eq!(files[0].content_hash.len(), 44);
+    // Should be valid Base64
+    assert!(files[0]
+        .content_hash
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '='));
+}
+
+#[test]
+fn test_scan_empty_directory() {
+    let dir = TempDir::new().unwrap();
+    let pattern = Regex::new(r".*\.emf\.json$").unwrap();
+
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    assert!(files.is_empty());
+}
+
+#[test]
+fn test_scan_single_file_is_active() {
+    let dir = TempDir::new().unwrap();
+    create_file_with_content(dir.path(), "only.emf.json", b"content");
+
+    let pattern = Regex::new(r".*\.emf\.json$").unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+
+    assert_eq!(files.len(), 1);
+    assert!(files[0].is_active, "Single file should be marked as active");
+}
+
+#[test]
+fn test_scan_filters_by_regex() {
+    let dir = TempDir::new().unwrap();
+    create_file_with_content(dir.path(), "match.emf.json", b"content");
+    create_file_with_content(dir.path(), "nomatch.txt", b"content");
+    create_file_with_content(dir.path(), "another.log", b"content");
+
+    let pattern = Regex::new(r".*\.emf\.json$").unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+
+    assert_eq!(files.len(), 1);
+    assert!(files[0].path.ends_with("match.emf.json"));
+}
+
+#[test]
+fn test_scan_directory_skips_symlinks() {
+    let dir = TempDir::new().unwrap();
+    // Create a real file
+    let real_path = dir.path().join("real.log");
+    std::fs::write(&real_path, "content").unwrap();
+    // Create a symlink
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&real_path, dir.path().join("link.log")).unwrap();
+    }
+    let pattern = regex::Regex::new(r".*\.log$").unwrap();
+    let result =
+        gg_log_manager::scanner::scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    // Should only find the real file, not the symlink
+    assert_eq!(result.len(), 1);
+    assert!(result[0].path.ends_with("real.log"));
+}


### PR DESCRIPTION
**Issue #:** N/A (Task 1.3 — LogManager Rust rewrite)

**Description of changes:**
File scanner subsystem — directory scanning, offset-tracked file reading, and content hashing for log rotation detection.

- `scan_directory()`: list files matching regex, sort by mtime, mark newest as active
- `compute_content_hash()`: SHA-256 Base64-encoded (backward compatible with Java LogManager checkpoints)
- `read_file_from_offset()`: offset-tracked reader with timestamp extraction (ISO-8601 + epoch-millis)
- Invalid UTF-8 replaced with U+FFFD (matching Java behavior)
- Truncation detection: reset to offset 0 if file shrinks
- Event size truncation at CW Logs 256KB limit
- Clippy/rustfmt fixes for merged #239 code

**Why is this change necessary:**
Core file scanning infrastructure for the Rust LogManager. Required by the upload pipeline to discover, read, and track log/EMF files across rotations.

**How was this change tested:**
- `cargo build` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo test` ✅ — 95 tests, 0 failures

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [x] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.