### PR TITLE
feat(uploader): log event batcher with CW API limits and Java parity

### DIFF
--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -53,9 +53,13 @@ pub(crate) fn free_disk_space(
     let mut file_info: Vec<_> = processed_files
         .iter()
         .filter_map(|p| {
-            fs::metadata(p)
-                .ok()
-                .map(|m| (p.clone(), m.len(), m.modified().unwrap_or(SystemTime::UNIX_EPOCH)))
+            fs::metadata(p).ok().map(|m| {
+                (
+                    p.clone(),
+                    m.len(),
+                    m.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+                )
+            })
         })
         .collect();
     file_info.sort_by_key(|(_, _, mtime)| *mtime); // oldest first
@@ -79,7 +83,11 @@ pub(crate) fn free_disk_space(
     }
 
     if !deleted.is_empty() {
-        tracing::info!(total_freed = actually_freed, files_deleted = deleted.len(), "Disk space freed");
+        tracing::info!(
+            total_freed = actually_freed,
+            files_deleted = deleted.len(),
+            "Disk space freed"
+        );
     }
 
     deleted
@@ -190,7 +198,12 @@ mod tests {
         set_mtime(&f3, 100);
 
         // total=1500, limit=100 → need 1400 freed → all 3 deleted
-        let deleted = free_disk_space(tmp.path(), &log_pattern(), 100, &[f1.clone(), f2.clone(), f3.clone()]);
+        let deleted = free_disk_space(
+            tmp.path(),
+            &log_pattern(),
+            100,
+            &[f1.clone(), f2.clone(), f3.clone()],
+        );
         assert_eq!(deleted.len(), 3);
         assert!(!f1.exists());
         assert!(!f2.exists());

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -14,9 +14,6 @@ pub use checkpoint::{
 pub use multiline::assemble_multiline;
 pub use reader::{compute_content_hash, read_file_from_offset, LogEvent};
 
-/// Maximum event message size: 256KB (262,144) - 8 (timestamp) - 26 (CW overhead) = 262,110
-pub(crate) const MAX_EVENT_SIZE: usize = 262_110;
-
 use regex::Regex;
 use std::fs;
 use std::path::PathBuf;

--- a/src/scanner/multiline.rs
+++ b/src/scanner/multiline.rs
@@ -4,7 +4,6 @@
 //! Multi-line log assembly
 
 use super::reader::{extract_timestamp, LogEvent};
-use super::MAX_EVENT_SIZE;
 use regex::Regex;
 use std::sync::LazyLock;
 use std::time::SystemTime;
@@ -75,23 +74,8 @@ fn emit_buffered(buffer: &[String], first_event_timestamp: Option<i64>) -> LogEv
                 .unwrap_or(NO_TIMESTAMP)
         });
     // Join without separator to match Java's StringBuilder.append(partialLogLine) behavior.
-    let joined = buffer.join("");
-    let message = if joined.len() <= MAX_EVENT_SIZE {
-        joined
-    } else {
-        let first_line = &buffer[0][..80.min(buffer[0].len())];
-        tracing::warn!(
-            original_size = joined.len(),
-            max_size = MAX_EVENT_SIZE,
-            first_line,
-            "Truncating oversized multiline event"
-        );
-        let mut end = MAX_EVENT_SIZE;
-        while !joined.is_char_boundary(end) {
-            end -= 1;
-        }
-        joined[..end].to_string()
-    };
+    // No truncation here — the batcher handles chunking oversized events.
+    let message = buffer.join("");
     LogEvent { timestamp, message }
 }
 
