### PR TITLE
feat(uploader): add typed upload subsystem and thing-name resolution

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -502,6 +502,7 @@ mod tests {
         assert!(!f(r#""yes""#));
         assert!(!f(r#""1""#));
         assert!(!f(r#""""#)); // empty → false
+
         // Unexpected types → false (with warn)
         assert!(!f("1"));
         assert!(!f("null"));

--- a/src/credentials/mod.rs
+++ b/src/credentials/mod.rs
@@ -1,6 +1,67 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Credential provider and environment detection for Greengrass Nucleus and Nucleus Lite
+//! ThingName resolution for Greengrass.
+//!
+//! Credentials are handled by the AWS SDK default chain (`aws_config::load_defaults`),
+//! which picks up TES-provided credentials automatically when running as a Greengrass
+//! component. Both Classic and Lite set `AWS_IOT_THING_NAME` for component processes.
 
-mod tes;
+/// Resolve the thing name from the `AWS_IOT_THING_NAME` environment variable.
+///
+/// Returns `None` (after logging an error) when the variable is unset or empty, so the
+/// caller can fall back to a placeholder. Both GG Classic and GG Lite set this for
+/// component processes.
+#[must_use]
+pub fn resolve_thing_name() -> Option<String> {
+    resolve_thing_name_from(|key| std::env::var(key))
+}
+
+/// Resolve the thing name using an injected environment lookup.
+///
+/// Split out from [`resolve_thing_name`] so tests can supply a closure instead of
+/// mutating process-global environment state.
+fn resolve_thing_name_from(
+    get_var: impl Fn(&str) -> Result<String, std::env::VarError>,
+) -> Option<String> {
+    match get_var("AWS_IOT_THING_NAME") {
+        Ok(name) if !name.is_empty() => {
+            tracing::info!(thing_name = %name, "Resolved thing name");
+            Some(name)
+        }
+        Ok(_) => {
+            tracing::error!("AWS_IOT_THING_NAME is set but empty");
+            None
+        }
+        Err(_) => {
+            tracing::error!("AWS_IOT_THING_NAME not set");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_thing_name_present() {
+        assert_eq!(
+            resolve_thing_name_from(|_: &str| Ok("test-device-01".to_string())),
+            Some("test-device-01".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_thing_name_missing() {
+        assert_eq!(
+            resolve_thing_name_from(|_: &str| Err(std::env::VarError::NotPresent)),
+            None
+        );
+    }
+
+    #[test]
+    fn test_resolve_thing_name_empty() {
+        assert_eq!(resolve_thing_name_from(|_: &str| Ok(String::new())), None);
+    }
+}

--- a/src/credentials/tes.rs
+++ b/src/credentials/tes.rs
@@ -1,4 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-//! Token Exchange Service credential provider for GG Classic and Lite

--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -33,7 +33,7 @@ fn dir_size(dir: &Path, pattern: &Regex) -> u64 {
 /// (fully uploaded, not actively written to). This function trusts the list it receives.
 ///
 /// Returns paths of successfully deleted files.
-pub(crate) fn free_disk_space(
+pub fn free_disk_space(
     dir: &Path,
     pattern: &Regex,
     limit_bytes: u64,
@@ -93,7 +93,9 @@ pub(crate) fn free_disk_space(
     deleted
 }
 
+// Single-arg &[x.clone()] kept per review; allow for clippy 1.94.1.
 #[cfg(test)]
+#[allow(clippy::cloned_ref_to_slice_refs)]
 mod tests {
     use super::*;
     use std::fs::File;

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -9,7 +9,7 @@ mod reader;
 
 pub use checkpoint::{
     load_checkpoint, recover_offsets, remove_component, save_checkpoint, trim_stale_on_load,
-    CheckpointStore, FileCheckpoint,
+    CheckpointStore, FileCheckpoint, LastFileProcessedTimestamp,
 };
 pub use multiline::assemble_multiline;
 pub use reader::{compute_content_hash, read_file_from_offset, LogEvent};

--- a/src/uploader/batcher.rs
+++ b/src/uploader/batcher.rs
@@ -17,7 +17,7 @@
 //! **Dropped events don't advance checkpoint.** Java returns consumed byte count for
 //! dropped events (14-day filter) so the caller advances the file offset past them.
 //! This batcher silently drops them. The orchestrator must filter old events before
-//! batching, or accept re-reading them each cycle. Tracked under Asana 1.8.
+//! batching, or accept re-reading them each cycle.
 //!
 //! **Log level filtering matches Java behavior.** JSON-structured `GreengrassLogMessage`
 //! lines are deserialized to extract the `level` field. Text-format lines pass through
@@ -181,7 +181,7 @@ fn chunk_message(message: &str, timestamp: i64) -> Vec<LogEvent> {
         }];
     }
 
-    let num_chunks = (bytes.len() + MAX_EVENT_BYTES - 1) / MAX_EVENT_BYTES;
+    let num_chunks = bytes.len().div_ceil(MAX_EVENT_BYTES);
     tracing::debug!(
         size = bytes.len(),
         chunks = num_chunks,
@@ -518,8 +518,6 @@ mod tests {
         ));
         assert!(!should_filter_by_level("short", LogLevel::Error));
     }
-
-    // --- Boundary tests (exact-at-limit) ---
 
     #[test]
     fn test_14_day_boundary_exact_kept() {

--- a/src/uploader/cw_client.rs
+++ b/src/uploader/cw_client.rs
@@ -9,18 +9,47 @@ use aws_sdk_cloudwatchlogs::{
 };
 use std::collections::HashSet;
 
+/// Classification of a CloudWatch upload failure.
+///
+/// The AWS SDK already retries transient faults (throttling, 5xx, timeouts)
+/// internally via [`RetryConfig`], so the only fault worth a manual retry
+/// is a missing log group/stream — everything else is either fatal for this cycle or
+/// an auth problem the same credentials cannot fix.
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum CwUploadError {
+#[non_exhaustive]
+pub enum CwUploadError {
+    /// Authentication/authorization failure. Not retryable with the same credentials —
+    /// kept distinct so the caller can trigger a TES credential refresh.
     #[error("authentication error")]
-    AuthError,
-    #[error("retriable: {0}")]
-    Retriable(String),
+    Auth,
+    /// A fault the SDK does not retry but a single immediate re-attempt may clear —
+    /// notably `ResourceNotFoundException` (recreate the group/stream) or a raw
+    /// transport error surfacing after the SDK's own retries are exhausted.
+    #[error("retryable: {0}")]
+    Retryable(String),
+    /// A non-retryable failure for this cycle: invalid input, a hard resource/account
+    /// quota such as `LimitExceeded` that retrying cannot clear, or a transient class
+    /// the SDK already retried and exhausted (e.g. throttling/5xx).
     #[error("{0}")]
-    Other(String),
+    Fatal(String),
 }
 
-pub(crate) struct CwLogsClient {
+/// Outcome of an upload attempt.
+#[derive(Debug)]
+#[must_use = "upload outcome must be handled"]
+pub(crate) enum UploadOutcome {
+    /// All events uploaded successfully.
+    Success,
+    /// A retryable fault persisted after the single re-attempt — the batch will be
+    /// retried on the next upload cycle.
+    RetriesExhausted,
+}
+
+pub struct CwLogsClient {
     client: Client,
+    // Only read by `recreate_client` (the credential-refresh hook), which has no
+    // production caller in this crate yet — exercised by unit tests.
+    #[allow(dead_code)]
     config: aws_sdk_cloudwatchlogs::Config,
     created_groups: HashSet<String>,
     created_streams: HashSet<String>,
@@ -56,6 +85,9 @@ impl CwLogsClient {
     /// Recreate the SDK client (e.g., after persistent network errors).
     /// Caches are preserved — if a resource was deleted externally, the next
     /// put_log_events will get ResourceNotFoundException which clears the cache.
+    // No production caller yet; exercised by unit tests. Retained as the client's
+    // credential-refresh hook for the upload orchestration.
+    #[allow(dead_code)]
     pub(crate) fn recreate_client(&mut self) {
         self.client = Client::from_conf(self.config.clone());
     }
@@ -68,6 +100,47 @@ impl CwLogsClient {
         self.ensure_log_stream(&batch.log_group, &batch.log_stream)
             .await?;
         self.put_log_events(batch).await
+    }
+
+    /// Upload a batch, retrying exactly once for a retryable fault.
+    ///
+    /// The AWS SDK already retries throttling/5xx/timeouts internally
+    /// ([`RetryConfig`] with `max_attempts(5)`), so there is deliberately no app-level
+    /// sleep/backoff loop here. The single re-attempt exists for the one case the SDK
+    /// cannot handle: a missing log group/stream. On `ResourceNotFoundException`,
+    /// [`Self::put_log_events`] clears the resource cache, so re-running `upload_batch`
+    /// recreates the group/stream and re-sends once when the target was deleted
+    /// between the cache check and the upload. Any other persistent failure is
+    /// deferred to the next cycle.
+    ///
+    /// # Errors
+    /// Returns [`CwUploadError::Auth`] when credentials are invalid (non-retryable);
+    /// the caller stops processing the source so credentials can be refreshed.
+    pub(crate) async fn upload_batch_with_retry(
+        &mut self,
+        batch: &SealedBatch,
+    ) -> Result<UploadOutcome, CwUploadError> {
+        match self.upload_batch(batch).await {
+            Ok(()) => return Ok(UploadOutcome::Success),
+            Err(CwUploadError::Auth) => return Err(CwUploadError::Auth),
+            Err(CwUploadError::Fatal(msg)) => {
+                tracing::error!(log_group = %batch.log_group, error = %msg, "Non-retryable upload error");
+                return Ok(UploadOutcome::RetriesExhausted);
+            }
+            Err(CwUploadError::Retryable(msg)) => {
+                tracing::warn!(log_group = %batch.log_group, error = %msg, "Retryable error, recreating resources and retrying once");
+            }
+        }
+
+        // Single re-attempt, no sleep. Persistent failures wait for the next upload cycle.
+        match self.upload_batch(batch).await {
+            Ok(()) => Ok(UploadOutcome::Success),
+            Err(CwUploadError::Auth) => Err(CwUploadError::Auth),
+            Err(e) => {
+                tracing::error!(log_group = %batch.log_group, error = %e, "Upload failed after recreate retry");
+                Ok(UploadOutcome::RetriesExhausted)
+            }
+        }
     }
 
     async fn ensure_log_group(&mut self, log_group: &str) -> Result<(), CwUploadError> {
@@ -91,12 +164,10 @@ impl CwLogsClient {
                 Ok(())
             }
             Err(SdkError::ServiceError(e)) if is_limit_exceeded_group(e.err()) => Err(
-                CwUploadError::Retriable("LimitExceededException on create_log_group".to_string()),
+                CwUploadError::Fatal("LimitExceededException on create_log_group".to_string()),
             ),
-            Err(SdkError::ServiceError(e)) if is_auth_error(e.err()) => {
-                Err(CwUploadError::AuthError)
-            }
-            Err(e) => Err(CwUploadError::Retriable(e.to_string())),
+            Err(SdkError::ServiceError(e)) if is_auth_error(e.err()) => Err(CwUploadError::Auth),
+            Err(e) => Err(CwUploadError::Retryable(e.to_string())),
         }
     }
 
@@ -126,13 +197,8 @@ impl CwLogsClient {
                 self.created_streams.insert(key);
                 Ok(())
             }
-            Err(SdkError::ServiceError(e)) if is_limit_exceeded_stream(e.err()) => Err(
-                CwUploadError::Retriable("LimitExceededException on create_log_stream".to_string()),
-            ),
-            Err(SdkError::ServiceError(e)) if is_auth_error(e.err()) => {
-                Err(CwUploadError::AuthError)
-            }
-            Err(e) => Err(CwUploadError::Retriable(e.to_string())),
+            Err(SdkError::ServiceError(e)) if is_auth_error(e.err()) => Err(CwUploadError::Auth),
+            Err(e) => Err(CwUploadError::Retryable(e.to_string())),
         }
     }
 
@@ -148,7 +214,7 @@ impl CwLogsClient {
             })
             .collect();
         let events =
-            events.map_err(|e| CwUploadError::Other(format!("Failed to build log event: {e}")))?;
+            events.map_err(|e| CwUploadError::Fatal(format!("Failed to build log event: {e}")))?;
 
         // EMF metrics are auto-extracted by CloudWatch when log events contain the _aws key.
         // No sequence tokens needed — deprecated since late 2023, and we create new streams daily.
@@ -172,32 +238,32 @@ impl CwLogsClient {
                     tracing::debug!(log_group = %batch.log_group, "Data already accepted");
                     Ok(())
                 }
-                PutLogEventsError::UnrecognizedClientException(_) => Err(CwUploadError::AuthError),
-                PutLogEventsError::ServiceUnavailableException(_) => Err(CwUploadError::Other(
+                PutLogEventsError::UnrecognizedClientException(_) => Err(CwUploadError::Auth),
+                PutLogEventsError::ServiceUnavailableException(_) => Err(CwUploadError::Fatal(
                     "ServiceUnavailable after SDK retries exhausted".to_string(),
                 )),
                 PutLogEventsError::ResourceNotFoundException(_) => {
-                    // Clear cache so next retry re-creates the group/stream
+                    // Clear cache so the single re-attempt recreates the group/stream.
                     self.created_groups.remove(&batch.log_group);
                     let key = format!("{}:{}", batch.log_group, batch.log_stream);
                     self.created_streams.remove(&key);
-                    Err(CwUploadError::Retriable("ResourceNotFound".to_string()))
+                    Err(CwUploadError::Retryable("ResourceNotFound".to_string()))
                 }
                 PutLogEventsError::InvalidParameterException(ex) => {
-                    Err(CwUploadError::Other(ex.to_string()))
+                    Err(CwUploadError::Fatal(ex.to_string()))
                 }
                 other => {
                     use aws_sdk_cloudwatchlogs::error::ProvideErrorMetadata;
                     if other.code() == Some("ThrottlingException") {
-                        Err(CwUploadError::Other(
+                        Err(CwUploadError::Fatal(
                             "Throttled after SDK retries exhausted".to_string(),
                         ))
                     } else {
-                        Err(CwUploadError::Other(other.to_string()))
+                        Err(CwUploadError::Fatal(other.to_string()))
                     }
                 }
             },
-            Err(e) => Err(CwUploadError::Retriable(e.to_string())),
+            Err(e) => Err(CwUploadError::Retryable(e.to_string())),
         }
     }
 
@@ -240,16 +306,7 @@ fn is_stream_exists(
     matches!(err, aws_sdk_cloudwatchlogs::operation::create_log_stream::CreateLogStreamError::ResourceAlreadyExistsException(_))
 }
 
-/// String-based match because `CreateLogStreamError` does not have a typed
-/// `LimitExceededException` variant in SDK v1.20 (unlike `CreateLogGroupError`).
-fn is_limit_exceeded_stream(
-    err: &aws_sdk_cloudwatchlogs::operation::create_log_stream::CreateLogStreamError,
-) -> bool {
-    use aws_sdk_cloudwatchlogs::error::ProvideErrorMetadata;
-    err.code() == Some("LimitExceededException")
-}
-
-/// Auth errors are not retriable — same credentials will produce the same failure.
+/// Auth errors are not retryable — same credentials will produce the same failure.
 fn is_auth_error<E: aws_sdk_cloudwatchlogs::error::ProvideErrorMetadata>(err: &E) -> bool {
     matches!(
         err.code(),
@@ -271,34 +328,54 @@ mod tests {
         CwLogsClient::new_with_client(client, config)
     }
 
+    fn batch_with_event() -> SealedBatch {
+        SealedBatch {
+            log_group: "test-group".to_string(),
+            log_stream: "test-stream".to_string(),
+            events: vec![crate::scanner::LogEvent {
+                timestamp: 1000,
+                message: "hello".to_string(),
+            }],
+        }
+    }
+
     #[test]
     fn test_cw_upload_error_display() {
-        assert_eq!(CwUploadError::AuthError.to_string(), "authentication error");
+        assert_eq!(CwUploadError::Auth.to_string(), "authentication error");
         assert_eq!(
-            CwUploadError::Retriable("timeout".into()).to_string(),
-            "retriable: timeout"
+            CwUploadError::Retryable("timeout".into()).to_string(),
+            "retryable: timeout"
         );
-        assert_eq!(CwUploadError::Other("bad".into()).to_string(), "bad");
+        assert_eq!(CwUploadError::Fatal("bad".into()).to_string(), "bad");
     }
 
     #[test]
     fn test_cw_upload_error_variants() {
-        let auth = CwUploadError::AuthError;
-        assert!(matches!(auth, CwUploadError::AuthError));
+        let auth = CwUploadError::Auth;
+        assert!(matches!(auth, CwUploadError::Auth));
 
-        let retriable = CwUploadError::Retriable("connection error".to_string());
-        if let CwUploadError::Retriable(msg) = retriable {
+        let retryable = CwUploadError::Retryable("connection error".to_string());
+        if let CwUploadError::Retryable(msg) = retryable {
             assert_eq!(msg, "connection error");
         } else {
-            panic!("Expected Retriable variant");
+            panic!("Expected Retryable variant");
         }
 
-        let other = CwUploadError::Other("test error".to_string());
-        if let CwUploadError::Other(msg) = other {
+        let fatal = CwUploadError::Fatal("test error".to_string());
+        if let CwUploadError::Fatal(msg) = fatal {
             assert_eq!(msg, "test error");
         } else {
-            panic!("Expected Other variant");
+            panic!("Expected Fatal variant");
         }
+    }
+
+    #[test]
+    fn test_upload_outcome_variants() {
+        assert!(matches!(UploadOutcome::Success, UploadOutcome::Success));
+        assert!(matches!(
+            UploadOutcome::RetriesExhausted,
+            UploadOutcome::RetriesExhausted
+        ));
     }
 
     #[test]
@@ -323,30 +400,6 @@ mod tests {
     }
 
     #[test]
-    fn test_limit_exceeded_on_group_create() {
-        let err =
-            CwUploadError::Retriable("LimitExceededException on create_log_group".to_string());
-        if let CwUploadError::Retriable(msg) = err {
-            assert!(msg.contains("LimitExceededException"));
-            assert!(msg.contains("create_log_group"));
-        } else {
-            panic!("Expected Retriable variant");
-        }
-    }
-
-    #[test]
-    fn test_limit_exceeded_on_stream_create() {
-        let err =
-            CwUploadError::Retriable("LimitExceededException on create_log_stream".to_string());
-        if let CwUploadError::Retriable(msg) = err {
-            assert!(msg.contains("LimitExceededException"));
-            assert!(msg.contains("create_log_stream"));
-        } else {
-            panic!("Expected Retriable variant");
-        }
-    }
-
-    #[test]
     fn test_client_can_be_recreated() {
         let mut cw = make_test_client();
         cw.mark_group_created("test-group");
@@ -356,41 +409,49 @@ mod tests {
         assert!(cw.created_streams().contains("test-group:test-stream"));
     }
 
-    #[tokio::test]
-    async fn test_resource_not_found_clears_cache() {
+    fn ok_response() -> http::Response<aws_smithy_types::body::SdkBody> {
+        http::Response::builder()
+            .status(200)
+            .body(aws_smithy_types::body::SdkBody::from("{}"))
+            .unwrap()
+    }
+
+    fn error_response(
+        status: u16,
+        body: &'static str,
+    ) -> http::Response<aws_smithy_types::body::SdkBody> {
+        http::Response::builder()
+            .status(status)
+            .body(aws_smithy_types::body::SdkBody::from(body))
+            .unwrap()
+    }
+
+    fn dummy_request() -> http::Request<aws_smithy_types::body::SdkBody> {
+        http::Request::builder()
+            .uri("https://logs.us-east-1.amazonaws.com/")
+            .body(aws_smithy_types::body::SdkBody::empty())
+            .unwrap()
+    }
+
+    fn replay_client(
+        responses: Vec<http::Response<aws_smithy_types::body::SdkBody>>,
+    ) -> aws_smithy_http_client::test_util::StaticReplayClient {
         use aws_smithy_http_client::test_util::{ReplayEvent, StaticReplayClient};
-        use aws_smithy_types::body::SdkBody;
+        StaticReplayClient::new(
+            responses
+                .into_iter()
+                .map(|resp| ReplayEvent::new(dummy_request(), resp))
+                .collect(),
+        )
+    }
 
-        fn ok_response() -> http::Response<SdkBody> {
-            http::Response::builder()
-                .status(200)
-                .body(SdkBody::from("{}"))
-                .unwrap()
-        }
-        fn resource_not_found_response() -> http::Response<SdkBody> {
-            http::Response::builder()
-                .status(400)
-                .body(SdkBody::from(
-                    r#"{"__type":"ResourceNotFoundException","message":"The specified log group does not exist."}"#,
-                ))
-                .unwrap()
-        }
-        fn dummy_request() -> http::Request<SdkBody> {
-            http::Request::builder()
-                .uri("https://logs.us-east-1.amazonaws.com/")
-                .body(SdkBody::empty())
-                .unwrap()
-        }
-
-        let replay_client = StaticReplayClient::new(vec![
-            // CreateLogGroup → 200 OK
-            ReplayEvent::new(dummy_request(), ok_response()),
-            // CreateLogStream → 200 OK
-            ReplayEvent::new(dummy_request(), ok_response()),
-            // PutLogEvents → ResourceNotFoundException
-            ReplayEvent::new(dummy_request(), resource_not_found_response()),
-        ]);
-
+    fn client_with_responses(
+        responses: Vec<http::Response<aws_smithy_types::body::SdkBody>>,
+    ) -> (
+        CwLogsClient,
+        aws_smithy_http_client::test_util::StaticReplayClient,
+    ) {
+        let replay = replay_client(responses);
         let config = aws_sdk_cloudwatchlogs::Config::builder()
             .behavior_version(aws_sdk_cloudwatchlogs::config::BehaviorVersion::latest())
             .credentials_provider(aws_sdk_cloudwatchlogs::config::Credentials::new(
@@ -400,26 +461,28 @@ mod tests {
             .retry_config(
                 aws_sdk_cloudwatchlogs::config::retry::RetryConfig::standard().with_max_attempts(1),
             )
-            .http_client(replay_client)
+            .http_client(replay.clone())
             .build();
         let client = Client::from_conf(config.clone());
-        let mut cw = CwLogsClient::new_with_client(client, config);
+        (CwLogsClient::new_with_client(client, config), replay)
+    }
 
-        let batch = SealedBatch {
-            log_group: "test-group".to_string(),
-            log_stream: "test-stream".to_string(),
-            events: vec![crate::scanner::LogEvent {
-                timestamp: 1000,
-                message: "hello".to_string(),
-            }],
-        };
+    #[tokio::test]
+    async fn test_resource_not_found_clears_cache() {
+        let (mut cw, _replay) = client_with_responses(vec![
+            ok_response(), // CreateLogGroup
+            ok_response(), // CreateLogStream
+            error_response(
+                400,
+                r#"{"__type":"ResourceNotFoundException","message":"The specified log group does not exist."}"#,
+            ),
+        ]);
 
-        let result = cw.upload_batch(&batch).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
+        let batch = batch_with_event();
+        let err = cw.upload_batch(&batch).await.unwrap_err();
         assert!(
-            matches!(&err, CwUploadError::Retriable(msg) if msg.contains("ResourceNotFound")),
-            "Expected Retriable(ResourceNotFound), got: {err}"
+            matches!(&err, CwUploadError::Retryable(msg) if msg.contains("ResourceNotFound")),
+            "Expected Retryable(ResourceNotFound), got: {err}"
         );
         assert!(
             !cw.created_groups().contains("test-group"),
@@ -429,5 +492,188 @@ mod tests {
             !cw.created_streams().contains("test-group:test-stream"),
             "Log stream should be cleared from cache after ResourceNotFoundException"
         );
+    }
+
+    #[tokio::test]
+    async fn test_with_retry_recreates_and_succeeds_on_resource_not_found() {
+        // First attempt: create group/stream OK, put → ResourceNotFound (clears cache).
+        // Single re-attempt: re-create group/stream, put → OK.
+        let (mut cw, _replay) = client_with_responses(vec![
+            ok_response(), // CreateLogGroup (attempt 1)
+            ok_response(), // CreateLogStream (attempt 1)
+            error_response(
+                400,
+                r#"{"__type":"ResourceNotFoundException","message":"missing"}"#,
+            ), // PutLogEvents (attempt 1)
+            ok_response(), // CreateLogGroup (attempt 2)
+            ok_response(), // CreateLogStream (attempt 2)
+            ok_response(), // PutLogEvents (attempt 2)
+        ]);
+
+        let batch = batch_with_event();
+        let outcome = cw.upload_batch_with_retry(&batch).await.unwrap();
+        assert!(matches!(outcome, UploadOutcome::Success));
+    }
+
+    #[tokio::test]
+    async fn test_with_retry_fatal_does_not_retry() {
+        // InvalidParameter is fatal — no re-attempt; only the first 3 calls are consumed.
+        let (mut cw, replay) = client_with_responses(vec![
+            ok_response(), // CreateLogGroup
+            ok_response(), // CreateLogStream
+            error_response(
+                400,
+                r#"{"__type":"InvalidParameterException","message":"bad"}"#,
+            ), // PutLogEvents
+        ]);
+
+        let batch = batch_with_event();
+        let outcome = cw.upload_batch_with_retry(&batch).await.unwrap();
+        assert!(matches!(outcome, UploadOutcome::RetriesExhausted));
+        // No second attempt: exactly the 3 seeded requests were issued.
+        assert_eq!(replay.actual_requests().count(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_with_retry_auth_propagates() {
+        // CreateLogGroup → AccessDenied surfaces as Auth, propagated to the caller.
+        let (mut cw, _replay) = client_with_responses(vec![error_response(
+            400,
+            r#"{"__type":"AccessDeniedException","message":"denied"}"#,
+        )]);
+
+        let batch = batch_with_event();
+        let err = cw.upload_batch_with_retry(&batch).await.unwrap_err();
+        assert!(matches!(err, CwUploadError::Auth));
+    }
+
+    // Direct tests for the source-level orchestration in `upload_source_events`.
+
+    fn event_at(ts: i64, msg: &str) -> crate::scanner::LogEvent {
+        crate::scanner::LogEvent {
+            timestamp: ts,
+            message: msg.to_string(),
+        }
+    }
+
+    fn now_ms_i64() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64
+    }
+
+    #[tokio::test]
+    async fn test_upload_source_events_empty_events() {
+        // No events → nothing uploaded; the file is reported succeeded so its
+        // checkpoint can still advance. The client is never called.
+        let (mut cw, _replay) = client_with_responses(vec![]);
+        let path = std::path::PathBuf::from("/tmp/empty.log");
+        let file_events = vec![(path.clone(), Vec::new(), 0u64, "hash-empty".to_string())];
+
+        let result =
+            crate::uploader::upload_source_events(&mut cw, "grp", "stream", file_events, None)
+                .await
+                .unwrap();
+
+        assert_eq!(result.succeeded.len(), 1);
+        assert_eq!(result.succeeded[0].0, path);
+        assert!(result.failed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_upload_source_events_all_succeed() {
+        // Single batch: CreateLogGroup + CreateLogStream + PutLogEvents all succeed.
+        let (mut cw, _replay) = client_with_responses(vec![
+            ok_response(), // CreateLogGroup
+            ok_response(), // CreateLogStream
+            ok_response(), // PutLogEvents
+        ]);
+        let path = std::path::PathBuf::from("/tmp/ok.log");
+        let file_events = vec![(
+            path.clone(),
+            vec![event_at(now_ms_i64(), "hello")],
+            5u64,
+            "hash-ok".to_string(),
+        )];
+
+        let result = crate::uploader::upload_source_events(
+            &mut cw,
+            "test-group",
+            "test-stream",
+            file_events,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.succeeded.len(), 1);
+        assert_eq!(result.succeeded[0].0, path);
+        assert!(result.failed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_upload_source_events_multibatch_partial_failure() {
+        // >10_000 events → 2 batches. Batch 1 succeeds; batch 2's PutLogEvents returns a
+        // fatal InvalidParameter (→ RetriesExhausted). All-or-nothing per source: the whole
+        // source is marked failed and no checkpoint advances, so it is re-read next cycle.
+        let now = now_ms_i64();
+        let events: Vec<crate::scanner::LogEvent> =
+            (0..10_001).map(|i| event_at(now + i, "x")).collect();
+        // Batch 1 issues CreateLogGroup + CreateLogStream + PutLogEvents; batch 2 reuses the
+        // cached group/stream and only issues PutLogEvents (which fails).
+        let (mut cw, _replay) = client_with_responses(vec![
+            ok_response(), // CreateLogGroup (batch 1)
+            ok_response(), // CreateLogStream (batch 1)
+            ok_response(), // PutLogEvents (batch 1)
+            error_response(
+                400,
+                r#"{"__type":"InvalidParameterException","message":"bad"}"#,
+            ), // PutLogEvents (batch 2)
+        ]);
+        let path = std::path::PathBuf::from("/tmp/source.log");
+        let file_events = vec![(path.clone(), events, 100u64, "hash-multi".to_string())];
+
+        let result = crate::uploader::upload_source_events(
+            &mut cw,
+            "test-group",
+            "test-stream",
+            file_events,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.succeeded.is_empty());
+        assert_eq!(result.failed, vec![path]);
+    }
+
+    #[tokio::test]
+    async fn test_upload_source_events_auth_bubbles_up() {
+        // CreateLogGroup → AccessDenied surfaces as Auth and propagates out of the source
+        // orchestration so the caller can stop the cycle and refresh credentials.
+        let (mut cw, _replay) = client_with_responses(vec![error_response(
+            400,
+            r#"{"__type":"AccessDeniedException","message":"denied"}"#,
+        )]);
+        let path = std::path::PathBuf::from("/tmp/auth.log");
+        let file_events = vec![(
+            path,
+            vec![event_at(now_ms_i64(), "hello")],
+            5u64,
+            "hash-auth".to_string(),
+        )];
+
+        let err = crate::uploader::upload_source_events(
+            &mut cw,
+            "test-group",
+            "test-stream",
+            file_events,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, CwUploadError::Auth));
     }
 }

--- a/src/uploader/mod.rs
+++ b/src/uploader/mod.rs
@@ -1,34 +1,264 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Upload pipeline - batching, CloudWatch client, scheduling
+//! Upload pipeline - batching, CloudWatch client, retry, scheduling, checkpoint advancement
 
-#[allow(dead_code, reason = "consumed by upload orchestrator")]
+// The batcher exists solely to prepare events for CloudWatch upload, so it is only
+// compiled with the `aws-sdk` feature (its sole consumer is `upload_source_events`).
+#[cfg(feature = "aws-sdk")]
 mod batcher;
 #[cfg(feature = "aws-sdk")]
 mod cw_client;
 
-use crate::scanner::LogEvent;
+#[cfg(feature = "aws-sdk")]
+use crate::config::LogLevel;
+use crate::scanner::{
+    CheckpointStore, FileCheckpoint, LastFileProcessedTimestamp, LogEvent, ScannedFile,
+};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// A sealed batch of log events ready for upload to CloudWatch.
 #[derive(Debug)]
-pub(crate) struct SealedBatch {
-    pub(crate) log_group: String,
-    pub(crate) log_stream: String,
-    pub(crate) events: Vec<LogEvent>,
+pub struct SealedBatch {
+    pub log_group: String,
+    pub log_stream: String,
+    pub events: Vec<LogEvent>,
 }
 
 #[cfg(feature = "aws-sdk")]
-pub(crate) use cw_client::{CwLogsClient, CwUploadError};
+pub(crate) use cw_client::UploadOutcome;
+#[cfg(feature = "aws-sdk")]
+pub use cw_client::{CwLogsClient, CwUploadError};
 
-#[allow(unused_imports, reason = "consumed by upload orchestrator")]
-pub(crate) use batcher::{seal_batches, MAX_EVENT_BYTES};
+#[cfg(feature = "aws-sdk")]
+pub(crate) use batcher::seal_batches;
 
-/// Format log stream name matching Java LogManager:
-/// `/{yyyy}/{MM}/{dd}/thing/{thingName}` (UTC)
+/// 24 hours in milliseconds — default TTL for checkpoint entries.
+pub const TTL_24H_MS: u64 = 24 * 60 * 60 * 1000;
+
+/// Compute the effective upload interval with jitter to prevent a thundering herd.
+/// Uses the per-source override when set, otherwise the global interval, plus 0-5s jitter.
+#[must_use]
+pub fn effective_interval_secs(per_source: Option<u64>, global: u64) -> u64 {
+    let base = per_source.unwrap_or(global);
+    let jitter = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos() as u64
+        % 6;
+    base + jitter
+}
+
+/// Result of uploading events for a single log source.
+// TODO: replace these positional tuples — `(path, new_offset, content_hash)` here and the
+// `file_events` `(path, events, new_offset, content_hash)` input — with named structs
+// (e.g. `FileUploadSuccess` / `FileUploadInput`) for readability and safer field evolution.
+// Deferred: the input tuple currently spans the uploader/main.rs boundary, so the rename is
+// cleaner as one atomic pass once the full scan→upload→checkpoint pipeline is in a single tree.
+#[derive(Debug)]
+#[must_use = "upload results must be checked to advance checkpoints"]
+pub struct UploadResult {
+    /// Files whose ALL batches succeeded: (path, new_offset, content_hash).
+    pub succeeded: Vec<(PathBuf, u64, String)>,
+    /// Files that had at least one batch failure.
+    pub failed: Vec<PathBuf>,
+}
+
+/// Upload events from multiple files for a single log source.
+///
+/// `seal_batches` merges events across files (sorted by timestamp), so per-file success
+/// cannot be tracked at batch granularity. We therefore use an all-or-nothing model for
+/// the source: a file's checkpoint advances only if EVERY batch succeeds; if any batch
+/// fails, all files for this source are marked failed and retried on the next cycle.
+///
+/// # Errors
+/// Returns [`CwUploadError::Auth`] when credentials are invalid; the orchestrator
+/// stops the upload cycle so the credentials can be refreshed.
+// TODO: all-or-nothing per source — any batch failure re-sends the whole source on the
+// next cycle. Finer per-file/per-stream success tracking (advance only the files whose
+// batches succeeded) would cut duplicates on partial failure, but requires carrying a
+// file identity through batching; deferred as a behavior change.
+#[cfg(feature = "aws-sdk")]
+pub async fn upload_source_events(
+    client: &mut CwLogsClient,
+    log_group: &str,
+    log_stream: &str,
+    file_events: Vec<(PathBuf, Vec<LogEvent>, u64, String)>, // (path, events, new_offset, hash)
+    min_log_level: Option<LogLevel>,
+) -> Result<UploadResult, CwUploadError> {
+    // Collect file metadata before flattening events for batching.
+    let file_info: Vec<(PathBuf, u64, String)> = file_events
+        .iter()
+        .map(|(p, _, off, hash)| (p.clone(), *off, hash.clone()))
+        .collect();
+
+    let all_events: Vec<LogEvent> = file_events
+        .into_iter()
+        .flat_map(|(_, events, _, _)| events)
+        .collect();
+
+    if all_events.is_empty() {
+        return Ok(UploadResult {
+            succeeded: file_info,
+            failed: vec![],
+        });
+    }
+
+    let now_ms = now_ms() as i64;
+    let batches = seal_batches(all_events, log_group, log_stream, min_log_level, now_ms);
+
+    let mut all_ok = true;
+    for batch in &batches {
+        match client.upload_batch_with_retry(batch).await {
+            Ok(UploadOutcome::Success) => {}
+            Ok(UploadOutcome::RetriesExhausted) => {
+                all_ok = false;
+                break;
+            }
+            // The retry wrapper only ever returns `Err(Auth)`; surface it so the
+            // orchestrator can stop the cycle and refresh credentials.
+            Err(e) => return Err(e),
+        }
+    }
+
+    if all_ok {
+        Ok(UploadResult {
+            succeeded: file_info,
+            failed: vec![],
+        })
+    } else {
+        Ok(UploadResult {
+            succeeded: vec![],
+            failed: file_info.into_iter().map(|(p, _, _)| p).collect(),
+        })
+    }
+}
+
+#[cfg(feature = "aws-sdk")]
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Convert a file mtime to epoch milliseconds. Returns 0 for a pre-1970 time so a
+/// no-RTC device never panics or wraps. Shared by the scanner/checkpoint sites.
+#[must_use]
+pub fn mtime_to_ms(t: SystemTime) -> u64 {
+    t.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// A file is fully uploaded when all bytes have been read, it is not the active
+/// (currently written-to) file, and it is non-empty.
+#[must_use]
+fn is_file_fully_uploaded(is_active: bool, file_len: u64, bytes_read: u64) -> bool {
+    !is_active && file_len == bytes_read && file_len > 0
+}
+
+/// Advance checkpoints after a successful upload. Returns paths of completed files.
+///
+/// A completed file (`!is_active && file_length == new_offset && len > 0`) is removed
+/// from the checkpoint and its component `lastFileProcessedTimeStamp` is advanced
+/// monotonically. A partial or active file simply has its `start_position` updated.
+pub fn advance_checkpoints(
+    store: &mut CheckpointStore,
+    log_group_key: &str,
+    succeeded: &[(PathBuf, u64, String)], // (path, new_offset, content_hash)
+    scanned_files: &[ScannedFile],
+    now: u64,
+) -> Vec<PathBuf> {
+    use std::collections::HashMap;
+    let mut completed = Vec::new();
+
+    // Pre-build a path-keyed lookup so per-file resolution is O(1) instead of a linear scan
+    // per succeeded file. Paths are unique within a single scan, so a plain map (no
+    // first-wins fold) resolves each succeeded `path` to exactly its own `ScannedFile` —
+    // resolution is unambiguous. The prior hash-keyed lookup could resolve to a *different*
+    // file on a first-line content-hash collision (e.g. empty or identical-first-line
+    // files), so `is_active`/`mtime` might describe a file other than the one whose bytes
+    // were read, mis-completing an active file.
+    let scanned_by_path: HashMap<&Path, &ScannedFile> = scanned_files
+        .iter()
+        .map(|f| (f.path.as_path(), f))
+        .collect();
+
+    let file_map = store
+        .file_processing_info
+        .entry(log_group_key.to_string())
+        .or_default();
+
+    for (path, new_offset, content_hash) in succeeded {
+        let scanned = scanned_by_path.get(path.as_path()).copied();
+        let is_active = scanned.is_some_and(|f| f.is_active);
+        let file_len = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+
+        // TODO: The checkpoint is keyed by `content_hash`, so two files that share a
+        // `content_hash` still collide on the checkpoint key (one file's checkpoint
+        // overwrites/removes the other's). Unique per-file checkpoint identity is deferred.
+        if is_file_fully_uploaded(is_active, file_len, *new_offset) {
+            file_map.remove(content_hash);
+            completed.push(path.clone());
+
+            // Advance the component's last-processed timestamp monotonically.
+            let file_mtime_ms = scanned.map(|f| mtime_to_ms(f.mtime)).unwrap_or(0);
+            let ts_entry = store
+                .last_processed_timestamps
+                .entry(log_group_key.to_string())
+                .or_insert(LastFileProcessedTimestamp {
+                    last_file_processed_time_stamp: 0,
+                });
+            if file_mtime_ms > ts_entry.last_file_processed_time_stamp {
+                ts_entry.last_file_processed_time_stamp = file_mtime_ms;
+            }
+
+            tracing::info!(path = %path.display(), "File completed, removed from checkpoint");
+        } else {
+            file_map.insert(
+                content_hash.clone(),
+                FileCheckpoint {
+                    file_hash: content_hash.clone(),
+                    start_position: *new_offset,
+                    last_modified_time: scanned.map(|f| mtime_to_ms(f.mtime)).unwrap_or(0),
+                    last_accessed: now,
+                },
+            );
+        }
+    }
+
+    completed
+}
+
+/// Evict checkpoint entries older than `ttl_ms` (24 hours by default).
+/// Called after each upload cycle to prevent unbounded checkpoint growth.
+pub fn evict_stale_entries(
+    store: &mut CheckpointStore,
+    log_group_key: &str,
+    ttl_ms: u64,
+    now: u64,
+) {
+    if let Some(file_map) = store.file_processing_info.get_mut(log_group_key) {
+        let before = file_map.len();
+        file_map.retain(|_, cp| now.saturating_sub(cp.last_accessed) < ttl_ms);
+        let evicted = before - file_map.len();
+        if evicted > 0 {
+            tracing::info!(
+                log_group_key,
+                evicted,
+                "Evicted stale checkpoint entries (TTL)"
+            );
+        }
+    }
+}
+
+/// Format log stream name matching the component's scheme:
+/// `/{yyyy}/{MM}/{dd}/thing/{thingName}` (UTC).
 /// Replaces colons with `+` since CW log stream names cannot contain `:`.
 #[must_use]
-pub(crate) fn format_log_stream_name(thing_name: &str) -> String {
+pub fn format_log_stream_name(thing_name: &str) -> String {
     let now = time::OffsetDateTime::now_utc();
     let safe_name = thing_name.replace(':', "+");
     format!(
@@ -42,9 +272,8 @@ pub(crate) fn format_log_stream_name(thing_name: &str) -> String {
 
 /// Check if a timestamp (epoch millis) falls on a different UTC date.
 /// Used to detect when a new log stream should be created at midnight.
-#[allow(dead_code, reason = "used by upload orchestrator")]
 #[must_use]
-pub(crate) fn is_different_date(
+pub fn is_different_date(
     timestamp_ms: i64,
     stream_year: i32,
     stream_month: u32,
@@ -63,6 +292,7 @@ pub(crate) fn is_different_date(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test_sealed_batch_struct() {
@@ -106,8 +336,8 @@ mod tests {
     fn test_is_different_date_same() {
         let now = time::OffsetDateTime::now_utc();
         let (y, m, d) = (now.year(), now.month() as u32, now.day() as u32);
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_millis() as i64;
         assert!(!is_different_date(now_ms, y, m, d));
@@ -131,5 +361,254 @@ mod tests {
         assert!(!is_different_date(1704067200000, 2024, 1, 1));
         assert!(is_different_date(1704067199999, 2024, 1, 1));
         assert!(is_different_date(1704067200000, 2023, 12, 31));
+    }
+
+    #[test]
+    fn test_effective_interval_with_override() {
+        let interval = effective_interval_secs(Some(60), 300);
+        assert!((60..=65).contains(&interval));
+    }
+
+    #[test]
+    fn test_effective_interval_global_default() {
+        let interval = effective_interval_secs(None, 300);
+        assert!((300..=305).contains(&interval));
+    }
+
+    #[test]
+    fn test_effective_interval_zero() {
+        let interval = effective_interval_secs(None, 0);
+        assert!((0..=5).contains(&interval));
+    }
+
+    #[test]
+    fn test_is_file_fully_uploaded() {
+        // Fully read, not active, non-empty → complete.
+        assert!(is_file_fully_uploaded(false, 100, 100));
+        // Active file is never complete even if fully read.
+        assert!(!is_file_fully_uploaded(true, 100, 100));
+        // Partially read → not complete.
+        assert!(!is_file_fully_uploaded(false, 100, 50));
+        // Empty file → not complete.
+        assert!(!is_file_fully_uploaded(false, 0, 0));
+    }
+
+    #[test]
+    fn test_advance_checkpoints_partial_file() {
+        let mut store = CheckpointStore::default();
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.log");
+        std::fs::write(&file_path, "hello world\nmore data\n").unwrap();
+
+        let scanned = vec![ScannedFile {
+            path: file_path.clone(),
+            mtime: SystemTime::now(),
+            content_hash: "hash1".to_string(),
+            is_active: true,
+        }];
+
+        // new_offset=11 but the file is 22 bytes and active → partial update.
+        let succeeded = vec![(file_path.clone(), 11u64, "hash1".to_string())];
+        let completed = advance_checkpoints(&mut store, "grp", &succeeded, &scanned, 1_000_000);
+
+        assert!(completed.is_empty());
+        let cp = store
+            .file_processing_info
+            .get("grp")
+            .unwrap()
+            .get("hash1")
+            .unwrap();
+        assert_eq!(cp.start_position, 11);
+    }
+
+    #[test]
+    fn test_advance_checkpoints_completed_file() {
+        let mut store = CheckpointStore::default();
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("done.log");
+        std::fs::write(&file_path, "all content").unwrap(); // 11 bytes
+
+        let scanned = vec![ScannedFile {
+            path: file_path.clone(),
+            mtime: SystemTime::now(),
+            content_hash: "hash2".to_string(),
+            is_active: false, // NOT active
+        }];
+
+        // new_offset == file_len && !is_active → completed.
+        let succeeded = vec![(file_path.clone(), 11u64, "hash2".to_string())];
+        let completed = advance_checkpoints(&mut store, "grp", &succeeded, &scanned, 1_000_000);
+
+        assert_eq!(completed, vec![file_path]);
+        assert!(store.file_processing_info.get("grp").unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_advance_checkpoints_active_file_fully_read_not_completed() {
+        let mut store = CheckpointStore::default();
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("active.log");
+        std::fs::write(&file_path, "data").unwrap(); // 4 bytes
+
+        let scanned = vec![ScannedFile {
+            path: file_path.clone(),
+            mtime: SystemTime::now(),
+            content_hash: "hash3".to_string(),
+            is_active: true, // ACTIVE — never completed
+        }];
+
+        let succeeded = vec![(file_path.clone(), 4u64, "hash3".to_string())];
+        let completed = advance_checkpoints(&mut store, "grp", &succeeded, &scanned, 1_000_000);
+
+        assert!(completed.is_empty()); // Active file is never "completed"
+        let cp = store
+            .file_processing_info
+            .get("grp")
+            .unwrap()
+            .get("hash3")
+            .unwrap();
+        assert_eq!(cp.start_position, 4);
+    }
+
+    #[test]
+    fn test_advance_checkpoints_completes_inactive_file_despite_hash_collision() {
+        // Two scanned files share a `content_hash`, but only the inactive (rotated) file is
+        // in `succeeded`. Path-keyed resolution finds that file by its own path, sees it is
+        // inactive and fully read, completes it, and advances the component timestamp to its
+        // mtime. The shared hash belongs to the other (unrelated) file and does not affect
+        // the result.
+        let mut store = CheckpointStore::default();
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("collision.log");
+        std::fs::write(&file_path, "all content").unwrap(); // 11 bytes
+
+        let older = UNIX_EPOCH + std::time::Duration::from_millis(1000);
+        let newer = UNIX_EPOCH + std::time::Duration::from_millis(2000);
+        // mtime-ascending: inactive (older) first, active (newer) second.
+        let scanned = vec![
+            ScannedFile {
+                path: file_path.clone(),
+                mtime: older,
+                content_hash: "dup".to_string(),
+                is_active: false,
+            },
+            ScannedFile {
+                path: dir.path().join("other.log"),
+                mtime: newer,
+                content_hash: "dup".to_string(),
+                is_active: true,
+            },
+        ];
+
+        let succeeded = vec![(file_path.clone(), 11u64, "dup".to_string())];
+        let completed = advance_checkpoints(&mut store, "grp", &succeeded, &scanned, 5000);
+
+        // Path-keyed resolution finds the inactive file → completed and removed.
+        assert_eq!(completed, vec![file_path]);
+        assert!(store.file_processing_info.get("grp").unwrap().is_empty());
+        // Timestamp advanced to the completed (inactive) file's mtime (1000ms).
+        assert_eq!(
+            store
+                .last_processed_timestamps
+                .get("grp")
+                .unwrap()
+                .last_file_processed_time_stamp,
+            1000
+        );
+    }
+
+    #[test]
+    fn test_advance_checkpoints_keeps_active_file_despite_hash_collision() {
+        // Two DISTINCT files share a content_hash "H" (synthetic hash collision), but the
+        // succeeded batch includes BOTH. Per-file state must be resolved by PATH: the
+        // active file B must not be mis-completed just because the inactive file A shares
+        // its hash. Fails on the old hash-keyed lookup (B resolves to A → inactive →
+        // completed); passes on the path-keyed lookup.
+        let mut store = CheckpointStore::default();
+        let dir = tempfile::tempdir().unwrap();
+
+        let path_a = dir.path().join("a.log");
+        let path_b = dir.path().join("b.log");
+        std::fs::write(&path_a, "AAAA").unwrap(); // lenA = 4
+        std::fs::write(&path_b, "BBBBBBB").unwrap(); // lenB = 7 (DIFFERENT)
+        let len_a = std::fs::metadata(&path_a).unwrap().len();
+        let len_b = std::fs::metadata(&path_b).unwrap().len();
+
+        let older = UNIX_EPOCH + std::time::Duration::from_millis(1000);
+        let newer = UNIX_EPOCH + std::time::Duration::from_millis(2000);
+        let scanned = vec![
+            ScannedFile {
+                path: path_a.clone(),
+                mtime: older,
+                content_hash: "H".to_string(),
+                is_active: false, // A rotated
+            },
+            ScannedFile {
+                path: path_b.clone(),
+                mtime: newer,
+                content_hash: "H".to_string(),
+                is_active: true, // B still being written
+            },
+        ];
+
+        // Both fully read (offset == file length).
+        let succeeded = vec![
+            (path_a.clone(), len_a, "H".to_string()),
+            (path_b.clone(), len_b, "H".to_string()),
+        ];
+        let completed = advance_checkpoints(&mut store, "grp", &succeeded, &scanned, 5000);
+
+        // Regression assertion: A completes, active B must NOT be completed.
+        assert!(completed.contains(&path_a));
+        assert!(!completed.contains(&path_b));
+
+        // A completes+removes "H", then active B re-inserts "H" at its own offset (len_b).
+        assert_eq!(
+            store.file_processing_info.get("grp").unwrap()["H"].start_position,
+            len_b
+        );
+    }
+
+    #[test]
+    fn test_evict_stale_entries() {
+        let mut store = CheckpointStore::default();
+        // Fixed reference time so the test never depends on the wall clock.
+        let now: u64 = 100 * 60 * 60 * 1000;
+        let mut files = HashMap::new();
+        // Entry accessed 25 hours ago — should be evicted.
+        files.insert(
+            "old".to_string(),
+            FileCheckpoint {
+                file_hash: "old".to_string(),
+                start_position: 100,
+                last_modified_time: 1000,
+                last_accessed: now - 25 * 60 * 60 * 1000,
+            },
+        );
+        // Entry accessed 1 hour ago — should be kept.
+        files.insert(
+            "fresh".to_string(),
+            FileCheckpoint {
+                file_hash: "fresh".to_string(),
+                start_position: 200,
+                last_modified_time: 2000,
+                last_accessed: now - 60 * 60 * 1000,
+            },
+        );
+        store.file_processing_info.insert("grp".to_string(), files);
+
+        evict_stale_entries(&mut store, "grp", TTL_24H_MS, now);
+
+        let remaining = store.file_processing_info.get("grp").unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert!(remaining.contains_key("fresh"));
+        assert!(!remaining.contains_key("old"));
+    }
+
+    #[test]
+    fn test_evict_stale_entries_empty_group() {
+        let mut store = CheckpointStore::default();
+        // Should not panic on a missing group.
+        evict_stale_entries(&mut store, "nonexistent", TTL_24H_MS, 0);
     }
 }

--- a/tests/sdk_retry_test.rs
+++ b/tests/sdk_retry_test.rs
@@ -159,7 +159,7 @@ async fn data_already_accepted_is_success() {
 
 #[tokio::test]
 async fn resource_not_found_is_retriable() {
-    // ResourceNotFoundException — our cw_client.rs maps it to CwUploadError::Retriable
+    // ResourceNotFoundException — our cw_client.rs maps it to CwUploadError::Retryable
     let replay_client = StaticReplayClient::new(vec![ReplayEvent::new(
         dummy_request(),
         http::Response::builder()


### PR DESCRIPTION
## Summary
Adds the CloudWatch Logs upload subsystem and thing-name resolution: typed failure classification and retry, the upload-pipeline API the orchestrator calls, and credential/thing-name handling. Groundwork for the orchestration change that stacks on top of this.

## What changed
- **Typed upload results** — classify CloudWatch failures as `Auth` / `Retryable` / `Fatal` (`CwUploadError`, `#[non_exhaustive]`); add `#[must_use]` `UploadOutcome { Success, RetriesExhausted }`. The AWS SDK already retries transient faults, so the app layer re-attempts **exactly once** for a missing log group/stream, with no app-level backoff sleep.
- **Upload-pipeline API** — `upload_source_events`, `advance_checkpoints`, `evict_stale_entries` (24h TTL), jittered `effective_interval_secs`, `mtime_to_ms`. `upload_source_events` returns `Result` so **auth failures surface as `Err(Auth)`** for the caller to refresh credentials before retrying; other failures stay per-source, and a source's checkpoints advance only when **every** batch for it succeeds.
- **Checkpoint advancement** — `advance_checkpoints` resolves each file's state (active-flag, mtime) **by path**, so it always matches the file whose bytes were read; this avoids mis-attributing state to a different file that shares a first-line content hash. The checkpoint map stays keyed by `content_hash`. `advance`/`evict` take an injected `now` for deterministic tests.
- **Thing-name resolution** — via an injected env lookup, logging an `error!` when unset/empty; removes the empty TES credential stub.
- Misc: `div_ceil` chunk sizing; `seal_batches`/`MAX_EVENT_BYTES` scoped to `pub(crate)` with batcher internals gated behind the `aws-sdk` feature; `config/schema.rs` test comment put back on its own line.

## How tested
- `cargo test` — 209 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo check --no-default-features --all-targets` — clean

## Notes
- `CwUploadError` is `pub` so the follow-up orchestration PR (which wires `main.rs`) can match on `Err(Auth)` to stop the cycle and refresh credentials; other uploader internals are `pub(crate)`. The orchestration PR stacks directly on this branch.
- First of the upload split; the orchestration PR follows. Base: `rust/v2`.
