### PR TITLE
fix: match Java diskSpaceLimit defaults (#243)

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,7 +7,7 @@ mod schema;
 
 pub use schema::{
     ComponentLogConfig, ConfigError, DiskSpaceLimitUnit, LogLevel, LogManagerConfig,
-    LogSourceConfig, SystemLogConfig, DEFAULT_DISK_SPACE_LIMIT, DEFAULT_UPLOAD_INTERVAL_SEC,
+    LogSourceConfig, SystemLogConfig, DEFAULT_UPLOAD_INTERVAL_SEC,
 };
 
 use regex::Regex;
@@ -35,7 +35,9 @@ pub fn parse_config(json: &str) -> Result<LogManagerConfig, ConfigError> {
 fn validate_log_source(source: &LogSourceConfig) -> Result<(), ConfigError> {
     validate_directory(&source.log_file_directory_path)?;
     validate_regex(&source.log_file_regex)?;
-    validate_disk_limit(&source.disk_space_limit)?;
+    if let Some(ref limit) = source.disk_space_limit {
+        validate_disk_limit(limit)?;
+    }
     Ok(())
 }
 
@@ -87,12 +89,16 @@ fn validate_disk_limit(limit: &str) -> Result<(), ConfigError> {
     Ok(())
 }
 
-/// Parse diskSpaceLimit string to u64.
+/// Parse diskSpaceLimit string to u64. Returns None if limit is not configured.
 #[must_use = "parse result must be handled"]
-pub fn parse_disk_space_limit(limit: &str) -> Result<u64, ConfigError> {
-    limit
-        .parse()
-        .map_err(|_| ConfigError::Parse(format!("Invalid diskSpaceLimit: {limit}")))
+pub fn parse_disk_space_limit(limit: Option<&str>) -> Result<Option<u64>, ConfigError> {
+    match limit {
+        Some(l) => l
+            .parse()
+            .map(Some)
+            .map_err(|_| ConfigError::Parse(format!("Invalid diskSpaceLimit: {l}"))),
+        None => Ok(None),
+    }
 }
 
 /// Derive log group name: /aws/greengrass/{componentType}/{region}/{componentName}
@@ -217,9 +223,10 @@ mod tests {
 
     #[test]
     fn test_parse_disk_space_limit() {
-        assert_eq!(parse_disk_space_limit("100").unwrap(), 100);
-        assert_eq!(parse_disk_space_limit("0").unwrap(), 0);
-        assert!(parse_disk_space_limit("abc").is_err());
+        assert_eq!(parse_disk_space_limit(Some("100")).unwrap(), Some(100));
+        assert_eq!(parse_disk_space_limit(Some("0")).unwrap(), Some(0));
+        assert!(parse_disk_space_limit(Some("abc")).is_err());
+        assert_eq!(parse_disk_space_limit(None).unwrap(), None);
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 pub const DEFAULT_UPLOAD_INTERVAL_SEC: u64 = 300;
-pub const DEFAULT_DISK_SPACE_LIMIT: u64 = 25;
 
 /// Custom error type for configuration operations.
 #[derive(Debug)]
@@ -54,8 +53,8 @@ pub enum LogLevel {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum DiskSpaceLimitUnit {
-    KB,
     #[default]
+    KB,
     MB,
     GB,
 }
@@ -78,18 +77,14 @@ pub struct LogSourceConfig {
     pub log_file_regex: String,
     #[serde(default)]
     pub minimum_log_level: LogLevel,
-    #[serde(default = "default_disk_limit")]
-    pub disk_space_limit: String,
+    #[serde(default)]
+    pub disk_space_limit: Option<String>,
     #[serde(default)]
     pub disk_space_limit_unit: DiskSpaceLimitUnit,
     #[serde(default)]
     pub delete_log_file_after_cloud_upload: bool,
     pub multi_line_start_pattern: Option<String>,
     pub upload_interval_sec: Option<u64>,
-}
-
-fn default_disk_limit() -> String {
-    DEFAULT_DISK_SPACE_LIMIT.to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -143,8 +138,8 @@ mod tests {
     fn test_component_defaults() {
         let json = r#"{"componentName":"test","logFileDirectoryPath":"/tmp","logFileRegex":".*"}"#;
         let comp: ComponentLogConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(comp.source.disk_space_limit, "25");
-        assert_eq!(comp.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+        assert_eq!(comp.source.disk_space_limit, None);
+        assert_eq!(comp.source.disk_space_limit_unit, DiskSpaceLimitUnit::KB);
         assert_eq!(comp.source.minimum_log_level, LogLevel::Info);
     }
 
@@ -158,7 +153,7 @@ mod tests {
                     log_file_directory_path: "/var/log".into(),
                     log_file_regex: ".*\\.log".into(),
                     minimum_log_level: LogLevel::Debug,
-                    disk_space_limit: "50".into(),
+                    disk_space_limit: Some("50".into()),
                     disk_space_limit_unit: DiskSpaceLimitUnit::GB,
                     delete_log_file_after_cloud_upload: true,
                     multi_line_start_pattern: Some("^\\d".into()),
@@ -174,7 +169,7 @@ mod tests {
         assert_eq!(parsed.component_logs_configuration.len(), 1);
         let comp = &parsed.component_logs_configuration[0];
         assert_eq!(comp.component_name, "test");
-        assert_eq!(comp.source.disk_space_limit, "50");
+        assert_eq!(comp.source.disk_space_limit, Some("50".into()));
         assert_eq!(comp.source.upload_interval_sec, Some(120));
     }
 

--- a/tests/config_integration_test.rs
+++ b/tests/config_integration_test.rs
@@ -85,7 +85,7 @@ fn test_lld_j5_system_health_component() {
         system_health.source.log_file_regex,
         "system-health-.*\\.emf\\.json"
     );
-    assert_eq!(system_health.source.disk_space_limit, "50");
+    assert_eq!(system_health.source.disk_space_limit, Some("50".into()));
     assert_eq!(
         system_health.source.disk_space_limit_unit,
         DiskSpaceLimitUnit::MB
@@ -129,7 +129,7 @@ fn test_lld_j5_docker_health_component() {
         docker_health.log_group_name,
         Some("/aws/greengrass/custom/docker-health".to_string())
     );
-    assert_eq!(docker_health.source.disk_space_limit, "25");
+    assert_eq!(docker_health.source.disk_space_limit, Some("25".into()));
     assert_eq!(
         docker_health.source.disk_space_limit_unit,
         DiskSpaceLimitUnit::MB
@@ -150,7 +150,7 @@ fn test_lld_j5_device_bridge_component_defaults() {
         "/greengrass/v2/logs/bridge"
     );
     assert_eq!(device_bridge.source.log_file_regex, "bridge-.*\\.log");
-    assert_eq!(device_bridge.source.disk_space_limit, "100");
+    assert_eq!(device_bridge.source.disk_space_limit, Some("100".into()));
     assert_eq!(
         device_bridge.source.disk_space_limit_unit,
         DiskSpaceLimitUnit::MB
@@ -173,7 +173,7 @@ fn test_lld_j5_insights_system_config() {
     );
     assert_eq!(insights.source.log_file_regex, "insights-.*\\.json");
     assert_eq!(insights.log_group_name, "/aws/greengrass/system/insights");
-    assert_eq!(insights.source.disk_space_limit, "200");
+    assert_eq!(insights.source.disk_space_limit, Some("200".into()));
     assert_eq!(
         insights.source.disk_space_limit_unit,
         DiskSpaceLimitUnit::MB
@@ -220,7 +220,7 @@ fn test_missing_optional_fields_get_defaults() {
     let comp = &config.component_logs_configuration[0];
 
     assert_eq!(comp.source.minimum_log_level, LogLevel::Info);
-    assert_eq!(comp.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert_eq!(comp.source.disk_space_limit_unit, DiskSpaceLimitUnit::KB);
     assert!(!comp.source.delete_log_file_after_cloud_upload);
     assert!(comp.log_group_name.is_none());
     assert!(comp.source.multi_line_start_pattern.is_none());

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -67,7 +67,7 @@ fn test_component_config_fields() {
     assert_eq!(comp.component_name, "com.example.MyApp");
     assert_eq!(comp.source.log_file_directory_path, "/tmp");
     assert_eq!(comp.source.log_file_regex, "app\\.log.*");
-    assert_eq!(comp.source.disk_space_limit, "25");
+    assert_eq!(comp.source.disk_space_limit, Some("25".into()));
     assert_eq!(comp.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
     assert!(!comp.source.delete_log_file_after_cloud_upload);
     assert!(comp.log_group_name.is_none());
@@ -92,7 +92,7 @@ fn test_defaults_applied() {
     let emf = &config.component_logs_configuration[2];
 
     assert_eq!(emf.source.minimum_log_level, LogLevel::Info);
-    assert_eq!(emf.source.disk_space_limit_unit, DiskSpaceLimitUnit::MB);
+    assert_eq!(emf.source.disk_space_limit_unit, DiskSpaceLimitUnit::KB);
     assert!(!emf.source.delete_log_file_after_cloud_upload);
     assert_eq!(
         emf.source.multi_line_start_pattern,
@@ -106,7 +106,7 @@ fn test_system_config_fields() {
     let sys = &config.system_logs_configuration[0];
 
     assert_eq!(sys.log_group_name, "/aws/greengrass/system/syslog");
-    assert_eq!(sys.source.disk_space_limit, "50");
+    assert_eq!(sys.source.disk_space_limit, Some("50".into()));
     assert_eq!(sys.source.disk_space_limit_unit, DiskSpaceLimitUnit::GB);
 }
 
@@ -141,10 +141,11 @@ fn test_default_periodic_interval() {
 
 #[test]
 fn test_disk_space_limit_string_parsing() {
-    assert_eq!(parse_disk_space_limit("100").unwrap(), 100);
-    assert_eq!(parse_disk_space_limit("0").unwrap(), 0);
-    assert!(parse_disk_space_limit("abc").is_err());
-    assert!(parse_disk_space_limit("-5").is_err());
+    assert_eq!(parse_disk_space_limit(Some("100")).unwrap(), Some(100));
+    assert_eq!(parse_disk_space_limit(Some("0")).unwrap(), Some(0));
+    assert!(parse_disk_space_limit(Some("abc")).is_err());
+    assert!(parse_disk_space_limit(Some("-5")).is_err());
+    assert_eq!(parse_disk_space_limit(None).unwrap(), None);
 }
 
 #[test]


### PR DESCRIPTION
## Fix

Matches Java LogManager disk space limit behavior for backward compatibility during migration.

### Changes

1. **diskSpaceLimitUnit default**: `MB` → `KB` (matching Java's `if (StringUtils.isEmpty(diskSpaceLimitUnit)) diskSpaceLimitUnit = "KB"`)
2. **diskSpaceLimit type**: `String` with default `"25"` → `Option<String>` with default `None`. When omitted, disk management is disabled — matching Java where `null` diskSpaceLimit causes `DiskSpaceManagementService.freeDiskSpace()` to return early.
3. **parse_disk_space_limit**: Updated to accept `Option<&str>`, returns `Result<Option<u64>>`

### Java behavior verified

| Config | Java | Rust (before) | Rust (after) |
|---|---|---|---|
| `{"diskSpaceLimit": "25"}` (no unit) | 25 KB | 25 MB | 25 KB ✅ |
| No `diskSpaceLimit` field | Disk mgmt disabled | 25 MB limit | Disabled ✅ |
| `{"diskSpaceLimit": "50", "diskSpaceLimitUnit": "MB"}` | 50 MB | 50 MB | 50 MB ✅ |

### Tests
111 tests, 0 failures

Closes #243