### PR TITLE
feat(scanner): checkpoint persistence and restart recovery

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,7 +28,24 @@ pub fn load_config(config_arg: &str) -> Result<LogManagerConfig, ConfigError> {
 
 #[must_use = "config result must be handled"]
 pub fn parse_config(json: &str) -> Result<LogManagerConfig, ConfigError> {
-    serde_json::from_str(json).map_err(|e| ConfigError::Parse(format!("{e}")))
+    let mut config: LogManagerConfig =
+        serde_json::from_str(json).map_err(|e| ConfigError::Parse(format!("{e}")))?;
+    // Deduplicate by component name, last-wins.
+    let mut seen = std::collections::HashMap::new();
+    for (i, c) in config.component_logs_configuration.iter().enumerate().rev() {
+        seen.entry(c.component_name.clone()).or_insert(i);
+    }
+    if seen.len() < config.component_logs_configuration.len() {
+        let indices: std::collections::HashSet<usize> = seen.into_values().collect();
+        config.component_logs_configuration = config
+            .component_logs_configuration
+            .into_iter()
+            .enumerate()
+            .filter(|(i, _)| indices.contains(i))
+            .map(|(_, c)| c)
+            .collect();
+    }
+    Ok(config)
 }
 
 /// Validate a single log source's directory, regex, and disk limit.
@@ -248,5 +265,32 @@ mod tests {
         let result = load_config("/nonexistent/config.json");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("IO error"));
+    }
+
+    #[test]
+    fn test_duplicate_component_name_last_wins() {
+        let json = r#"{
+            "componentLogsConfiguration": [
+                {
+                    "componentName": "MyApp",
+                    "logFileDirectoryPath": "/first/dir",
+                    "logFileRegex": ".*\\.log"
+                },
+                {
+                    "componentName": "MyApp",
+                    "logFileDirectoryPath": "/second/dir",
+                    "logFileRegex": ".*\\.log"
+                }
+            ]
+        }"#;
+        let config = parse_config(json).unwrap();
+        // Java's Map.put deduplicates by name, last wins
+        assert_eq!(config.component_logs_configuration.len(), 1);
+        assert_eq!(
+            config.component_logs_configuration[0]
+                .source
+                .log_file_directory_path,
+            "/second/dir"
+        );
     }
 }