@@ -244,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn test_oversized_multiline_truncation() {
+    fn test_oversized_multiline_passed_raw() {
         let pattern = Regex::new(r"^START").unwrap();
         let large_line = "x".repeat(200_000);
         let lines = vec![
@@ -254,7 +238,9 @@ mod tests {
         ];
         let events = assemble_multiline(lines, Some(&pattern));
         assert_eq!(events.len(), 1);
-        assert!(events[0].message.len() <= MAX_EVENT_SIZE);
+        // No truncation — batcher handles chunking
+        // assemble_multiline joins without separator: "START event" (11) + 200_000 + 200_000 = 400_011
+        assert_eq!(events[0].message.len(), 400_011);
     }
 
     #[test]

--- a/src/scanner/reader.rs
+++ b/src/scanner/reader.rs
@@ -3,7 +3,6 @@
 
 //! File reader with offset tracking and content hashing
 
-use super::MAX_EVENT_SIZE;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use sha2::{Digest, Sha256};
 use std::fs::File;
@@ -72,7 +71,7 @@ pub fn read_file_from_offset(
         .filter(|line| !line.trim().is_empty())
         .map(|line| {
             let timestamp = extract_timestamp(line).unwrap_or(default_timestamp);
-            let message = truncate_message(line);
+            let message = line.to_string();
             LogEvent { timestamp, message }
         })
         .collect();
@@ -155,18 +154,6 @@ fn days_since_epoch(year: i32, month: u32, day: u32) -> Option<i64> {
     Some(days)
 }
 
-fn truncate_message(s: &str) -> String {
-    if s.len() <= MAX_EVENT_SIZE {
-        s.to_string()
-    } else {
-        let mut end = MAX_EVENT_SIZE;
-        while !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        s[..end].to_string()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -239,13 +226,14 @@ mod tests {
     }
 
     #[test]
-    fn test_event_size_truncation() {
+    fn test_oversized_event_passed_raw() {
         let mut file = NamedTempFile::new().unwrap();
         let large_msg = "x".repeat(300_000);
         writeln!(file, "{}", large_msg).unwrap();
 
         let (events, _) = read_file_from_offset(file.path(), 0, 1000).unwrap();
-        assert_eq!(events[0].message.len(), MAX_EVENT_SIZE);
+        // Reader no longer truncates — batcher handles chunking
+        assert_eq!(events[0].message.len(), 300_000);
     }
 
     #[test]
@@ -392,19 +380,16 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_message_multibyte_char_boundary() {
-        // Create a string with multibyte UTF-8 characters that would be split
-        // at a non-char-boundary if we just truncated at MAX_EVENT_SIZE
+    fn test_oversized_multibyte_passed_raw() {
+        // Oversized messages with multibyte chars are passed raw to the batcher
         let emoji = "🎉"; // 4 bytes
-        let base = "x".repeat(MAX_EVENT_SIZE - 2);
+        let base = "x".repeat(300_000);
         let large_msg = format!("{}{}", base, emoji);
 
         let mut file = NamedTempFile::new().unwrap();
         writeln!(file, "{}", large_msg).unwrap();
 
         let (events, _) = read_file_from_offset(file.path(), 0, 1000).unwrap();
-        // Should truncate at a valid char boundary
-        assert!(events[0].message.len() <= MAX_EVENT_SIZE);
-        assert!(events[0].message.is_char_boundary(events[0].message.len()));
+        assert_eq!(events[0].message.len(), large_msg.len());
     }
 }

--- a/src/uploader/batcher.rs
+++ b/src/uploader/batcher.rs
@@ -1,4 +1,641 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Log event batching for PutLogEvents
+//! Log event batching for PutLogEvents.
+//!
+//! Accumulates [`LogEvent`]s into [`SealedBatch`]es respecting CloudWatch Logs API limits.
+//! Matches Java `CloudWatchAttemptLogsProcessor.addNewLogEvent` behavior:
+//! - 1 MB max batch payload (including 26+8 byte per-event overhead)
+//! - 10,000 max events per batch
+//! - 23-hour max time span within a batch
+//! - 14-day age filter (events older than 14 days are dropped)
+//! - 2-hour future filter (CW rejects events >2h ahead; Java relies on server-side rejection)
+//! - Oversized events (>262,110 bytes) are chunked, not truncated
+//!
+//! # Known divergences from Java
+//!
+//! **Dropped events don't advance checkpoint.** Java returns consumed byte count for
+//! dropped events (14-day filter) so the caller advances the file offset past them.
+//! This batcher silently drops them. The orchestrator must filter old events before
+//! batching, or accept re-reading them each cycle. Tracked under Asana 1.8.
+//!
+//! **Log level filtering matches Java behavior.** JSON-structured `GreengrassLogMessage`
+//! lines are deserialized to extract the `level` field. Text-format lines pass through
+//! without level filtering (matching Java's `addNewLogEvent` path).
+
+use super::SealedBatch;
+use crate::config::LogLevel;
+use crate::scanner::LogEvent;
+
+/// CW per-event framing overhead (bytes).
+const EVENT_STORAGE_OVERHEAD: usize = 26;
+/// Timestamp field size (bytes).
+const TIMESTAMP_BYTES: usize = 8;
+/// CW PutLogEvents max payload: 1 MB.
+const MAX_BATCH_SIZE: usize = 1_048_576;
+/// CW max message bytes per event: 256KB - 8 - 26 = 262,110.
+pub(crate) const MAX_EVENT_BYTES: usize = 256 * 1024 - TIMESTAMP_BYTES - EVENT_STORAGE_OVERHEAD;
+/// CW max events per PutLogEvents call.
+const MAX_NUM_OF_LOG_EVENTS: usize = 10_000;
+/// Max time span between earliest and latest event in a batch (23 hours in ms).
+const MAX_TIME_SPAN_MS: i64 = 23 * 60 * 60 * 1000;
+/// Events older than 14 days are rejected by CW.
+const FOURTEEN_DAYS_MS: i64 = 14 * 24 * 60 * 60 * 1000;
+/// Events more than 2 hours in the future are rejected by CW.
+const TWO_HOURS_FUTURE_MS: i64 = 2 * 60 * 60 * 1000;
+
+/// Per-event effective size for batch accounting.
+fn event_wire_size(message_bytes: usize) -> usize {
+    message_bytes + TIMESTAMP_BYTES + EVENT_STORAGE_OVERHEAD
+}
+
+/// Seal log events into batches ready for CloudWatch upload.
+///
+/// Events are sorted by timestamp, filtered by age and log level,
+/// oversized events are chunked, and batches are sealed at CW API limits.
+#[must_use]
+pub(crate) fn seal_batches(
+    mut events: Vec<LogEvent>,
+    log_group: &str,
+    log_stream: &str,
+    min_log_level: Option<LogLevel>,
+    now_ms: i64,
+) -> Vec<SealedBatch> {
+    // CW requires events sorted by timestamp. Must use stable sort to preserve
+    // insertion order for events with equal timestamps.
+    events.sort_by_key(|e| e.timestamp);
+
+    let cutoff = now_ms - FOURTEEN_DAYS_MS;
+    let max_future = now_ms + TWO_HOURS_FUTURE_MS;
+
+    let mut batches: Vec<SealedBatch> = Vec::new();
+    let mut current_events: Vec<LogEvent> = Vec::new();
+    let mut current_size: usize = 0;
+    let mut earliest_ts: Option<i64> = None;
+
+    let seal_current = |events: &mut Vec<LogEvent>,
+                        size: &mut usize,
+                        earliest: &mut Option<i64>,
+                        batches: &mut Vec<SealedBatch>| {
+        if !events.is_empty() {
+            batches.push(SealedBatch {
+                log_group: log_group.to_string(),
+                log_stream: log_stream.to_string(),
+                events: std::mem::take(events),
+            });
+            *size = 0;
+            *earliest = None;
+        }
+    };
+
+    for event in events {
+        // Drop events outside CW allowed range
+        if event.timestamp < cutoff || event.timestamp > max_future {
+            tracing::debug!(
+                timestamp = event.timestamp,
+                cutoff = cutoff,
+                max_future = max_future,
+                "Dropping event outside CW allowed range"
+            );
+            continue;
+        }
+
+        // minimumLogLevel filtering for GG structured log format
+        if let Some(min_level) = min_log_level {
+            if should_filter_by_level(&event.message, min_level) {
+                tracing::debug!(
+                    min_level = ?min_level,
+                    "Filtering event below minimum log level"
+                );
+                continue;
+            }
+        }
+
+        // Chunk oversized messages
+        let chunks = chunk_message(&event.message, event.timestamp);
+
+        for chunk in chunks {
+            if chunk.message.is_empty() {
+                continue;
+            }
+
+            let wire_size = event_wire_size(chunk.message.len());
+
+            // Check 23-hour span
+            let earliest = earliest_ts.unwrap_or(chunk.timestamp);
+            if chunk.timestamp - earliest > MAX_TIME_SPAN_MS {
+                seal_current(
+                    &mut current_events,
+                    &mut current_size,
+                    &mut earliest_ts,
+                    &mut batches,
+                );
+            }
+
+            // Check event count limit
+            if current_events.len() >= MAX_NUM_OF_LOG_EVENTS {
+                seal_current(
+                    &mut current_events,
+                    &mut current_size,
+                    &mut earliest_ts,
+                    &mut batches,
+                );
+            }
+
+            // Check batch size limit
+            if current_size + wire_size > MAX_BATCH_SIZE {
+                seal_current(
+                    &mut current_events,
+                    &mut current_size,
+                    &mut earliest_ts,
+                    &mut batches,
+                );
+            }
+
+            if earliest_ts.is_none() {
+                earliest_ts = Some(chunk.timestamp);
+            }
+            current_size += wire_size;
+            current_events.push(chunk);
+        }
+    }
+
+    seal_current(
+        &mut current_events,
+        &mut current_size,
+        &mut earliest_ts,
+        &mut batches,
+    );
+
+    batches
+}
+
+/// Split a message into chunks of at most MAX_EVENT_BYTES bytes.
+/// Each chunk gets the same timestamp (matching Java behavior).
+fn chunk_message(message: &str, timestamp: i64) -> Vec<LogEvent> {
+    let bytes = message.as_bytes();
+    if bytes.len() <= MAX_EVENT_BYTES {
+        return vec![LogEvent {
+            timestamp,
+            message: message.to_string(),
+        }];
+    }
+
+    let num_chunks = (bytes.len() + MAX_EVENT_BYTES - 1) / MAX_EVENT_BYTES;
+    tracing::debug!(
+        size = bytes.len(),
+        chunks = num_chunks,
+        "Chunking oversized event into multiple CW events"
+    );
+
+    let mut chunks = Vec::with_capacity(num_chunks);
+    let mut pos = 0;
+    while pos < bytes.len() {
+        let end = (pos + MAX_EVENT_BYTES).min(bytes.len());
+        // Find a valid UTF-8 char boundary
+        let mut boundary = end;
+        while boundary > pos && !message.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
+        if boundary == pos {
+            // Safety: can't happen with valid UTF-8 (max 4 bytes < MAX_EVENT_BYTES),
+            // but guard against infinite loop.
+            tracing::error!(
+                pos = pos,
+                total_bytes = bytes.len(),
+                "Chunking failed: boundary walked back to pos, dropping remaining bytes"
+            );
+            break;
+        }
+        let chunk_str = &message[pos..boundary];
+        if !chunk_str.is_empty() {
+            chunks.push(LogEvent {
+                timestamp,
+                message: chunk_str.to_string(),
+            });
+        }
+        pos = boundary;
+    }
+    chunks
+}
+
+/// Check if an event should be filtered based on minimumLogLevel.
+/// Matches Java `tryGetStructuredLogMessage` + `checkAndAddNewLogEvent`:
+/// - Lines starting with `{` are deserialized as JSON to extract the `level` field
+/// - If level < min_level, the event is filtered
+/// - Non-JSON lines (text logs, EMF) always pass through (Java behavior)
+fn should_filter_by_level(message: &str, min_level: LogLevel) -> bool {
+    // Java fast path: only attempt JSON parse if line starts with '{'
+    if !message.starts_with('{') {
+        return false;
+    }
+    if let Ok(msg) = serde_json::from_str::<GgLogMessage>(message) {
+        if let Some(ref level) = msg.level {
+            if let Some(event_level) = parse_log_level(level) {
+                return level_ordinal(event_level) < level_ordinal(min_level);
+            }
+        }
+    }
+    false
+}
+
+/// Minimal struct for extracting level from Greengrass structured JSON logs.
+/// Matches Java's `GreengrassLogMessage` — only the `level` field is needed for filtering.
+#[derive(serde::Deserialize)]
+struct GgLogMessage {
+    level: Option<String>,
+}
+
+fn parse_log_level(s: &str) -> Option<LogLevel> {
+    match s.trim() {
+        "DEBUG" => Some(LogLevel::Debug),
+        "INFO" => Some(LogLevel::Info),
+        "WARN" => Some(LogLevel::Warn),
+        "ERROR" => Some(LogLevel::Error),
+        _ => None,
+    }
+}
+
+fn level_ordinal(level: LogLevel) -> u8 {
+    match level {
+        LogLevel::Debug => 0,
+        LogLevel::Info => 1,
+        LogLevel::Warn => 2,
+        LogLevel::Error => 3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(ts: i64, msg: &str) -> LogEvent {
+        LogEvent {
+            timestamp: ts,
+            message: msg.to_string(),
+        }
+    }
+
+    fn now_ms() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64
+    }
+
+    #[test]
+    fn test_single_event_single_batch() {
+        let now = now_ms();
+        let batches = seal_batches(vec![ev(now, "hello")], "/grp", "/stream", None, now);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].events.len(), 1);
+        assert_eq!(batches[0].events[0].message, "hello");
+        assert_eq!(batches[0].log_group, "/grp");
+    }
+
+    #[test]
+    fn test_event_count_limit() {
+        let now = now_ms();
+        let events: Vec<LogEvent> = (0..10_001).map(|i| ev(now + i, "x")).collect();
+        let batches = seal_batches(events, "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].events.len(), 10_000);
+        assert_eq!(batches[1].events.len(), 1);
+    }
+
+    #[test]
+    fn test_batch_size_limit() {
+        let now = now_ms();
+        // Each event: 100 bytes msg + 8 + 26 = 134 bytes wire size
+        // 1,048,576 / 134 = 7825.9 → 7825 events per batch
+        let msg = "x".repeat(100);
+        let events: Vec<LogEvent> = (0..8000).map(|i| ev(now + i, &msg)).collect();
+        let batches = seal_batches(events, "/grp", "/s", None, now);
+        assert!(batches.len() >= 2);
+        // First batch should have ~7825 events
+        let first_size: usize = batches[0]
+            .events
+            .iter()
+            .map(|e| event_wire_size(e.message.len()))
+            .sum();
+        assert!(first_size <= MAX_BATCH_SIZE);
+    }
+
+    #[test]
+    fn test_time_span_limit() {
+        let now = now_ms();
+        let hour_ms = 60 * 60 * 1000;
+        // 23h + 1min gap exceeds the 23-hour span limit
+        let events = vec![
+            ev(now - 24 * hour_ms, "early"),
+            ev(now - 24 * hour_ms + 23 * hour_ms + 60_000, "late"),
+        ];
+        let batches = seal_batches(events, "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].events[0].message, "early");
+        assert_eq!(batches[1].events[0].message, "late");
+    }
+
+    #[test]
+    fn test_oversized_event_chunked() {
+        let now = now_ms();
+        let big_msg = "a".repeat(MAX_EVENT_BYTES * 2 + 100);
+        let batches = seal_batches(vec![ev(now, &big_msg)], "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].events.len(), 3); // 2 full chunks + 1 remainder
+        assert_eq!(batches[0].events[0].message.len(), MAX_EVENT_BYTES);
+        assert_eq!(batches[0].events[1].message.len(), MAX_EVENT_BYTES);
+        assert_eq!(batches[0].events[2].message.len(), 100);
+        // All chunks have same timestamp
+        assert!(batches[0].events.iter().all(|e| e.timestamp == now));
+    }
+
+    #[test]
+    fn test_event_exactly_max_length() {
+        let now = now_ms();
+        let msg = "b".repeat(MAX_EVENT_BYTES);
+        let batches = seal_batches(vec![ev(now, &msg)], "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].events.len(), 1);
+        assert_eq!(batches[0].events[0].message.len(), MAX_EVENT_BYTES);
+    }
+
+    #[test]
+    fn test_14_day_old_event_dropped() {
+        let now = now_ms();
+        let old = now - 15 * 24 * 60 * 60 * 1000; // 15 days ago
+        let batches = seal_batches(vec![ev(old, "old")], "/grp", "/s", None, now);
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn test_13_day_old_event_kept() {
+        let now = now_ms();
+        let recent = now - 13 * 24 * 60 * 60 * 1000; // 13 days ago
+        let batches = seal_batches(vec![ev(recent, "recent")], "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].events[0].message, "recent");
+    }
+
+    #[test]
+    fn test_future_event_dropped() {
+        let now = now_ms();
+        let future = now + 3 * 60 * 60 * 1000; // 3 hours in future
+        let batches = seal_batches(vec![ev(future, "future")], "/grp", "/s", None, now);
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn test_near_future_event_kept() {
+        let now = now_ms();
+        let near_future = now + 60 * 60 * 1000; // 1 hour in future
+        let batches = seal_batches(vec![ev(near_future, "soon")], "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].events[0].message, "soon");
+    }
+
+    #[test]
+    fn test_empty_message_skipped() {
+        let now = now_ms();
+        let batches = seal_batches(vec![ev(now, "")], "/grp", "/s", None, now);
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn test_events_sorted_by_timestamp() {
+        let now = now_ms();
+        let events = vec![ev(now + 2000, "c"), ev(now, "a"), ev(now + 1000, "b")];
+        let batches = seal_batches(events, "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].events[0].message, "a");
+        assert_eq!(batches[0].events[1].message, "b");
+        assert_eq!(batches[0].events[2].message, "c");
+    }
+
+    #[test]
+    fn test_mixed_old_oversized_normal() {
+        let now = now_ms();
+        let old = now - 15 * 24 * 60 * 60 * 1000;
+        let big_msg = "x".repeat(MAX_EVENT_BYTES + 50);
+        let events = vec![ev(old, "dropped"), ev(now, "normal"), ev(now + 1, &big_msg)];
+        let batches = seal_batches(events, "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 1);
+        // "dropped" is gone, "normal" + 2 chunks of big_msg
+        assert_eq!(batches[0].events.len(), 3);
+        assert_eq!(batches[0].events[0].message, "normal");
+    }
+
+    #[test]
+    fn test_minimum_log_level_filtering() {
+        let now = now_ms();
+        let events = vec![
+            // JSON-structured GG log — DEBUG filtered when min=WARN
+            ev(
+                now,
+                r#"{"level":"DEBUG","message":"debug msg","timestamp":1000}"#,
+            ),
+            // JSON-structured GG log — INFO filtered when min=WARN
+            ev(
+                now + 1,
+                r#"{"level":"INFO","message":"info msg","timestamp":1001}"#,
+            ),
+            // JSON-structured GG log — WARN passes
+            ev(
+                now + 2,
+                r#"{"level":"WARN","message":"warn msg","timestamp":1002}"#,
+            ),
+            // JSON-structured GG log — ERROR passes
+            ev(
+                now + 3,
+                r#"{"level":"ERROR","message":"error msg","timestamp":1003}"#,
+            ),
+            // Text-format log — always passes (Java doesn't filter text logs)
+            ev(now + 4, "2024-01-15 10:30:45 [DEBUG] text debug msg"),
+            // EMF JSON — always passes (no "level" field)
+            ev(now + 5, r#"{"_aws":{"Timestamp":1234},"metric":1}"#),
+        ];
+        let batches = seal_batches(events, "/grp", "/s", Some(LogLevel::Warn), now);
+        assert_eq!(batches.len(), 1);
+        // JSON DEBUG and INFO filtered, WARN + ERROR + text DEBUG + EMF kept
+        assert_eq!(batches[0].events.len(), 4);
+        assert!(batches[0].events[0].message.contains("warn msg"));
+        assert!(batches[0].events[1].message.contains("error msg"));
+        assert!(batches[0].events[2].message.contains("text debug msg"));
+        assert!(batches[0].events[3].message.contains("_aws"));
+    }
+
+    #[test]
+    fn test_chunk_multibyte_boundary() {
+        let now = now_ms();
+        // Fill to near boundary then add a 4-byte emoji
+        let base = "x".repeat(MAX_EVENT_BYTES - 2);
+        let msg = format!("{base}🎉more");
+        let batches = seal_batches(vec![ev(now, &msg)], "/grp", "/s", None, now);
+        // Should chunk at a valid char boundary
+        for batch in &batches {
+            for event in &batch.events {
+                assert!(event.message.is_char_boundary(event.message.len()));
+            }
+        }
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let batches = seal_batches(vec![], "/grp", "/s", None, now_ms());
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn test_chunk_message_small() {
+        let chunks = chunk_message("hello", 1000);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].message, "hello");
+    }
+
+    #[test]
+    fn test_chunk_message_exact_boundary() {
+        let msg = "a".repeat(MAX_EVENT_BYTES);
+        let chunks = chunk_message(&msg, 1000);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].message.len(), MAX_EVENT_BYTES);
+    }
+
+    #[test]
+    fn test_chunk_message_oversized() {
+        let msg = "b".repeat(MAX_EVENT_BYTES * 3);
+        let chunks = chunk_message(&msg, 1000);
+        assert_eq!(chunks.len(), 3);
+        assert!(chunks.iter().all(|c| c.timestamp == 1000));
+    }
+
+    #[test]
+    fn test_level_filtering_non_json_passes() {
+        // Text-format logs always pass through (Java behavior)
+        assert!(!should_filter_by_level("just plain text", LogLevel::Error));
+        assert!(!should_filter_by_level(
+            "2024-01-15 10:30:45 [DEBUG] text log",
+            LogLevel::Error
+        ));
+        assert!(!should_filter_by_level("short", LogLevel::Error));
+    }
+
+    // --- Boundary tests (exact-at-limit) ---
+
+    #[test]
+    fn test_14_day_boundary_exact_kept() {
+        let now = now_ms();
+        // Exactly 14 days ago — no clock drift since now_ms is injected
+        let exactly_14d = now - 14 * 24 * 60 * 60 * 1000;
+        let batches = seal_batches(vec![ev(exactly_14d, "boundary")], "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].events[0].message, "boundary");
+    }
+
+    #[test]
+    fn test_14_day_boundary_one_ms_over_dropped() {
+        let now = now_ms();
+        let just_over = now - 14 * 24 * 60 * 60 * 1000 - 1;
+        let batches = seal_batches(vec![ev(just_over, "gone")], "/grp", "/s", None, now);
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn test_2h_future_boundary_exact_kept() {
+        let now = now_ms();
+        // Exactly 2 hours in future — strict > means this is NOT dropped
+        let exactly_2h = now + 2 * 60 * 60 * 1000;
+        let batches = seal_batches(vec![ev(exactly_2h, "boundary")], "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 1);
+    }
+
+    #[test]
+    fn test_2h_future_boundary_one_ms_over_dropped() {
+        let now = now_ms();
+        // Exactly 1ms over 2h — dropped
+        let just_over = now + 2 * 60 * 60 * 1000 + 1;
+        let batches = seal_batches(vec![ev(just_over, "gone")], "/grp", "/s", None, now);
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn test_23h_span_exact_same_batch() {
+        let now = now_ms();
+        let hour_ms = 60 * 60 * 1000;
+        // Exactly 23h span — strict > means these stay in SAME batch
+        let events = vec![
+            ev(now - 24 * hour_ms, "early"),
+            ev(now - 24 * hour_ms + 23 * hour_ms, "late"),
+        ];
+        let batches = seal_batches(events, "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].events.len(), 2);
+    }
+
+    #[test]
+    fn test_exactly_10k_events_single_batch() {
+        let now = now_ms();
+        let events: Vec<LogEvent> = (0..10_000).map(|i| ev(now + i, "x")).collect();
+        let batches = seal_batches(events, "/grp", "/s", None, now);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].events.len(), 10_000);
+    }
+
+    #[test]
+    fn test_batch_overflow_not_dropped() {
+        let now = now_ms();
+        // Each 600KB message gets chunked into ~3 x 262KB chunks before batch size checks.
+        // Total chunks exceed 1MB, forcing a batch split. "overflow" must not be dropped.
+        let msg = "x".repeat(600_000);
+        let events = vec![ev(now, &msg), ev(now + 1, &msg), ev(now + 2, "overflow")];
+        let batches = seal_batches(events, "/grp", "/s", None, now);
+        assert!(batches.len() >= 2);
+        let all_msgs: Vec<&str> = batches
+            .iter()
+            .flat_map(|b| b.events.iter().map(|e| e.message.as_str()))
+            .collect();
+        assert!(all_msgs.contains(&"overflow"));
+    }
+
+    #[test]
+    fn test_single_event_larger_than_max_batch() {
+        let now = now_ms();
+        // 4MB message — larger than MAX_BATCH_SIZE (1MB)
+        let msg = "z".repeat(4 * 1024 * 1024);
+        let batches = seal_batches(vec![ev(now, &msg)], "/grp", "/s", None, now);
+        // Should produce multiple batches, each within 1MB
+        assert!(batches.len() >= 4);
+        for batch in &batches {
+            let total: usize = batch
+                .events
+                .iter()
+                .map(|e| event_wire_size(e.message.len()))
+                .sum();
+            assert!(total <= MAX_BATCH_SIZE);
+        }
+    }
+
+    #[test]
+    fn test_timestamp_zero_dropped() {
+        // timestamp=0 is before the 14-day cutoff
+        let batches = seal_batches(vec![ev(0, "epoch")], "/grp", "/s", None, now_ms());
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn test_negative_timestamp_dropped() {
+        let batches = seal_batches(vec![ev(-1000, "negative")], "/grp", "/s", None, now_ms());
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn test_debug_passes_at_min_debug() {
+        let now = now_ms();
+        let events = vec![ev(
+            now,
+            r#"{"level":"DEBUG","message":"debug msg","timestamp":1000}"#,
+        )];
+        let batches = seal_batches(events, "/grp", "/s", Some(LogLevel::Debug), now);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].events.len(), 1);
+    }
+}

--- a/src/uploader/cw_client.rs
+++ b/src/uploader/cw_client.rs
@@ -28,8 +28,7 @@ pub(crate) struct CwLogsClient {
 
 impl CwLogsClient {
     pub async fn new() -> Self {
-        let retry_config = aws_config::retry::RetryConfig::standard()
-            .with_max_attempts(5);
+        let retry_config = aws_config::retry::RetryConfig::standard().with_max_attempts(5);
         let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
             .retry_config(retry_config)
             .load()
@@ -91,9 +90,9 @@ impl CwLogsClient {
                 self.created_groups.insert(log_group.to_string());
                 Ok(())
             }
-            Err(SdkError::ServiceError(e)) if is_limit_exceeded_group(e.err()) => {
-                Err(CwUploadError::Retriable("LimitExceededException on create_log_group".to_string()))
-            }
+            Err(SdkError::ServiceError(e)) if is_limit_exceeded_group(e.err()) => Err(
+                CwUploadError::Retriable("LimitExceededException on create_log_group".to_string()),
+            ),
             Err(SdkError::ServiceError(e)) if is_auth_error(e.err()) => {
                 Err(CwUploadError::AuthError)
             }
@@ -127,9 +126,9 @@ impl CwLogsClient {
                 self.created_streams.insert(key);
                 Ok(())
             }
-            Err(SdkError::ServiceError(e)) if is_limit_exceeded_stream(e.err()) => {
-                Err(CwUploadError::Retriable("LimitExceededException on create_log_stream".to_string()))
-            }
+            Err(SdkError::ServiceError(e)) if is_limit_exceeded_stream(e.err()) => Err(
+                CwUploadError::Retriable("LimitExceededException on create_log_stream".to_string()),
+            ),
             Err(SdkError::ServiceError(e)) if is_auth_error(e.err()) => {
                 Err(CwUploadError::AuthError)
             }
@@ -148,7 +147,8 @@ impl CwLogsClient {
                     .build()
             })
             .collect();
-        let events = events.map_err(|e| CwUploadError::Other(format!("Failed to build log event: {e}")))?;
+        let events =
+            events.map_err(|e| CwUploadError::Other(format!("Failed to build log event: {e}")))?;
 
         // EMF metrics are auto-extracted by CloudWatch when log events contain the _aws key.
         // No sequence tokens needed — deprecated since late 2023, and we create new streams daily.
@@ -172,12 +172,10 @@ impl CwLogsClient {
                     tracing::debug!(log_group = %batch.log_group, "Data already accepted");
                     Ok(())
                 }
-                PutLogEventsError::UnrecognizedClientException(_) => {
-                    Err(CwUploadError::AuthError)
-                }
-                PutLogEventsError::ServiceUnavailableException(_) => {
-                    Err(CwUploadError::Other("ServiceUnavailable after SDK retries exhausted".to_string()))
-                }
+                PutLogEventsError::UnrecognizedClientException(_) => Err(CwUploadError::AuthError),
+                PutLogEventsError::ServiceUnavailableException(_) => Err(CwUploadError::Other(
+                    "ServiceUnavailable after SDK retries exhausted".to_string(),
+                )),
                 PutLogEventsError::ResourceNotFoundException(_) => {
                     // Clear cache so next retry re-creates the group/stream
                     self.created_groups.remove(&batch.log_group);
@@ -191,7 +189,9 @@ impl CwLogsClient {
                 other => {
                     use aws_sdk_cloudwatchlogs::error::ProvideErrorMetadata;
                     if other.code() == Some("ThrottlingException") {
-                        Err(CwUploadError::Other("Throttled after SDK retries exhausted".to_string()))
+                        Err(CwUploadError::Other(
+                            "Throttled after SDK retries exhausted".to_string(),
+                        ))
                     } else {
                         Err(CwUploadError::Other(other.to_string()))
                     }
@@ -324,7 +324,8 @@ mod tests {
 
     #[test]
     fn test_limit_exceeded_on_group_create() {
-        let err = CwUploadError::Retriable("LimitExceededException on create_log_group".to_string());
+        let err =
+            CwUploadError::Retriable("LimitExceededException on create_log_group".to_string());
         if let CwUploadError::Retriable(msg) = err {
             assert!(msg.contains("LimitExceededException"));
             assert!(msg.contains("create_log_group"));
@@ -335,7 +336,8 @@ mod tests {
 
     #[test]
     fn test_limit_exceeded_on_stream_create() {
-        let err = CwUploadError::Retriable("LimitExceededException on create_log_stream".to_string());
+        let err =
+            CwUploadError::Retriable("LimitExceededException on create_log_stream".to_string());
         if let CwUploadError::Retriable(msg) = err {
             assert!(msg.contains("LimitExceededException"));
             assert!(msg.contains("create_log_stream"));
@@ -396,8 +398,7 @@ mod tests {
             ))
             .region(aws_sdk_cloudwatchlogs::config::Region::new("us-east-1"))
             .retry_config(
-                aws_sdk_cloudwatchlogs::config::retry::RetryConfig::standard()
-                    .with_max_attempts(1),
+                aws_sdk_cloudwatchlogs::config::retry::RetryConfig::standard().with_max_attempts(1),
             )
             .http_client(replay_client)
             .build();

--- a/src/uploader/mod.rs
+++ b/src/uploader/mod.rs
@@ -3,6 +3,7 @@
 
 //! Upload pipeline - batching, CloudWatch client, scheduling
 
+#[allow(dead_code, reason = "consumed by upload orchestrator")]
 mod batcher;
 #[cfg(feature = "aws-sdk")]
 mod cw_client;
@@ -20,9 +21,13 @@ pub(crate) struct SealedBatch {
 #[cfg(feature = "aws-sdk")]
 pub(crate) use cw_client::{CwLogsClient, CwUploadError};
 
+#[allow(unused_imports, reason = "consumed by upload orchestrator")]
+pub(crate) use batcher::{seal_batches, MAX_EVENT_BYTES};
+
 /// Format log stream name matching Java LogManager:
 /// `/{yyyy}/{MM}/{dd}/thing/{thingName}` (UTC)
 /// Replaces colons with `+` since CW log stream names cannot contain `:`.
+#[must_use]
 pub(crate) fn format_log_stream_name(thing_name: &str) -> String {
     let now = time::OffsetDateTime::now_utc();
     let safe_name = thing_name.replace(':', "+");
@@ -37,7 +42,8 @@ pub(crate) fn format_log_stream_name(thing_name: &str) -> String {
 
 /// Check if a timestamp (epoch millis) falls on a different UTC date.
 /// Used to detect when a new log stream should be created at midnight.
-#[allow(dead_code, reason = "used by upload orchestrator in follow-up PR")]
+#[allow(dead_code, reason = "used by upload orchestrator")]
+#[must_use]
 pub(crate) fn is_different_date(
     timestamp_ms: i64,
     stream_year: i32,

--- a/tests/sdk_retry_test.rs
+++ b/tests/sdk_retry_test.rs
@@ -6,7 +6,9 @@
 //! Integration tests verifying AWS SDK retry behavior and our CwLogsClient error handling.
 //! Uses mock HTTP to prove retry/no-retry semantics without hitting real CloudWatch.
 
-use aws_sdk_cloudwatchlogs::{config::BehaviorVersion, config::Credentials, config::Region, Client};
+use aws_sdk_cloudwatchlogs::{
+    config::BehaviorVersion, config::Credentials, config::Region, Client,
+};
 use aws_smithy_http_client::test_util::{ReplayEvent, StaticReplayClient};
 use aws_smithy_types::body::SdkBody;
 
@@ -34,8 +36,8 @@ fn dummy_request() -> http::Request<SdkBody> {
 }
 
 fn make_client(replay_client: StaticReplayClient) -> Client {
-    let retry_config = aws_sdk_cloudwatchlogs::config::retry::RetryConfig::standard()
-        .with_max_attempts(5);
+    let retry_config =
+        aws_sdk_cloudwatchlogs::config::retry::RetryConfig::standard().with_max_attempts(5);
     Client::from_conf(
         aws_sdk_cloudwatchlogs::Config::builder()
             .behavior_version(BehaviorVersion::latest())
@@ -65,7 +67,10 @@ async fn sdk_retries_on_throttling() {
         .send()
         .await;
 
-    assert!(result.is_ok(), "Expected success after SDK retries, got: {result:?}");
+    assert!(
+        result.is_ok(),
+        "Expected success after SDK retries, got: {result:?}"
+    );
 
     let actual_requests: Vec<_> = replay_client.actual_requests().collect();
     assert_eq!(
@@ -79,17 +84,15 @@ async fn sdk_retries_on_throttling() {
 #[tokio::test]
 async fn sdk_does_not_retry_invalid_parameter() {
     // 400 InvalidParameterException — SDK should NOT retry client errors
-    let replay_client = StaticReplayClient::new(vec![
-        ReplayEvent::new(
-            dummy_request(),
-            http::Response::builder()
-                .status(400)
-                .body(SdkBody::from(
-                    r#"{"__type":"InvalidParameterException","message":"Invalid"}"#,
-                ))
-                .unwrap(),
-        ),
-    ]);
+    let replay_client = StaticReplayClient::new(vec![ReplayEvent::new(
+        dummy_request(),
+        http::Response::builder()
+            .status(400)
+            .body(SdkBody::from(
+                r#"{"__type":"InvalidParameterException","message":"Invalid"}"#,
+            ))
+            .unwrap(),
+    )]);
 
     let client = make_client(replay_client.clone());
 
@@ -100,7 +103,10 @@ async fn sdk_does_not_retry_invalid_parameter() {
         .send()
         .await;
 
-    assert!(result.is_err(), "Expected error for InvalidParameterException");
+    assert!(
+        result.is_err(),
+        "Expected error for InvalidParameterException"
+    );
 
     let actual_requests: Vec<_> = replay_client.actual_requests().collect();
     assert_eq!(
@@ -136,7 +142,10 @@ async fn data_already_accepted_is_success() {
         .await;
 
     // SDK returns this as a typed error — our CwLogsClient maps it to Ok(())
-    assert!(result.is_err(), "SDK surfaces DataAlreadyAcceptedException as error");
+    assert!(
+        result.is_err(),
+        "SDK surfaces DataAlreadyAcceptedException as error"
+    );
     let err = result.unwrap_err();
     let service_err = err.into_service_error();
     assert!(
@@ -151,17 +160,15 @@ async fn data_already_accepted_is_success() {
 #[tokio::test]
 async fn resource_not_found_is_retriable() {
     // ResourceNotFoundException — our cw_client.rs maps it to CwUploadError::Retriable
-    let replay_client = StaticReplayClient::new(vec![
-        ReplayEvent::new(
-            dummy_request(),
-            http::Response::builder()
-                .status(400)
-                .body(SdkBody::from(
-                    r#"{"__type":"ResourceNotFoundException","message":"log group not found"}"#,
-                ))
-                .unwrap(),
-        ),
-    ]);
+    let replay_client = StaticReplayClient::new(vec![ReplayEvent::new(
+        dummy_request(),
+        http::Response::builder()
+            .status(400)
+            .body(SdkBody::from(
+                r#"{"__type":"ResourceNotFoundException","message":"log group not found"}"#,
+            ))
+            .unwrap(),
+    )]);
 
     let client = make_client(replay_client.clone());
 
@@ -172,7 +179,10 @@ async fn resource_not_found_is_retriable() {
         .send()
         .await;
 
-    assert!(result.is_err(), "SDK surfaces ResourceNotFoundException as error");
+    assert!(
+        result.is_err(),
+        "SDK surfaces ResourceNotFoundException as error"
+    );
     let err = result.unwrap_err();
     let service_err = err.into_service_error();
     assert!(


### PR DESCRIPTION
**Issue #, if available:**

N/A — Log event batcher for Rust v2 LogManager

**Description of changes:**

`seal_batches()` in `uploader/batcher.rs` — batches LogEvents into SealedBatches respecting CW Logs API limits:
- 1 MB max batch payload (with 26+8 byte per-event overhead)
- 10,000 max events per batch
- 23-hour max time span within a batch (Java uses 23h leeway on CW 24h limit)
- 14-day past / 2-hour future timestamp filtering
- Oversized events (>262,110 bytes) chunked into multiple CW events with same timestamp
- minimumLogLevel filtering via JSON deserialization matching Java `tryGetStructuredLogMessage` + `checkAndAddNewLogEvent`
- Events sorted by timestamp ascending (stable sort)
- Pure function: `now_ms` injected as parameter for testability
- `SealedBatch` type and `MAX_EVENT_BYTES` constant in `uploader/mod.rs`

Scanner changes:
- Removed truncation from `reader.rs` and `multiline.rs` — batcher handles chunking (no data loss)
- Moved `MAX_EVENT_SIZE` from `scanner/mod.rs` to `uploader/batcher.rs` as `MAX_EVENT_BYTES`

Known divergence (documented in module doc):
- Dropped events do not advance checkpoint — orchestrator responsibility

Deferred to upload orchestrator:
- Per-stream date routing (midnight boundary)
- Checkpoint advancement for dropped events
- CheckpointStore encapsulation
- Eviction separation from recover_offsets

**Why is this change necessary:**

The batcher is the core batching layer that sits between the scanner (which reads log events) and the CW client (which uploads them). Without it, events cannot be grouped into valid PutLogEvents requests.

**How was this change tested:**

- 31 unit tests covering boundary-exact cases, chunking, filtering, overflow, and timestamp sorting
- 190 total tests passing
- `seal_batches` is a pure function (injected `now_ms`) — deterministic, no timing flakiness

**Any additional information or context required to review the change:**

N/A

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
