### PR TITLE
feat(scanner): legacy checkpoint compatibility and content-hash dedup

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -102,6 +102,9 @@ pub struct LogsUploaderConfig {
 pub struct LogManagerConfig {
     pub logs_uploader_configuration: LogsUploaderConfig,
     pub periodic_upload_interval_sec: u64,
+    /// Write the deprecated flat checkpoint format alongside the current nested one, and read
+    /// it on load, for compatibility with older LogManager versions. Defaults to `true`.
+    pub deprecated_version_support: bool,
 }
 
 impl<'de> Deserialize<'de> for LogManagerConfig {
@@ -133,6 +136,21 @@ impl<'de> Deserialize<'de> for LogManagerConfig {
             },
         };
 
+        // Absent → default true (keep writing the deprecated format for downgrade safety).
+        // Accept a JSON bool or a string ("true"/"false"), like the other bool fields, since
+        // the Nucleus passes config values as strings; anything unparseable falls back to true.
+        let deprecated_version_support = match obj.get("deprecatedVersionSupport") {
+            None => true,
+            Some(v) => v
+                .as_bool()
+                .or_else(|| match v.as_str().map(str::trim) {
+                    Some(s) if s.eq_ignore_ascii_case("true") => Some(true),
+                    Some(s) if s.eq_ignore_ascii_case("false") => Some(false),
+                    _ => None,
+                })
+                .unwrap_or(true),
+        };
+
         // Accept the nested `logsUploaderConfiguration` wrapper (official schema) or a
         // flat top-level object (recipe interpolation flattens the subtree).
         let inner = value
@@ -146,6 +164,7 @@ impl<'de> Deserialize<'de> for LogManagerConfig {
         Ok(LogManagerConfig {
             logs_uploader_configuration: uploader_config,
             periodic_upload_interval_sec: periodic,
+            deprecated_version_support,
         })
     }
 }