--- a/src/scanner/checkpoint.rs
+++ b/src/scanner/checkpoint.rs
@@ -2,3 +2,604 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Checkpoint persistence with atomic writes and restart recovery.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::ScannedFile;
+
+/// Per-file checkpoint state. Compatible with Java LogManager v2.3.1+ config.tlog.
+/// Java's deprecated `currentProcessingFileName` field is ignored on read, not written.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FileCheckpoint {
+    #[serde(rename = "currentProcessingFileHash")]
+    pub file_hash: String,
+    #[serde(rename = "currentProcessingFileStartPosition")]
+    pub start_position: u64,
+    #[serde(rename = "currentProcessingFileLastModified")]
+    pub last_modified_time: u64,
+    /// Epoch millis when this entry was last accessed. Defaults to now on construction.
+    #[serde(rename = "lastAccessed")]
+    pub last_accessed: u64,
+}
+
+impl FileCheckpoint {
+    /// Create a new checkpoint entry. `last_accessed` is set to now automatically.
+    pub fn new(file_hash: String, start_position: u64, last_modified_time: u64) -> Self {
+        Self {
+            file_hash,
+            start_position,
+            last_modified_time,
+            last_accessed: now_ms(),
+        }
+    }
+}
+
+/// Timestamp of the last fully processed file for a component.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LastFileProcessedTimestamp {
+    #[serde(rename = "lastFileProcessedTimeStamp")]
+    pub last_file_processed_time_stamp: u64,
+}
+
+/// Checkpoint store for all components.
+///
+/// # Write semantics (for batcher implementer)
+/// - Load path: use `putIfAbsent` — don't overwrite existing entries
+/// - Upload path: use `put` — overwrite with new startPosition + trigger TTL eviction
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct CheckpointStore {
+    #[serde(rename = "currentComponentFileProcessingInformationV2", default)]
+    pub file_processing_info: HashMap<String, HashMap<String, FileCheckpoint>>,
+    #[serde(rename = "componentLastFileProcessedTimeStamp", default)]
+    pub last_processed_timestamps: HashMap<String, LastFileProcessedTimestamp>,
+}
+
+/// Save checkpoint atomically: write to temp file, then rename.
+///
+/// # Errors
+/// Returns `io::Error` if the file cannot be created, written, synced, or renamed.
+pub fn save_checkpoint(path: &Path, store: &CheckpointStore) -> io::Result<()> {
+    let tmp_path = path.with_extension("tmp");
+    let result = (|| -> io::Result<()> {
+        let file = fs::File::create(&tmp_path)
+            .map_err(|e| io::Error::new(e.kind(), format!("create {}: {e}", tmp_path.display())))?;
+        serde_json::to_writer_pretty(&file, store)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        file.sync_all()
+            .map_err(|e| io::Error::new(e.kind(), format!("sync {}: {e}", tmp_path.display())))?;
+        fs::rename(&tmp_path, path)
+            .map_err(|e| io::Error::new(e.kind(), format!("rename to {}: {e}", path.display())))?;
+        // Fsync parent directory to ensure the rename is durable on power loss
+        if let Some(parent) = path.parent() {
+            fs::File::open(parent)?.sync_all()?;
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
+    }
+    result?;
+    tracing::debug!(path = %path.display(), "Checkpoint saved");
+    Ok(())
+}
+
+/// Load checkpoint from disk. Returns empty store if file missing or corrupt.
+///
+/// # Errors
+/// Returns `io::Error` on read failures other than `NotFound`.
+pub fn load_checkpoint(path: &Path) -> io::Result<CheckpointStore> {
+    match fs::read_to_string(path) {
+        Ok(content) => match serde_json::from_str::<CheckpointStore>(&content) {
+            Ok(store) => {
+                let entry_count: usize = store.file_processing_info.values().map(|m| m.len()).sum();
+                tracing::debug!(path = %path.display(), entry_count = entry_count, "Checkpoint loaded");
+                Ok(store)
+            }
+            Err(e) => {
+                tracing::warn!("Corrupt checkpoint file, starting fresh: {}", e);
+                Ok(CheckpointStore::default())
+            }
+        },
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(CheckpointStore::default()),
+        Err(e) => Err(io::Error::new(
+            e.kind(),
+            format!("read {}: {e}", path.display()),
+        )),
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Trim stale entries where lastModifiedTime is at or before the component's
+/// lastFileProcessedTimeStamp. Prevents loading already-completed entries from older LM versions.
+pub fn trim_stale_on_load(store: &mut CheckpointStore) {
+    let ts_snapshot: HashMap<&str, u64> = store
+        .last_processed_timestamps
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.last_file_processed_time_stamp))
+        .collect();
+
+    for (component, files) in &mut store.file_processing_info {
+        if let Some(&cutoff) = ts_snapshot.get(component.as_str()) {
+            let before = files.len();
+            files.retain(|_, cp| cp.last_modified_time > cutoff);
+            let removed = before - files.len();
+            if removed > 0 {
+                tracing::info!(
+                    component = component.as_str(),
+                    removed,
+                    "Trimmed stale entries on load"
+                );
+            }
+        }
+    }
+}
+
+/// Recover file offsets from checkpoint for restart recovery.
+/// Returns (file_path, resume_offset) pairs for each scanned file.
+/// Updates last_accessed on read (touch-on-read).
+/// Evicts entries for files no longer on disk (see DIVERGENCE comment in body).
+///
+/// The caller must pass ALL files for the component in a single call.
+/// One directory per component — the config schema enforces this.
+#[must_use = "recovered offsets must be used for file reading"]
+pub fn recover_offsets(
+    checkpoint: &mut CheckpointStore,
+    log_group_key: &str,
+    scanned_files: &[ScannedFile],
+) -> Vec<(PathBuf, u64)> {
+    let current_hashes: HashSet<&str> = scanned_files
+        .iter()
+        .map(|f| f.content_hash.as_str())
+        .collect();
+    let now = now_ms();
+
+    let result: Vec<(PathBuf, u64)> = scanned_files
+        .iter()
+        .map(|file| {
+            let offset = checkpoint
+                .file_processing_info
+                .get_mut(log_group_key)
+                .and_then(|m| m.get_mut(&file.content_hash))
+                .map(|cp| {
+                    cp.last_accessed = now; // touch-on-read
+                    tracing::debug!(
+                        "Resuming file {} from offset {}",
+                        file.path.display(),
+                        cp.start_position
+                    );
+                    cp.start_position
+                })
+                .unwrap_or_else(|| {
+                    tracing::debug!("New file {}, reading from start", file.path.display());
+                    0
+                });
+            (file.path.clone(), offset)
+        })
+        .collect();
+
+    // DIVERGENCE: Java evicts via TTL on every put() call (triggered by upload
+    // callbacks) and explicitly via deleteFileFromGroup() on completed files.
+    // We evict on scan because the upload path doesn't exist yet.
+    // Move to upload path when batcher lands.
+    if let Some(file_map) = checkpoint.file_processing_info.get_mut(log_group_key) {
+        file_map.retain(|hash, _| {
+            let keep = current_hashes.contains(hash.as_str());
+            if !keep {
+                tracing::debug!("Evicting checkpoint for hash {}", hash);
+            }
+            keep
+        });
+    }
+
+    result
+}
+
+/// Remove all checkpoint data for a component. Called when a component is removed from config.
+pub fn remove_component(store: &mut CheckpointStore, component: &str) {
+    store.file_processing_info.remove(component);
+    store.last_processed_timestamps.remove(component);
+    tracing::debug!(component, "Removed checkpoint data for component");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scanner::ScannedFile;
+    use std::time::SystemTime;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_save_and_reload() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+
+        let mut store = CheckpointStore::default();
+        let mut files = HashMap::new();
+        files.insert(
+            "abc123".to_string(),
+            FileCheckpoint {
+                file_hash: "abc123".to_string(),
+                start_position: 1024,
+                last_modified_time: 1700000000000,
+                last_accessed: 1700000001000,
+            },
+        );
+        store
+            .file_processing_info
+            .insert("/aws/greengrass/test".to_string(), files);
+        store.last_processed_timestamps.insert(
+            "/aws/greengrass/test".to_string(),
+            LastFileProcessedTimestamp {
+                last_file_processed_time_stamp: 1700000000000,
+            },
+        );
+
+        save_checkpoint(&path, &store).unwrap();
+        let loaded = load_checkpoint(&path).unwrap();
+        assert_eq!(store, loaded);
+    }
+
+    // Verifies the serialized JSON uses Java's field names for backward compatibility for checkpointing.
+    #[test]
+    fn test_json_field_names_match_java() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+
+        let mut store = CheckpointStore::default();
+        let mut files = HashMap::new();
+        files.insert(
+            "hash123".to_string(),
+            FileCheckpoint {
+                file_hash: "hash123".to_string(),
+                start_position: 512,
+                last_modified_time: 1600000000000,
+                last_accessed: 1600000001000,
+            },
+        );
+        store
+            .file_processing_info
+            .insert("test-group".to_string(), files);
+
+        save_checkpoint(&path, &store).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+
+        // Verify Java-compatible field names
+        assert!(content.contains("currentComponentFileProcessingInformationV2"));
+        assert!(content.contains("currentProcessingFileHash"));
+        assert!(content.contains("currentProcessingFileStartPosition"));
+        assert!(content.contains("currentProcessingFileLastModified"));
+        assert!(content.contains("lastAccessed"));
+    }
+
+    #[test]
+    fn test_load_java_checkpoint() {
+        // Simulate a checkpoint written by Java LogManager
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.tlog");
+        let java_checkpoint = r#"{
+            "currentComponentFileProcessingInformationV2": {
+                "system-health": {
+                    "abc123hash": {
+                        "currentProcessingFileHash": "abc123hash",
+                        "currentProcessingFileStartPosition": 2048,
+                        "currentProcessingFileLastModified": 1709913600000,
+                        "lastAccessed": 1709913660000
+                    }
+                }
+            },
+            "componentLastFileProcessedTimeStamp": {
+                "system-health": {
+                    "lastFileProcessedTimeStamp": 1709913600000
+                }
+            }
+        }"#;
+        fs::write(&path, java_checkpoint).unwrap();
+
+        let store = load_checkpoint(&path).unwrap();
+        let files = store.file_processing_info.get("system-health").unwrap();
+        let entry = files.get("abc123hash").unwrap();
+        assert_eq!(entry.file_hash, "abc123hash");
+        assert_eq!(entry.start_position, 2048);
+        assert_eq!(entry.last_modified_time, 1709913600000);
+        assert_eq!(entry.last_accessed, 1709913660000);
+    }
+
+    #[test]
+    fn test_atomic_write_no_partial() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+        let tmp_path = path.with_extension("tmp");
+
+        let store = CheckpointStore::default();
+        save_checkpoint(&path, &store).unwrap();
+
+        assert!(!tmp_path.exists());
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_missing_file_returns_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonexistent.json");
+        let store = load_checkpoint(&path).unwrap();
+        assert!(store.file_processing_info.is_empty());
+        assert!(store.last_processed_timestamps.is_empty());
+    }
+
+    #[test]
+    fn test_corrupt_json_returns_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("corrupt.json");
+        fs::write(&path, "{ invalid json }").unwrap();
+        let result = load_checkpoint(&path).unwrap();
+        assert!(result.file_processing_info.is_empty());
+        assert!(result.last_processed_timestamps.is_empty());
+    }
+
+    #[test]
+    fn test_recover_offsets_matching_hash() {
+        let mut store = CheckpointStore::default();
+        let mut files = HashMap::new();
+        files.insert(
+            "hash123".to_string(),
+            FileCheckpoint {
+                file_hash: "hash123".to_string(),
+                start_position: 1024,
+                last_modified_time: 1700000000000,
+                last_accessed: 1700000001000,
+            },
+        );
+        store
+            .file_processing_info
+            .insert("test-group".to_string(), files);
+
+        let scanned = vec![ScannedFile {
+            path: PathBuf::from("/var/log/app.log"),
+            mtime: SystemTime::now(),
+            content_hash: "hash123".to_string(),
+            is_active: true,
+        }];
+
+        let result = recover_offsets(&mut store, "test-group", &scanned);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, PathBuf::from("/var/log/app.log"));
+        assert_eq!(result[0].1, 1024);
+    }
+
+    #[test]
+    fn test_recover_offsets_new_file() {
+        let mut store = CheckpointStore::default();
+
+        let scanned = vec![ScannedFile {
+            path: PathBuf::from("/var/log/new.log"),
+            mtime: SystemTime::now(),
+            content_hash: "newhash".to_string(),
+            is_active: true,
+        }];
+
+        let result = recover_offsets(&mut store, "test-group", &scanned);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].1, 0);
+    }
+
+    #[test]
+    fn test_recover_offsets_removes_stale() {
+        let mut store = CheckpointStore::default();
+        let mut files = HashMap::new();
+        files.insert(
+            "stale_hash".to_string(),
+            FileCheckpoint {
+                file_hash: "stale_hash".to_string(),
+                start_position: 500,
+                last_modified_time: 1700000000000,
+                last_accessed: 1700000001000,
+            },
+        );
+        files.insert(
+            "current_hash".to_string(),
+            FileCheckpoint {
+                file_hash: "current_hash".to_string(),
+                start_position: 200,
+                last_modified_time: 1700000000000,
+                last_accessed: 1700000001000,
+            },
+        );
+        store
+            .file_processing_info
+            .insert("test-group".to_string(), files);
+
+        let scanned = vec![ScannedFile {
+            path: PathBuf::from("/var/log/current.log"),
+            mtime: SystemTime::now(),
+            content_hash: "current_hash".to_string(),
+            is_active: true,
+        }];
+
+        let _ = recover_offsets(&mut store, "test-group", &scanned);
+
+        let remaining = store.file_processing_info.get("test-group").unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert!(remaining.contains_key("current_hash"));
+        assert!(!remaining.contains_key("stale_hash"));
+    }
+
+    #[test]
+    fn test_trim_stale_on_load() {
+        let mut store = CheckpointStore::default();
+        let mut files = HashMap::new();
+        // Entry with lastModifiedTime BEFORE lastProcessedTimestamp — should be trimmed
+        files.insert(
+            "old_hash".to_string(),
+            FileCheckpoint {
+                file_hash: "old_hash".to_string(),
+                start_position: 100,
+                last_modified_time: 1000,
+                last_accessed: 2000,
+            },
+        );
+        // Entry with lastModifiedTime AFTER lastProcessedTimestamp — should be kept
+        files.insert(
+            "new_hash".to_string(),
+            FileCheckpoint {
+                file_hash: "new_hash".to_string(),
+                start_position: 200,
+                last_modified_time: 3000,
+                last_accessed: 4000,
+            },
+        );
+        store.file_processing_info.insert("comp".to_string(), files);
+        store.last_processed_timestamps.insert(
+            "comp".to_string(),
+            LastFileProcessedTimestamp {
+                last_file_processed_time_stamp: 2000,
+            },
+        );
+
+        trim_stale_on_load(&mut store);
+
+        let remaining = store.file_processing_info.get("comp").unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert!(remaining.contains_key("new_hash"));
+        assert!(!remaining.contains_key("old_hash"));
+    }
+
+    #[test]
+    fn test_touch_on_read_refreshes_old_entries() {
+        let mut store = CheckpointStore::default();
+        let mut files = HashMap::new();
+        // Entry with old last_accessed — touch-on-read will refresh it
+        let old_accessed = now_ms() - 90_000_000; // 25 hours ago
+        files.insert(
+            "stale_ttl".to_string(),
+            FileCheckpoint {
+                file_hash: "stale_ttl".to_string(),
+                start_position: 100,
+                last_modified_time: 1000,
+                last_accessed: old_accessed,
+            },
+        );
+        // Fresh entry — should be kept
+        files.insert(
+            "fresh_hash".to_string(),
+            FileCheckpoint {
+                file_hash: "fresh_hash".to_string(),
+                start_position: 200,
+                last_modified_time: 2000,
+                last_accessed: now_ms(),
+            },
+        );
+        store
+            .file_processing_info
+            .insert("group".to_string(), files);
+
+        // Both files are on disk, but stale_ttl has old last_accessed
+        let scanned = vec![
+            ScannedFile {
+                path: PathBuf::from("/var/log/stale.log"),
+                mtime: SystemTime::now(),
+                content_hash: "stale_ttl".to_string(),
+                is_active: false,
+            },
+            ScannedFile {
+                path: PathBuf::from("/var/log/fresh.log"),
+                mtime: SystemTime::now(),
+                content_hash: "fresh_hash".to_string(),
+                is_active: true,
+            },
+        ];
+
+        let _ = recover_offsets(&mut store, "group", &scanned);
+
+        // Both files are on disk — both survive. Touch-on-read refreshes last_accessed.
+        let remaining = store.file_processing_info.get("group").unwrap();
+        assert_eq!(remaining.len(), 2);
+        // Verify old entry's last_accessed was refreshed
+        assert!(remaining.get("stale_ttl").unwrap().last_accessed > old_accessed);
+    }
+
+    #[test]
+    fn test_touch_on_read_updates_last_accessed() {
+        let mut store = CheckpointStore::default();
+        let mut files = HashMap::new();
+        let old_accessed = 1000; // very old
+        files.insert(
+            "hash1".to_string(),
+            FileCheckpoint {
+                file_hash: "hash1".to_string(),
+                start_position: 500,
+                last_modified_time: 2000,
+                last_accessed: old_accessed,
+            },
+        );
+        store
+            .file_processing_info
+            .insert("group".to_string(), files);
+
+        let scanned = vec![ScannedFile {
+            path: PathBuf::from("/var/log/app.log"),
+            mtime: SystemTime::now(),
+            content_hash: "hash1".to_string(),
+            is_active: true,
+        }];
+
+        let before = now_ms();
+        let _ = recover_offsets(&mut store, "group", &scanned);
+        let after = now_ms();
+
+        let entry = store
+            .file_processing_info
+            .get("group")
+            .unwrap()
+            .get("hash1")
+            .unwrap();
+        // last_accessed should be updated to approximately now
+        assert!(entry.last_accessed >= before);
+        assert!(entry.last_accessed <= after);
+    }
+
+    #[test]
+    fn test_remove_component() {
+        let mut store = CheckpointStore::default();
+        let mut files = HashMap::new();
+        files.insert(
+            "h1".to_string(),
+            FileCheckpoint::new("h1".into(), 100, 1000),
+        );
+        store
+            .file_processing_info
+            .insert("comp-a".to_string(), files);
+        store.last_processed_timestamps.insert(
+            "comp-a".to_string(),
+            LastFileProcessedTimestamp {
+                last_file_processed_time_stamp: 1000,
+            },
+        );
+
+        remove_component(&mut store, "comp-a");
+
+        assert!(!store.file_processing_info.contains_key("comp-a"));
+        assert!(!store.last_processed_timestamps.contains_key("comp-a"));
+    }
+
+    #[test]
+    fn test_save_checkpoint_cleans_tmp_on_error() {
+        // Write to a nonexistent directory — create will fail
+        let path = Path::new("/nonexistent/dir/checkpoint.json");
+        let tmp_path = path.with_extension("tmp");
+        let store = CheckpointStore::default();
+        let result = save_checkpoint(path, &store);
+        assert!(result.is_err());
+        assert!(!tmp_path.exists());
+    }
+}

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -7,6 +7,10 @@ mod checkpoint;
 mod multiline;
 mod reader;
 
