### PR TITLE
feat(scanner): multi-line log assembly

### DIFF
--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -7,7 +7,11 @@ mod checkpoint;
 mod multiline;
 mod reader;
 
+pub use multiline::assemble_multiline;
 pub use reader::{compute_content_hash, read_file_from_offset, LogEvent};
+
+/// Maximum event message size: 256KB (262,144) - 8 (timestamp) - 26 (CW overhead) = 262,110
+pub(crate) const MAX_EVENT_SIZE: usize = 262_110;
 
 use regex::Regex;
 use std::fs;

--- a/src/scanner/multiline.rs
+++ b/src/scanner/multiline.rs
@@ -2,3 +2,263 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Multi-line log assembly
+
+use super::reader::{extract_timestamp, LogEvent};
+use super::MAX_EVENT_SIZE;
+use regex::Regex;
+use std::sync::LazyLock;
+use std::time::SystemTime;
+
+/// Default multiline start pattern matching Java LogManager behavior.
+/// Matches lines starting with a date (optionally in brackets/parens) or JSON object.
+static DEFAULT_MULTILINE_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[\[(]?\d{4}-\d\d-\d\d|^\{").unwrap());
+
+/// Assemble lines into LogEvents based on multi-line start pattern.
+/// When start_pattern is None, the default pattern is applied (matching Java behavior).
+/// When start_pattern is Some, that pattern is used.
+/// Lines are buffered until a new match, then emitted concatenated (no separator, matching Java).
+#[must_use = "assembled events must be consumed"]
+pub fn assemble_multiline(lines: Vec<LogEvent>, start_pattern: Option<&Regex>) -> Vec<LogEvent> {
+    let pattern = start_pattern.unwrap_or(&DEFAULT_MULTILINE_PATTERN);
+    let mut events = Vec::with_capacity(lines.len());
+    let mut buffer: Vec<String> = Vec::new();
+    let mut first_timestamp: Option<i64> = None;
+
+    for event in lines {
+        if pattern.is_match(&event.message) && !buffer.is_empty() {
+            events.push(emit_buffered(&buffer, first_timestamp));
+            buffer.clear();
+            first_timestamp = None;
+        }
+        if !event.message.trim().is_empty() {
+            if buffer.is_empty() {
+                first_timestamp = Some(event.timestamp);
+            }
+            buffer.push(event.message);
+        }
+    }
+    if !buffer.is_empty() {
+        events.push(emit_buffered(&buffer, first_timestamp));
+    }
+    tracing::debug!(event_count = events.len(), "Multiline assembly complete");
+    events
+}
+
+fn emit_buffered(buffer: &[String], first_event_timestamp: Option<i64>) -> LogEvent {
+    debug_assert!(!buffer.is_empty(), "emit_buffered called with empty buffer");
+    let timestamp = first_event_timestamp
+        .and_then(|ts| if ts != 0 { Some(ts) } else { None })
+        .or_else(|| extract_timestamp(&buffer[0]))
+        .unwrap_or_else(|| {
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0)
+        });
+    // Join without separator to match Java's StringBuilder.append(partialLogLine) behavior.
+    let joined = buffer.join("");
+    let message = if joined.len() <= MAX_EVENT_SIZE {
+        joined
+    } else {
+        let first_line = &buffer[0][..80.min(buffer[0].len())];
+        tracing::warn!(
+            original_size = joined.len(),
+            max_size = MAX_EVENT_SIZE,
+            first_line,
+            "Truncating oversized multiline event"
+        );
+        let mut end = MAX_EVENT_SIZE;
+        while !joined.is_char_boundary(end) {
+            end -= 1;
+        }
+        joined[..end].to_string()
+    };
+    LogEvent { timestamp, message }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(ts: i64, msg: &str) -> LogEvent {
+        LogEvent {
+            timestamp: ts,
+            message: msg.into(),
+        }
+    }
+
+    #[test]
+    fn test_default_pattern_groups_non_matching_lines() {
+        // With None pattern, the default Java pattern is applied.
+        // Lines without date/JSON prefix are grouped as continuations.
+        let lines = vec![ev(1000, "line1"), ev(1000, "line2"), ev(1000, "line3")];
+        let events = assemble_multiline(lines, None);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "line1line2line3");
+    }
+
+    #[test]
+    fn test_default_pattern_splits_on_date() {
+        let lines = vec![
+            ev(1000, "2024-01-15 first event"),
+            ev(1000, "  continuation"),
+            ev(1000, "2024-01-16 second event"),
+        ];
+        let events = assemble_multiline(lines, None);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].message, "2024-01-15 first event  continuation");
+        assert_eq!(events[1].message, "2024-01-16 second event");
+    }
+
+    #[test]
+    fn test_default_pattern_splits_on_json() {
+        let lines = vec![ev(1000, r#"{"key":"val1"}"#), ev(1000, r#"{"key":"val2"}"#)];
+        let events = assemble_multiline(lines, None);
+        assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn test_multiline_assembly() {
+        let pattern = Regex::new(r"^\d{4}-\d{2}-\d{2}").unwrap();
+        let lines = vec![
+            ev(1705276800000, "2024-01-15 ERROR something"),
+            ev(0, "  stack trace line 1"),
+            ev(0, "  stack trace line 2"),
+            ev(1705363200000, "2024-01-16 INFO next event"),
+        ];
+        let events = assemble_multiline(lines, Some(&pattern));
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].message,
+            "2024-01-15 ERROR something  stack trace line 1  stack trace line 2"
+        );
+        assert_eq!(events[1].message, "2024-01-16 INFO next event");
+    }
+
+    #[test]
+    fn test_eof_flush() {
+        let pattern = Regex::new(r"^START").unwrap();
+        let lines = vec![ev(1000, "START event1"), ev(0, "continuation")];
+        let events = assemble_multiline(lines, Some(&pattern));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "START event1continuation");
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let events = assemble_multiline(vec![], None);
+        assert!(events.is_empty());
+
+        let pattern = Regex::new(r"^START").unwrap();
+        let events = assemble_multiline(vec![], Some(&pattern));
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_empty_lines_skipped() {
+        let lines = vec![
+            ev(1000, "line1"),
+            ev(0, ""),
+            ev(0, "   "),
+            ev(1000, "line2"),
+        ];
+        let events = assemble_multiline(lines, None);
+        // Default pattern groups non-matching lines; empty lines are filtered
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "line1line2");
+    }
+
+    #[test]
+    fn test_timestamp_extraction_in_multiline() {
+        let pattern = Regex::new(r"^\d{13}").unwrap();
+        let lines = vec![
+            ev(1705314645000, "1705314645000 first event"),
+            ev(0, "continuation"),
+            ev(1705314646000, "1705314646000 second event"),
+        ];
+        let events = assemble_multiline(lines, Some(&pattern));
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].timestamp, 1705314645000);
+        assert_eq!(events[1].timestamp, 1705314646000);
+    }
+
+    #[test]
+    fn test_timestamp_fallback_to_system_time() {
+        let lines = vec![ev(0, "no timestamp here")];
+        let before = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+        let events = assemble_multiline(lines, None);
+        let after = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+        // Timestamp should be current time, not the default
+        assert!(events[0].timestamp >= before && events[0].timestamp <= after);
+    }
+
+    #[test]
+    fn test_orphan_continuation_lines() {
+        let pattern = Regex::new(r"^START").unwrap();
+        let lines = vec![
+            ev(0, "  orphan continuation 1"),
+            ev(0, "  orphan continuation 2"),
+            ev(1000, "START actual event"),
+        ];
+        let events = assemble_multiline(lines, Some(&pattern));
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].message,
+            "  orphan continuation 1  orphan continuation 2"
+        );
+        assert_eq!(events[1].message, "START actual event");
+    }
+
+    #[test]
+    fn test_only_orphan_lines() {
+        let pattern = Regex::new(r"^START").unwrap();
+        let lines = vec![ev(0, "  orphan line 1"), ev(0, "  orphan line 2")];
+        let events = assemble_multiline(lines, Some(&pattern));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "  orphan line 1  orphan line 2");
+    }
+
+    #[test]
+    fn test_oversized_multiline_truncation() {
+        let pattern = Regex::new(r"^START").unwrap();
+        let large_line = "x".repeat(200_000);
+        let lines = vec![
+            ev(1000, "START event"),
+            ev(0, &large_line),
+            ev(0, &large_line),
+        ];
+        let events = assemble_multiline(lines, Some(&pattern));
+        assert_eq!(events.len(), 1);
+        assert!(events[0].message.len() <= MAX_EVENT_SIZE);
+    }
+
+    #[test]
+    fn test_regex_pathological_pattern_no_crash() {
+        let pattern = Regex::new(r"^(a+)+$").unwrap();
+        let lines = vec![ev(1000, "aaaaaaaaaaaaaaaaab")];
+        let events = assemble_multiline(lines, Some(&pattern));
+        assert!(!events.is_empty());
+    }
+
+    #[test]
+    fn test_orphan_lines_flushed_on_pattern_change() {
+        let pattern1 = Regex::new(r"^START").unwrap();
+        let lines1 = vec![ev(0, "  orphan line"), ev(1000, "START event")];
+        let events1 = assemble_multiline(lines1, Some(&pattern1));
+        assert_eq!(events1.len(), 2);
+
+        let pattern2 = Regex::new(r"^BEGIN").unwrap();
+        let lines2 = vec![ev(0, "  leftover orphan"), ev(2000, "BEGIN new event")];
+        let events2 = assemble_multiline(lines2, Some(&pattern2));
+        assert_eq!(events2.len(), 2);
+        assert_eq!(events2[0].message, "  leftover orphan");
+        assert_eq!(events2[1].message, "BEGIN new event");
+    }
+}