@@ -316,6 +335,7 @@ mod tests {
         );
         let config = LogManagerConfig {
             periodic_upload_interval_sec: 600,
+            deprecated_version_support: true,
             logs_uploader_configuration: LogsUploaderConfig {
                 component_logs_configuration_map: map,
                 system_logs_configuration: None,
@@ -473,6 +493,40 @@ mod tests {
     #[test]
     fn test_default_log_level_is_info() {
         assert_eq!(LogLevel::default(), LogLevel::Info);
+    }
+
+    #[test]
+    fn test_deprecated_version_support_defaults_true() {
+        let config: LogManagerConfig = serde_json::from_str("{}").unwrap();
+        assert!(config.deprecated_version_support);
+    }
+
+    #[test]
+    fn test_deprecated_version_support_present_false() {
+        let config: LogManagerConfig =
+            serde_json::from_str(r#"{"deprecatedVersionSupport": false}"#).unwrap();
+        assert!(!config.deprecated_version_support);
+    }
+
+    #[test]
+    fn test_deprecated_version_support_string_false() {
+        let config: LogManagerConfig =
+            serde_json::from_str(r#"{"deprecatedVersionSupport": "false"}"#).unwrap();
+        assert!(!config.deprecated_version_support);
+    }
+
+    #[test]
+    fn test_deprecated_version_support_string_true() {
+        let config: LogManagerConfig =
+            serde_json::from_str(r#"{"deprecatedVersionSupport": "true"}"#).unwrap();
+        assert!(config.deprecated_version_support);
+    }
+
+    #[test]
+    fn test_deprecated_version_support_unparseable_defaults_true() {
+        let config: LogManagerConfig =
+            serde_json::from_str(r#"{"deprecatedVersionSupport": "maybe"}"#).unwrap();
+        assert!(config.deprecated_version_support);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,10 +85,11 @@ async fn main() {
     });
 
     let checkpoint_path = Path::new(&work_dir).join("checkpoint.json");
-    let mut store = load_checkpoint(&checkpoint_path).unwrap_or_else(|e| {
-        error!("Failed to load checkpoint: {e}, starting fresh");
-        CheckpointStore::default()
-    });
+    let mut store = load_checkpoint(&checkpoint_path, config.deprecated_version_support)
+        .unwrap_or_else(|e| {
+            error!("Failed to load checkpoint: {e}, starting fresh");
+            CheckpointStore::default()
+        });
     trim_stale_on_load(&mut store);
 
     let mut client = CwLogsClient::new().await;
@@ -140,7 +141,9 @@ async fn main() {
 
         // Persist the checkpoint at most once per upload interval.
         if last_persist.elapsed() >= persist_interval {
-            if let Err(e) = save_checkpoint(&checkpoint_path, &store) {
+            if let Err(e) =
+                save_checkpoint(&checkpoint_path, &store, config.deprecated_version_support)
+            {
                 error!("Failed to persist checkpoint: {e}");
             }
             last_persist = Instant::now();
@@ -157,7 +160,7 @@ async fn main() {
 
     // Persist the checkpoint unconditionally on the way out so progress is not lost.
     info!("Shutting down — persisting final checkpoint");
-    if let Err(e) = save_checkpoint(&checkpoint_path, &store) {
+    if let Err(e) = save_checkpoint(&checkpoint_path, &store, config.deprecated_version_support) {
         error!("Failed to persist checkpoint on shutdown: {e}");
     }
     info!("Shutdown complete");

--- a/src/scanner/checkpoint.rs
+++ b/src/scanner/checkpoint.rs
@@ -46,6 +46,27 @@ pub struct LastFileProcessedTimestamp {
     pub last_file_processed_time_stamp: u64,
 }
 
+/// Deprecated flat checkpoint leaf: one entry per component (not nested by hash), used by
+/// LogManager versions before 2.3.1. Read and written only when `deprecated_version_support`
+/// is enabled; ignored otherwise.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct DeprecatedFileCheckpoint {
+    #[serde(
+        rename = "currentProcessingFileName",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub file_name: Option<String>,
+    #[serde(rename = "currentProcessingFileHash")]
+    pub file_hash: String,
+    #[serde(rename = "currentProcessingFileStartPosition")]
+    pub start_position: u64,
+    #[serde(rename = "currentProcessingFileLastModified")]
+    pub last_modified_time: u64,
+    #[serde(rename = "lastAccessed", default)]
+    pub last_accessed: u64,
+}
+
 /// Checkpoint store for all components.
 ///
 /// # Write semantics (for batcher implementer)
@@ -53,22 +74,47 @@ pub struct LastFileProcessedTimestamp {
 /// - Upload path: use `put` — overwrite with new startPosition + trigger TTL eviction
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct CheckpointStore {
+    /// Current nested format (2.3.1+): `component -> hash -> FileCheckpoint`.
     #[serde(rename = "currentComponentFileProcessingInformationV2", default)]
     pub file_processing_info: HashMap<String, HashMap<String, FileCheckpoint>>,
+    /// Deprecated flat format (≤2.3.0): `component -> single FileCheckpoint`. Merged into the
+    /// current map on load and regenerated on save when `deprecated_version_support` is on;
+    /// omitted from the serialized file when empty.
+    #[serde(
+        rename = "currentComponentFileProcessingInformation",
+        default,
+        skip_serializing_if = "HashMap::is_empty"
+    )]
+    pub(crate) deprecated_file_processing_info: HashMap<String, DeprecatedFileCheckpoint>,
     #[serde(rename = "componentLastFileProcessedTimeStamp", default)]
     pub last_processed_timestamps: HashMap<String, LastFileProcessedTimestamp>,
 }
 
 /// Save checkpoint atomically: write to temp file, then rename.
 ///
+/// When `deprecated_version_support` is true, the deprecated flat format is regenerated from
+/// the current map (one entry per component, the most-recently-accessed) and written alongside
+/// it for backward compatibility; when false, the deprecated format is omitted.
+///
 /// # Errors
 /// Returns `io::Error` if the file cannot be created, written, synced, or renamed.
-pub fn save_checkpoint(path: &Path, store: &CheckpointStore) -> io::Result<()> {
+pub fn save_checkpoint(
+    path: &Path,
+    store: &CheckpointStore,
+    deprecated_version_support: bool,
+) -> io::Result<()> {
+    let mut store_to_write = store.clone();
+    if deprecated_version_support {
+        populate_deprecated_from_current(&mut store_to_write);
+    } else {
+        store_to_write.deprecated_file_processing_info.clear();
+    }
+
     let tmp_path = path.with_extension("tmp");
     let result = (|| -> io::Result<()> {
         let file = fs::File::create(&tmp_path)
             .map_err(|e| io::Error::new(e.kind(), format!("create {}: {e}", tmp_path.display())))?;
-        serde_json::to_writer_pretty(&file, store)
+        serde_json::to_writer_pretty(&file, &store_to_write)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         file.sync_all()
             .map_err(|e| io::Error::new(e.kind(), format!("sync {}: {e}", tmp_path.display())))?;
@@ -88,14 +134,46 @@ pub fn save_checkpoint(path: &Path, store: &CheckpointStore) -> io::Result<()> {
     Ok(())
 }
 
+/// Regenerate the deprecated flat map from the current map: for each component, pick the
+/// entry with the highest `last_accessed` as the single deprecated entry.
+fn populate_deprecated_from_current(store: &mut CheckpointStore) {
+    store.deprecated_file_processing_info.clear();
+    for (component, files) in &store.file_processing_info {
+        if let Some(most_recent) = files.values().max_by_key(|cp| cp.last_accessed) {
+            store.deprecated_file_processing_info.insert(
+                component.clone(),
+                DeprecatedFileCheckpoint {
+                    file_name: None,
+                    file_hash: most_recent.file_hash.clone(),
+                    start_position: most_recent.start_position,
+                    last_modified_time: most_recent.last_modified_time,
+                    last_accessed: most_recent.last_accessed,
+                },
+            );
+        }
+    }
+}
+
 /// Load checkpoint from disk. Returns empty store if file missing or corrupt.
+///
+/// When `deprecated_version_support` is true, entries from the deprecated flat format are
+/// merged into the current map with put-if-absent semantics (a current entry for the same
+/// hash wins); when false, the deprecated format is discarded.
 ///
 /// # Errors
 /// Returns `io::Error` on read failures other than `NotFound`.
-pub fn load_checkpoint(path: &Path) -> io::Result<CheckpointStore> {
+pub fn load_checkpoint(
+    path: &Path,
+    deprecated_version_support: bool,
+) -> io::Result<CheckpointStore> {
     match fs::read_to_string(path) {
         Ok(content) => match serde_json::from_str::<CheckpointStore>(&content) {
-            Ok(store) => {
+            Ok(mut store) => {
+                if deprecated_version_support {
+                    merge_deprecated_entries(&mut store);
+                } else {
+                    store.deprecated_file_processing_info.clear();
+                }
                 let entry_count: usize = store.file_processing_info.values().map(|m| m.len()).sum();
                 tracing::debug!(path = %path.display(), entry_count = entry_count, "Checkpoint loaded");
                 Ok(store)
@@ -111,6 +189,27 @@ pub fn load_checkpoint(path: &Path) -> io::Result<CheckpointStore> {
             format!("read {}: {e}", path.display()),
         )),
     }
+}
+
+/// Merge deprecated flat entries into the current map with put-if-absent semantics (a current
+/// entry for the same component + hash is preserved), then clear the deprecated map so no stale
+/// state lingers in memory; `save_checkpoint` regenerates it from the current map on every write.
+fn merge_deprecated_entries(store: &mut CheckpointStore) {
+    for (component, deprecated_entry) in &store.deprecated_file_processing_info {
+        let component_map = store
+            .file_processing_info
+            .entry(component.clone())
+            .or_default();
+        component_map
+            .entry(deprecated_entry.file_hash.clone())
+            .or_insert_with(|| FileCheckpoint {
+                file_hash: deprecated_entry.file_hash.clone(),
+                start_position: deprecated_entry.start_position,
+                last_modified_time: deprecated_entry.last_modified_time,
+                last_accessed: deprecated_entry.last_accessed,
+            });
+    }
+    store.deprecated_file_processing_info.clear();
 }
 
 fn now_ms() -> u64 {
@@ -245,8 +344,8 @@ mod tests {
             },
         );
 
-        save_checkpoint(&path, &store).unwrap();
-        let loaded = load_checkpoint(&path).unwrap();
+        save_checkpoint(&path, &store, true).unwrap();
+        let loaded = load_checkpoint(&path, true).unwrap();
         assert_eq!(store, loaded);
     }
 
@@ -271,7 +370,7 @@ mod tests {
             .file_processing_info
             .insert("test-group".to_string(), files);
 
-        save_checkpoint(&path, &store).unwrap();
+        save_checkpoint(&path, &store, true).unwrap();
         let content = fs::read_to_string(&path).unwrap();
 
         // Verify Java-compatible field names
@@ -280,6 +379,12 @@ mod tests {
         assert!(content.contains("currentProcessingFileStartPosition"));
         assert!(content.contains("currentProcessingFileLastModified"));
         assert!(content.contains("lastAccessed"));
+        // Dual-write also emits the deprecated flat top-level key (exact-key check, since the
+        // V2 key name contains this string as a prefix).
+        let saved: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(saved
+            .get("currentComponentFileProcessingInformation")
+            .is_some());
     }
 
     #[test]
@@ -306,7 +411,7 @@ mod tests {
         }"#;
         fs::write(&path, java_checkpoint).unwrap();
 
-        let store = load_checkpoint(&path).unwrap();
+        let store = load_checkpoint(&path, true).unwrap();
         let files = store.file_processing_info.get("system-health").unwrap();
         let entry = files.get("abc123hash").unwrap();
         assert_eq!(entry.file_hash, "abc123hash");
@@ -322,7 +427,7 @@ mod tests {
         let tmp_path = path.with_extension("tmp");
 
         let store = CheckpointStore::default();
-        save_checkpoint(&path, &store).unwrap();
+        save_checkpoint(&path, &store, true).unwrap();
 
         assert!(!tmp_path.exists());
         assert!(path.exists());
@@ -332,7 +437,7 @@ mod tests {
     fn test_missing_file_returns_empty() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("nonexistent.json");
-        let store = load_checkpoint(&path).unwrap();
+        let store = load_checkpoint(&path, true).unwrap();
         assert!(store.file_processing_info.is_empty());
         assert!(store.last_processed_timestamps.is_empty());
     }
@@ -342,7 +447,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("corrupt.json");
         fs::write(&path, "{ invalid json }").unwrap();
-        let result = load_checkpoint(&path).unwrap();
+        let result = load_checkpoint(&path, true).unwrap();
         assert!(result.file_processing_info.is_empty());
         assert!(result.last_processed_timestamps.is_empty());
     }
@@ -598,8 +703,160 @@ mod tests {
         let path = Path::new("/nonexistent/dir/checkpoint.json");
         let tmp_path = path.with_extension("tmp");
         let store = CheckpointStore::default();
-        let result = save_checkpoint(path, &store);
+        let result = save_checkpoint(path, &store, true);
         assert!(result.is_err());
         assert!(!tmp_path.exists());
+    }
+
+    #[test]
+    fn test_load_deprecated_checkpoint() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+        // Deprecated flat format: component -> single entry with the hash as a leaf field.
+        let v1_json = r#"{
+            "currentComponentFileProcessingInformation": {
+                "my-component": {
+                    "currentProcessingFileName": "/var/log/app.log",
+                    "currentProcessingFileHash": "v1hash123",
+                    "currentProcessingFileStartPosition": 4096,
+                    "currentProcessingFileLastModified": 1700000000000,
+                    "lastAccessed": 1700000001000
+                }
+            }
+        }"#;
+        fs::write(&path, v1_json).unwrap();
+
+        let store = load_checkpoint(&path, true).unwrap();
+        // Deprecated entry is merged into the current map.
+        let files = store.file_processing_info.get("my-component").unwrap();
+        let entry = files.get("v1hash123").unwrap();
+        assert_eq!(entry.file_hash, "v1hash123");
+        assert_eq!(entry.start_position, 4096);
+        assert_eq!(entry.last_modified_time, 1700000000000);
+        assert_eq!(entry.last_accessed, 1700000001000);
+    }
+
+    #[test]
+    fn test_load_deprecated_does_not_overwrite_current() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+        // Both formats present for the same component + hash — the current entry wins.
+        let json = r#"{
+            "currentComponentFileProcessingInformationV2": {
+                "my-component": {
+                    "v1hash123": {
+                        "currentProcessingFileHash": "v1hash123",
+                        "currentProcessingFileStartPosition": 8192,
+                        "currentProcessingFileLastModified": 1700000002000,
+                        "lastAccessed": 1700000003000
+                    }
+                }
+            },
+            "currentComponentFileProcessingInformation": {
+                "my-component": {
+                    "currentProcessingFileHash": "v1hash123",
+                    "currentProcessingFileStartPosition": 4096,
+                    "currentProcessingFileLastModified": 1700000000000,
+                    "lastAccessed": 1700000001000
+                }
+            }
+        }"#;
+        fs::write(&path, json).unwrap();
+
+        let store = load_checkpoint(&path, true).unwrap();
+        let files = store.file_processing_info.get("my-component").unwrap();
+        let entry = files.get("v1hash123").unwrap();
+        // put-if-absent: the current value is preserved.
+        assert_eq!(entry.start_position, 8192);
+    }
+
+    #[test]
+    fn test_save_writes_both_deprecated_and_current() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+
+        let mut store = CheckpointStore::default();
+        let mut files = HashMap::new();
+        files.insert(
+            "hashA".to_string(),
+            FileCheckpoint {
+                file_hash: "hashA".to_string(),
+                start_position: 100,
+                last_modified_time: 1000,
+                last_accessed: 5000, // most recently accessed
+            },
+        );
+        files.insert(
+            "hashB".to_string(),
+            FileCheckpoint {
+                file_hash: "hashB".to_string(),
+                start_position: 200,
+                last_modified_time: 2000,
+                last_accessed: 3000,
+            },
+        );
+        store.file_processing_info.insert("comp".to_string(), files);
+
+        save_checkpoint(&path, &store, true).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+
+        let saved: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(saved
+            .get("currentComponentFileProcessingInformationV2")
+            .is_some());
+        // Deprecated format holds the single most-recently-accessed entry (hashA).
+        let deprecated = &saved["currentComponentFileProcessingInformation"]["comp"];
+        assert_eq!(deprecated["currentProcessingFileHash"], "hashA");
+        assert_eq!(deprecated["currentProcessingFileStartPosition"], 100);
+    }
+
+    #[test]
+    fn test_load_deprecated_skipped_when_deprecated_support_false() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+        let v1_json = r#"{
+            "currentComponentFileProcessingInformation": {
+                "my-component": {
+                    "currentProcessingFileName": "/var/log/app.log",
+                    "currentProcessingFileHash": "v1hash123",
+                    "currentProcessingFileStartPosition": 4096,
+                    "currentProcessingFileLastModified": 1700000000000,
+                    "lastAccessed": 1700000001000
+                }
+            }
+        }"#;
+        fs::write(&path, v1_json).unwrap();
+
+        let store = load_checkpoint(&path, false).unwrap();
+        // Deprecated data is neither merged nor retained.
+        assert!(store.file_processing_info.is_empty());
+        assert!(store.deprecated_file_processing_info.is_empty());
+    }
+
+    #[test]
+    fn test_save_skips_deprecated_when_deprecated_support_false() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("checkpoint.json");
+
+        let mut store = CheckpointStore::default();
+        let mut files = HashMap::new();
+        files.insert(
+            "hashA".to_string(),
+            FileCheckpoint {
+                file_hash: "hashA".to_string(),
+                start_position: 100,
+                last_modified_time: 1000,
+                last_accessed: 5000,
+            },
+        );
+        store.file_processing_info.insert("comp".to_string(), files);
+
+        save_checkpoint(&path, &store, false).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+
+        // Current format present, deprecated format absent (the trailing quote distinguishes
+        // it from the V2 key, which shares this prefix).
+        assert!(content.contains("currentComponentFileProcessingInformationV2"));
+        assert!(!content.contains("currentComponentFileProcessingInformation\""));
     }
 }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -15,6 +15,7 @@ pub use multiline::assemble_multiline;
 pub use reader::{compute_content_hash, read_file_from_offset, LogEvent};
 
 use regex::Regex;
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::time::SystemTime;
@@ -78,6 +79,37 @@ pub fn scan_directory(directory: &str, pattern: &Regex) -> std::io::Result<Vec<S
             }
         })
         .collect();
+
+    // Collapse files that share a content hash (e.g. an identical first line — see the reader's
+    // hashing), keeping the newest. The vec is mtime-ascending, so the last occurrence of each
+    // hash is the newest. This is order-preserving (a plain HashMap collect would lose the
+    // mtime order that the active-file selection below relies on): we keep each hash's last
+    // index and drop earlier duplicates, so exactly one file per hash survives and the overall
+    // last element stays the global newest.
+    let newest_index: HashMap<String, usize> = result
+        .iter()
+        .enumerate()
+        .map(|(i, f)| (f.content_hash.clone(), i))
+        .collect();
+    if newest_index.len() != result.len() {
+        let survivor_paths: HashMap<String, PathBuf> = newest_index
+            .iter()
+            .map(|(hash, &i)| (hash.clone(), result[i].path.clone()))
+            .collect();
+        let mut deduped = Vec::with_capacity(newest_index.len());
+        for (i, file) in result.into_iter().enumerate() {
+            if newest_index.get(&file.content_hash) == Some(&i) {
+                deduped.push(file);
+            } else if let Some(kept) = survivor_paths.get(&file.content_hash) {
+                tracing::warn!(
+                    dropped = %file.path.display(),
+                    kept = %kept.display(),
+                    "file shares content hash with a newer file; skipping"
+                );
+            }
+        }
+        result = deduped;
+    }
 
     // The last file by mtime (already sorted) is the active file
     if let Some(last) = result.last_mut() {
@@ -178,5 +210,30 @@ mod tests {
         let pattern = Regex::new(r".*\.log$").unwrap();
         let result = scan_directory("/nonexistent/path/12345", &pattern).unwrap();
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_scan_directory_dedups_shared_content_hash_keeps_newest() {
+        let dir = tempfile::tempdir().unwrap();
+        // Same first line → same content hash; distinct trailing content and mtimes.
+        create_test_file(
+            dir.path(),
+            "old.log",
+            b"shared header line\nold unique tail",
+        );
+        sleep(Duration::from_millis(50));
+        create_test_file(
+            dir.path(),
+            "new.log",
+            b"shared header line\nnew unique tail",
+        );
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+
+        // Only the newest of the two colliding files survives, and it is the active file.
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path.file_name().unwrap(), "new.log");
+        assert!(result[0].is_active);
     }
 }

--- a/src/uploader/mod.rs
+++ b/src/uploader/mod.rs
@@ -154,9 +154,6 @@ fn is_file_fully_uploaded(is_active: bool, file_len: u64, bytes_read: u64) -> bo
 /// `lastFileProcessedTimeStamp` monotonically. Shared by the upload-path checkpoint
 /// advancement and the rotation edge case so the two completion sites cannot drift. The
 /// caller owns the completion trigger and any file deletion.
-// TODO: the checkpoint is keyed by `content_hash`, so two files that share a `content_hash`
-// still collide on the checkpoint key (one file's entry overwrites/removes the other's).
-// Unique per-file checkpoint identity is deferred.
 pub fn complete_file(
     file_map: &mut HashMap<String, FileCheckpoint>,
     ts_map: &mut HashMap<String, LastFileProcessedTimestamp>,

--- a/tests/checkpoint_backward_compat_test.rs
+++ b/tests/checkpoint_backward_compat_test.rs
@@ -1,0 +1,113 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backward-compatibility tests: reading a deprecated flat-format checkpoint written by an
+//! older LogManager and migrating it into the current nested format through the same
+//! load → trim sequence the binary runs at startup.
+
+use gg_log_manager::scanner::{load_checkpoint, trim_stale_on_load};
+use std::io::Write;
+use tempfile::tempdir;
+
+/// A deprecated flat-format checkpoint is read, merged into the current map, and the migrated
+/// entry survives the stale-trim step, so the resume offset is recovered. Reading the old
+/// format must never panic. The entry's last-modified time is AFTER the component's
+/// last-processed timestamp, so `trim_stale_on_load` keeps it (a non-vacuous trim: the trim
+/// runs and the entry is retained because of that relationship).
+#[test]
+fn test_migrate_deprecated_checkpoint_survives_load_and_trim() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("config.tlog");
+
+    let deprecated_tlog = r#"{
+        "currentComponentFileProcessingInformation": {
+            "my-component": {
+                "currentProcessingFileName": "/var/log/my-component/app.log",
+                "currentProcessingFileHash": "deadbeefhash",
+                "currentProcessingFileStartPosition": 4096,
+                "currentProcessingFileLastModified": 1700000000000,
+                "lastAccessed": 1700000005000
+            }
+        },
+        "componentLastFileProcessedTimeStamp": {
+            "my-component": {
+                "lastFileProcessedTimeStamp": 1600000000000
+            }
+        }
+    }"#;
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(deprecated_tlog.as_bytes()).unwrap();
+
+    // Same sequence main() runs at startup: load (with deprecated support) then trim.
+    let mut store = load_checkpoint(&path, true).unwrap();
+    trim_stale_on_load(&mut store);
+
+    // The deprecated entry migrated into the current nested map and survived the trim.
+    let files = store
+        .file_processing_info
+        .get("my-component")
+        .expect("component present after migration");
+    let entry = files
+        .get("deadbeefhash")
+        .expect("deprecated entry migrated and not trimmed");
+    assert_eq!(entry.start_position, 4096);
+    assert_eq!(entry.last_modified_time, 1700000000000);
+}
+
+/// A stale deprecated entry (last-modified at or before the component's last-processed
+/// timestamp) is trimmed away after migration — confirming the load → trim path is live and
+/// the survival above is not vacuous.
+#[test]
+fn test_migrate_deprecated_checkpoint_trimmed_when_stale() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("config.tlog");
+
+    let deprecated_tlog = r#"{
+        "currentComponentFileProcessingInformation": {
+            "my-component": {
+                "currentProcessingFileHash": "stalehash",
+                "currentProcessingFileStartPosition": 4096,
+                "currentProcessingFileLastModified": 1600000000000,
+                "lastAccessed": 1700000005000
+            }
+        },
+        "componentLastFileProcessedTimeStamp": {
+            "my-component": {
+                "lastFileProcessedTimeStamp": 1700000000000
+            }
+        }
+    }"#;
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(deprecated_tlog.as_bytes()).unwrap();
+
+    let mut store = load_checkpoint(&path, true).unwrap();
+    trim_stale_on_load(&mut store);
+
+    // Migrated but stale (mtime <= last-processed) → trimmed.
+    let files = store.file_processing_info.get("my-component").unwrap();
+    assert!(!files.contains_key("stalehash"));
+}
+
+/// With deprecated support disabled, a flat-format checkpoint is ignored (not migrated) and
+/// still does not panic.
+#[test]
+fn test_deprecated_checkpoint_ignored_when_support_disabled() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("config.tlog");
+
+    let deprecated_tlog = r#"{
+        "currentComponentFileProcessingInformation": {
+            "my-component": {
+                "currentProcessingFileHash": "deadbeefhash",
+                "currentProcessingFileStartPosition": 4096,
+                "currentProcessingFileLastModified": 1700000000000,
+                "lastAccessed": 1700000005000
+            }
+        }
+    }"#;
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(deprecated_tlog.as_bytes()).unwrap();
+
+    let store = load_checkpoint(&path, false).unwrap();
+    assert!(store.file_processing_info.is_empty());
+}