+pub use checkpoint::{
+    load_checkpoint, recover_offsets, remove_component, save_checkpoint, trim_stale_on_load,
+    CheckpointStore, FileCheckpoint,
+};
 pub use multiline::assemble_multiline;
 pub use reader::{compute_content_hash, read_file_from_offset, LogEvent};
 

--- a/src/scanner/multiline.rs
+++ b/src/scanner/multiline.rs
@@ -12,15 +12,15 @@ use std::time::SystemTime;
 /// Sentinel value indicating no timestamp was parsed for a LogEvent.
 const NO_TIMESTAMP: i64 = 0;
 
-/// Default multiline start pattern matching Java LogManager behavior.
+/// Default multiline start pattern for log lines starting with a date or JSON.
 /// Matches lines starting with a date (optionally in brackets/parens) or JSON object.
 static DEFAULT_MULTILINE_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[\[(]?\d{4}-\d\d-\d\d|^\{").unwrap());
 
 /// Assemble lines into LogEvents based on multi-line start pattern.
-/// When start_pattern is None, the default pattern is applied (matching Java behavior).
+/// When start_pattern is None, the default pattern is applied.
 /// When start_pattern is Some, that pattern is used.
-/// Lines are buffered until a new match, then emitted concatenated (no separator, matching Java).
+/// Lines are buffered until a new match, then emitted concatenated (no separator).
 ///
 /// # Examples
 ///

--- a/src/scanner/reader.rs
+++ b/src/scanner/reader.rs
@@ -26,7 +26,7 @@ pub fn compute_content_hash(path: &Path) -> std::io::Result<String> {
     let mut buffer = [0u8; 1024];
     let bytes_read = file.read(&mut buffer)?;
     let data = &buffer[..bytes_read];
-    // Match Java: decode bytes as UTF-8 string, then hash the string bytes
+    // Decode bytes as UTF-8 string, then hash the string bytes
     let text = String::from_utf8_lossy(data);
     let hash_input = match text.find('\n') {
         Some(pos) => &text[..=pos],

--- a/tests/checkpoint_integration_test.rs
+++ b/tests/checkpoint_integration_test.rs
@@ -1,0 +1,109 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for checkpoint persistence and restart recovery
+
+use gg_log_manager::scanner::{
+    load_checkpoint, recover_offsets, save_checkpoint, scan_directory, CheckpointStore,
+    FileCheckpoint,
+};
+use regex::Regex;
+use std::io::Write;
+use tempfile::tempdir;
+
+#[test]
+fn test_scan_checkpoint_restart_resume() {
+    let dir = tempdir().unwrap();
+    let checkpoint_path = dir.path().join("checkpoint.json");
+
+    // Write 3 log files with known content
+    for name in &["a.log", "b.log", "c.log"] {
+        let mut f = std::fs::File::create(dir.path().join(name)).unwrap();
+        writeln!(f, "log line from {name}").unwrap();
+    }
+
+    // First scan
+    let pattern = Regex::new(r".*\.log$").unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    assert_eq!(files.len(), 3);
+
+    // Simulate partial upload: checkpoint 2 files with offsets
+    let mut store = CheckpointStore::default();
+    let mut file_map = std::collections::HashMap::new();
+    file_map.insert(
+        files[0].content_hash.clone(),
+        FileCheckpoint::new(files[0].content_hash.clone(), 10, 1000),
+    );
+    file_map.insert(
+        files[1].content_hash.clone(),
+        FileCheckpoint::new(files[1].content_hash.clone(), 20, 2000),
+    );
+    store
+        .file_processing_info
+        .insert("test-group".to_string(), file_map);
+
+    // Save checkpoint (simulating shutdown)
+    save_checkpoint(&checkpoint_path, &store).unwrap();
+
+    // Load checkpoint (simulating restart)
+    let mut loaded = load_checkpoint(&checkpoint_path).unwrap();
+
+    // Re-scan and recover offsets
+    let files_after_restart = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    let offsets = recover_offsets(&mut loaded, "test-group", &files_after_restart);
+
+    // Assert: 2 files resume from checkpointed offsets, 1 starts at 0
+    assert_eq!(offsets.len(), 3);
+    let offset_map: std::collections::HashMap<_, _> = offsets.into_iter().collect();
+    assert_eq!(offset_map[&files[0].path], 10);
+    assert_eq!(offset_map[&files[1].path], 20);
+    assert_eq!(offset_map[&files[2].path], 0);
+}
+
+#[test]
+fn test_checkpoint_stale_entry_removed_after_file_deleted() {
+    let dir = tempdir().unwrap();
+    let checkpoint_path = dir.path().join("checkpoint.json");
+
+    // Write 2 log files
+    for name in &["keep.log", "delete_me.log"] {
+        let mut f = std::fs::File::create(dir.path().join(name)).unwrap();
+        writeln!(f, "content of {name}").unwrap();
+    }
+
+    // Scan and checkpoint both
+    let pattern = Regex::new(r".*\.log$").unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    assert_eq!(files.len(), 2);
+
+    let mut store = CheckpointStore::default();
+    let mut file_map = std::collections::HashMap::new();
+    for file in &files {
+        file_map.insert(
+            file.content_hash.clone(),
+            FileCheckpoint::new(file.content_hash.clone(), 100, 1000),
+        );
+    }
+    store
+        .file_processing_info
+        .insert("test-group".to_string(), file_map);
+    save_checkpoint(&checkpoint_path, &store).unwrap();
+
+    // Delete one file
+    std::fs::remove_file(dir.path().join("delete_me.log")).unwrap();
+
+    // Re-scan (now only 1 file) and recover
+    let mut loaded = load_checkpoint(&checkpoint_path).unwrap();
+    let files_after = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    assert_eq!(files_after.len(), 1);
+
+    let offsets = recover_offsets(&mut loaded, "test-group", &files_after);
+
+    // Remaining file resumes at checkpointed offset
+    assert_eq!(offsets.len(), 1);
+    assert_eq!(offsets[0].1, 100);
+
+    // Deleted file's checkpoint entry is evicted
+    let remaining = loaded.file_processing_info.get("test-group").unwrap();
+    assert_eq!(remaining.len(), 1);
+}


### PR DESCRIPTION
## Checkpoint persistence and restart recovery (task 1.5)

### Changes
- `FileCheckpoint` with backward-compatible serde field names (V2 format)
- `FileCheckpoint::new()` auto-sets `last_accessed` to now
- Atomic write (write-tmp + fsync file + rename + fsync parent directory)
- Tmp file cleanup on write error
- Load with corrupt/missing file fallback
- Startup stale trim: skip entries where `lastModifiedTime <= lastProcessedTimestamp`
- `recover_offsets`: resume from persisted byte offset per content hash
- Touch-on-read: update `last_accessed` on checkpoint access
- `remove_component`: cleanup when component removed from config
- Config dedup: duplicate component names deduplicated (last-wins)
- I/O errors include file path context

### Deferred to upload path
- TTL eviction (24h) — Java runs on every `put()` after upload
- Move scan-time eviction to upload path (documented DIVERGENCE)
- Update offset after upload
- Completed file detection
- Throttled persistence
- Shutdown flush
- `put` vs `putIfAbsent` semantics (documented in `CheckpointStore` doc comment)

### Tests
15 unit tests + 2 integration tests, 0 failures