--- a/src/scanner/reader.rs
+++ b/src/scanner/reader.rs
@@ -3,14 +3,12 @@
 
 //! File reader with offset tracking and content hashing
 
+use super::MAX_EVENT_SIZE;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use sha2::{Digest, Sha256};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
-
-/// Maximum event size in bytes (CloudWatch Logs limit: 256KB - 8 timestamp - 26 overhead)
-const MAX_EVENT_SIZE: usize = 262_110;
 
 /// A parsed log event with timestamp and message
 #[derive(Debug, Clone, PartialEq)]

--- a/tests/emf_tailing_test.rs
+++ b/tests/emf_tailing_test.rs
@@ -3,7 +3,7 @@
 
 //! Integration tests for EMF file tailing end-to-end
 
-use gg_log_manager::scanner::{read_file_from_offset, LogEvent};
+use gg_log_manager::scanner::read_file_from_offset;
 use std::fs::File;
 use std::io::Write;
 use tempfile::TempDir;

--- a/tests/multiline_integration_test.rs
+++ b/tests/multiline_integration_test.rs
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for multiline log assembly
+
+use gg_log_manager::scanner::{assemble_multiline, read_file_from_offset};
+use regex::Regex;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_multiline_with_scanner() {
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(file, "2024-01-15T10:00:00 ERROR NullPointerException").unwrap();
+    writeln!(file, "    at com.example.App.main(App.java:42)").unwrap();
+    writeln!(file, "    at java.lang.Thread.run(Thread.java:750)").unwrap();
+    writeln!(file, "2024-01-15T10:00:01 INFO Recovery complete").unwrap();
+
+    let (lines, _) = read_file_from_offset(file.path(), 0, 1000).unwrap();
+
+    let pattern = Regex::new(r"^\d{4}-\d{2}-\d{2}").unwrap();
+    let events = assemble_multiline(lines, Some(&pattern));
+
+    assert_eq!(events.len(), 2);
+    assert!(events[0].message.contains("NullPointerException"));
+    assert!(events[0].message.contains("App.java:42"));
+    assert!(events[0].message.contains("Thread.java:750"));
+    assert_eq!(
+        events[1].message,
+        "2024-01-15T10:00:01 INFO Recovery complete"
+    );
+}
+
+#[test]
+fn test_emf_single_line_passthrough() {
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(
+        file,
+        r#"{{"_aws":{{"Timestamp":1705314645000}},"metric":1}}"#
+    )
+    .unwrap();
+    writeln!(
+        file,
+        r#"{{"_aws":{{"Timestamp":1705314646000}},"metric":2}}"#
+    )
+    .unwrap();
+
+    let (lines, _) = read_file_from_offset(file.path(), 0, 1000).unwrap();
+
+    let events = assemble_multiline(lines, None);
+
+    assert_eq!(events.len(), 2);
+    assert!(events[0].message.contains(r#""metric":1"#));
+    assert!(events[1].message.contains(r#""metric":2"#));
+    // Timestamp comes from LogEvent.timestamp (set by reader's default_timestamp), not from assemble_multiline
+    assert_eq!(events[0].timestamp, 1000);
+    assert_eq!(events[1].timestamp, 1000);
+}


### PR DESCRIPTION
## Multi-line log assembly (task 1.4)

Implements multiline log event grouping for the Rust LogManager, matching Java LogManager behavior.

### Changes
- `assemble_multiline()`: buffers lines until start pattern match, emits concatenated (no separator, matching Java's `StringBuilder.append`)
- Default pattern `^[\[(]?\d{4}-\d\d-\d\d|^\{` applied when `multiLineStartPattern` is null (matching Java's `DEFAULT_MULTILINE_PATTERN`)
- Timestamp fallback uses `SystemTime::now()` (matching Java's `Instant.now()`)
- Accepts `Vec<LogEvent>` directly, eliminating double timestamp parsing
- Oversized multiline truncation at 256KB CW limit with first-line context in warning

### Java behavioral parity
| Behavior | Java | Rust | Match |
|---|---|---|---|
| Default pattern when null | `DEFAULT_MULTILINE_PATTERN` | Same via `LazyLock` | ✅ |
| Join separator | `StringBuilder.append()` — none | `buffer.join("")` — none | ✅ |
| Timestamp fallback | `Instant.now()` | `SystemTime::now()` | ✅ |
| MAX_EVENT_LENGTH | 262,110 | 262,110 | ✅ |

### Known gaps (tracked separately in Asana)
- Oversized events: Java chunks, Rust truncates
- Log level filtering: not yet implemented (batcher scope)

### Tests
14 unit tests + 2 integration tests, 0 failures