--- a/tests/checkpoint_integration_test.rs
+++ b/tests/checkpoint_integration_test.rs
@@ -43,10 +43,10 @@ fn test_scan_checkpoint_restart_resume() {
         .insert("test-group".to_string(), file_map);
 
     // Save checkpoint (simulating shutdown)
-    save_checkpoint(&checkpoint_path, &store).unwrap();
+    save_checkpoint(&checkpoint_path, &store, true).unwrap();
 
     // Load checkpoint (simulating restart)
-    let mut loaded = load_checkpoint(&checkpoint_path).unwrap();
+    let mut loaded = load_checkpoint(&checkpoint_path, true).unwrap();
 
     // Re-scan and recover offsets
     let files_after_restart = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
@@ -87,13 +87,13 @@ fn test_checkpoint_stale_entry_removed_after_file_deleted() {
     store
         .file_processing_info
         .insert("test-group".to_string(), file_map);
-    save_checkpoint(&checkpoint_path, &store).unwrap();
+    save_checkpoint(&checkpoint_path, &store, true).unwrap();
 
     // Delete one file
     std::fs::remove_file(dir.path().join("delete_me.log")).unwrap();
 
     // Re-scan (now only 1 file) and recover
-    let mut loaded = load_checkpoint(&checkpoint_path).unwrap();
+    let mut loaded = load_checkpoint(&checkpoint_path, true).unwrap();
     let files_after = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
     assert_eq!(files_after.len(), 1);
 


### PR DESCRIPTION
## Summary
Adds backward-compatible checkpoint reading and removes a content-hash collision hazard. Reads both the legacy flat checkpoint format and the current hash-keyed format (no-panic migration, correct resume), and deduplicates scanned files by content hash so two files sharing a first line can't collide on one checkpoint key.

## What changed
- **Legacy checkpoint compatibility** (`src/scanner/checkpoint.rs`): dual-read (current format wins on conflict) + dual-write of the single most-recently-accessed legacy entry per component, gated by a new `deprecatedVersionSupport` config flag (default `true`). A legacy-format file migrates in-memory with no panic; resume offsets are preserved.
- **`deprecatedVersionSupport` config** (`src/config/schema.rs`): parsed in the config deserializer, accepts a bool or string, defaults to `true`.
- **Content-hash dedup** (`src/scanner/mod.rs`): `scan_directory` keeps the newest file per content hash (order-preserving); files sharing a first-line hash no longer collide on one checkpoint key. Exactly one active (newest) file remains; drops are logged.
- Removes the now-resolved checkpoint-key collision TODO in `src/uploader/mod.rs`.

## How tested
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — all green (236 tests).
- New tempfile tests: legacy-format migration through the real load+trim path (paired with a stale-trim test to prove non-vacuity), disabled-flag ignores legacy, and same-first-line dedup keeps only the newest active file.

## Notes for reviewers
- Dual-format (not migrate-and-delete): both formats are maintained for upgrade/downgrade safety; `deprecatedVersionSupport=false` disables the legacy dual-write.
- Dedup keeps the newest file per content hash (consistent with the "single active file per configuration key" guidance); an older file sharing a first-line hash is skipped that cycle and its checkpoint (shared hash) is resumed by the survivor.
- Downgrade note: the regenerated legacy entry omits the filename (not retained in the current format); resume relies on the content hash.

## Stack
Stacked on the orchestrator PR (#253); base `dev/upload-orchestration`. Retargets to `rust/v2` after #253 merges.


## AWS docs alignment
- `deprecatedVersionSupport` follows the [documented default](https://docs.aws.amazon.com/greengrass/v2/developerguide/log-manager-component.html#log-manager-component-configuration) (`true`): the deprecated checkpoint format is maintained by default; setting it `false` skips that dual-write.
- Deduplicating to the newest file per content hash is consistent with the [documented guidance](https://docs.aws.amazon.com/greengrass/v2/developerguide/log-manager-component.html) to target a single actively-written log file per configuration key.
