### PR TITLE
feat(config): IPC config source with live reload (Greengrass nucleus + nucleus lite)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-greengrass-component-sdk"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34fc6201e58c3f0b31726ad9ca9478f7333bb557e5dbd93e7df9f68a9b53df2"
+dependencies = [
+ "bindgen",
+ "cc",
+]
+
+[[package]]
 name = "aws-runtime"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +492,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +596,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +644,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -896,6 +946,7 @@ name = "gg-log-manager"
 version = "0.1.0"
 dependencies = [
  "aws-config",
+ "aws-greengrass-component-sdk",
  "aws-sdk-cloudwatchlogs",
  "aws-smithy-http-client",
  "aws-smithy-types",
@@ -914,6 +965,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1237,6 +1294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1337,16 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libredox"
@@ -1597,6 +1673,12 @@ checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
 dependencies = [
  "xmlparser",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,13 @@ time = "0.3"
 thiserror = "1"
 aws-sdk-cloudwatchlogs = "=1.20.0"
 aws-config = "=1.1.10"
+gg_sdk = { version = "=1.0.4", optional = true, package = "aws-greengrass-component-sdk" }
+
+[features]
+# Opt-in only: the gg_sdk build depends on libclang/cc, so it is kept out of the
+# default build to keep `cargo build/test/clippy` portable. Enable with
+# `--features gg-ipc` to compile the IPC config source.
+gg-ipc = ["dep:gg_sdk"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/ipc_config.rs
+++ b/src/ipc_config.rs
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! IPC configuration loading via the `aws-greengrass-component-sdk` crate
+//! (imported as `gg_sdk`).
+//!
+//! Loads the component's own merged configuration from the Greengrass runtime
+//! over IPC (`GetConfiguration`), converting the SDK's `Object` into a
+//! `serde_json::Value` for the existing JSON-based config loader. Works on both
+//! Greengrass Classic and Greengrass Lite, which speak the same component IPC
+//! protocol.
+
+/// Connect to the Greengrass runtime over IPC, returning a reusable handle.
+///
+/// Returns `None` when IPC is unavailable (e.g. not running under a Greengrass
+/// runtime), so the caller can fall through to the next config source.
+///
+/// This MUST be called at most once per process: `gg_sdk::Sdk::init()` panics if
+/// called more than once. The returned handle is a cheap `Copy` value and should
+/// be reused for both the startup config read and the configuration-update
+/// subscription rather than reconnecting.
+#[cfg(feature = "gg-ipc")]
+pub fn connect_ipc() -> Option<gg_sdk::Sdk> {
+    use gg_sdk::Sdk;
+
+    // Fast-fail: skip IPC unless the runtime has provided the component IPC socket.
+    if std::env::var("AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT").is_err() {
+        return None;
+    }
+
+    tracing::info!("Connecting to Greengrass IPC");
+    let sdk = Sdk::init();
+    if let Err(e) = sdk.connect() {
+        tracing::warn!(error = %e, "GG IPC connect failed, using defaults");
+        return None;
+    }
+    Some(sdk)
+}
+
+/// Read the component's own merged configuration over an already-connected IPC
+/// handle (`GetConfiguration`), converting it to JSON for the config loader.
+///
+/// Returns `None` when the configuration is empty or the read fails, so the
+/// caller falls back to the previous/next config source. Callable repeatedly on
+/// the same handle (e.g. once at startup and again on each configuration-update
+/// notification) — but only from a thread that owns the handle, never from a
+/// subscription callback (the SDK rejects IPC calls made on the callback thread).
+#[cfg(feature = "gg-ipc")]
+pub fn read_config(sdk: gg_sdk::Sdk) -> Option<String> {
+    use core::mem::MaybeUninit;
+
+    let mut buf = [MaybeUninit::uninit(); 16384];
+    match sdk.get_config(&[], None, &mut buf) {
+        Ok(obj) => {
+            let json_value = object_to_json(&obj);
+            if json_value.is_null() || json_value.as_object().is_some_and(|m| m.is_empty()) {
+                tracing::warn!("IPC GetConfiguration returned empty config, using defaults");
+                return None;
+            }
+            match serde_json::to_string(&json_value) {
+                Ok(json) => {
+                    tracing::info!("Configuration loaded from Greengrass IPC");
+                    Some(json)
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to serialize IPC config to JSON");
+                    None
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "GetConfiguration IPC failed, using defaults");
+            None
+        }
+    }
+}
+
+#[cfg(feature = "gg-ipc")]
+fn object_to_json(obj: &gg_sdk::Object) -> serde_json::Value {
+    use gg_sdk::UnpackedObject;
+    match obj.unpack() {
+        UnpackedObject::Null => serde_json::Value::Null,
+        UnpackedObject::Bool(b) => serde_json::Value::Bool(b),
+        UnpackedObject::I64(i) => serde_json::json!(i),
+        UnpackedObject::F64(f) => serde_json::json!(f),
+        UnpackedObject::Buf(s) => serde_json::Value::String(s.to_string()),
+        UnpackedObject::List(list) => {
+            serde_json::Value::Array(list.iter().map(object_to_json).collect())
+        }
+        UnpackedObject::Map(map) => {
+            let obj = map
+                .iter()
+                .map(|kv| (kv.key().to_string(), object_to_json(kv.val())))
+                .collect();
+            serde_json::Value::Object(obj)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,6 @@
 pub mod config;
 pub mod credentials;
 pub mod disk;
+pub mod ipc_config;
 pub mod scanner;
 pub mod uploader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ use gg_log_manager::config::{
     LogSourceConfig,
 };
 use gg_log_manager::credentials::resolve_thing_name;
+#[cfg(feature = "gg-ipc")]
+use gg_log_manager::ipc_config::{connect_ipc, read_config};
 use gg_log_manager::scanner::{
     assemble_multiline, load_checkpoint, read_file_from_offset, recover_offsets, save_checkpoint,
     scan_directory, trim_stale_on_load, CheckpointStore, LogEvent, ScannedFile,
@@ -23,7 +25,7 @@ use gg_log_manager::uploader::{
 use regex::Regex;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Instant;
 use tokio::sync::Notify;
 use tokio::time::Duration;
@@ -48,7 +50,21 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     let args: Vec<String> = std::env::args().collect();
-    let raw_config = resolve_raw_config(&args);
+
+    // Establish the single IPC connection (gg-ipc build) up front and read the startup config
+    // from it. The same handle is reused for the configuration-update subscription below, so
+    // `Sdk::init()` runs at most once per process.
+    #[cfg(feature = "gg-ipc")]
+    let ipc_sdk = connect_ipc();
+    #[cfg(feature = "gg-ipc")]
+    let ipc_value = match ipc_sdk {
+        Some(sdk) => read_config(sdk),
+        None => None,
+    };
+    #[cfg(not(feature = "gg-ipc"))]
+    let ipc_value: Option<String> = None;
+
+    let raw_config = resolve_raw_config(&args, ipc_value);
     let work_dir = parse_arg(&args, "--work-dir").unwrap_or_else(|| ".".to_string());
 
     let config = match load_config(&raw_config) {
@@ -115,8 +131,43 @@ async fn main() {
 
     // TODO: a LogManager struct owning client/store/thing_name/checkpoint_path would let the
     // process_* helpers carry less state; kept as free functions for now.
+
+    // Live config cell: the loop reads a fresh snapshot at the top of each cycle, and the
+    // configuration-update subscription (gg-ipc) swaps in a new value between cycles, so config
+    // changes are consumed without restarting the component.
+    let shared_config: Arc<RwLock<Arc<LogManagerConfig>>> = Arc::new(RwLock::new(Arc::new(config)));
+
+    // Woken when the runtime notifies a configuration update. The subscription callback runs on
+    // the SDK's IPC receive thread, which must NOT make IPC calls, so it only signals here; the
+    // loop thread (which owns the SDK handle) does the actual re-read. Never fired on the default
+    // build (no subscription), where the cell keeps the startup config for the process lifetime.
+    let config_changed = Arc::new(Notify::new());
+
+    // Subscribe to the component's own configuration updates and hold the subscription for the
+    // process lifetime (its Drop unsubscribes). The callback is leaked to give it a 'static
+    // lifetime; it only wakes the loop.
+    #[cfg(feature = "gg-ipc")]
+    let _config_sub = ipc_sdk.and_then(|sdk| {
+        let notify_cb = config_changed.clone();
+        let cb: &'static _ = Box::leak(Box::new(move |_component: &str, _key: &[&str]| {
+            // A panic unwinding across the extern "C" trampoline would abort the process, so the
+            // callback body is guarded even though notifying cannot realistically panic.
+            let _ =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| notify_cb.notify_one()));
+        }));
+        match sdk.subscribe_to_configuration_update(None, &[], cb) {
+            Ok(sub) => {
+                info!("Subscribed to configuration updates");
+                Some(sub)
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to subscribe to configuration updates; config changes will not apply until restart");
+                None
+            }
+        }
+    });
+
     let mut last_persist = Instant::now();
-    let persist_interval = Duration::from_secs(config.periodic_upload_interval_sec);
 
     // Fixed-delay loop: process every source, then sleep the upload interval (so a slow cycle
     // never overlaps the next). The wait is a tokio::select! over the sleep and the shutdown
@@ -125,6 +176,16 @@ async fn main() {
         if SHUTDOWN_REQUESTED.load(Ordering::SeqCst) {
             break;
         }
+
+        // Snapshot the current config for this cycle (cheap Arc clone; lock released immediately).
+        // A live update swaps the cell between cycles, so the next pass picks it up.
+        let config = shared_config
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        // Recomputed each cycle (the only config-derived value cached across cycles) so a live
+        // change to periodicUploadIntervalSec takes effect on reload.
+        let persist_interval = Duration::from_secs(config.periodic_upload_interval_sec);
 
         // One timestamp shared across this cycle's checkpoint advancement and stale eviction.
         let now = std::time::SystemTime::now()
@@ -155,30 +216,51 @@ async fn main() {
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(sleep_secs)) => {}
             _ = shutdown_notify.notified() => { break; }
+            _ = config_changed.notified() => {
+                // Config-update notification: re-read on THIS (loop) thread — the callback thread
+                // may not make IPC calls — then swap the new config in for the next cycle.
+                #[cfg(feature = "gg-ipc")]
+                let updated = ipc_sdk.and_then(read_config);
+                #[cfg(not(feature = "gg-ipc"))]
+                let updated: Option<String> = None;
+                if let Some(json) = updated {
+                    apply_config_update(&shared_config, &json);
+                }
+            }
         }
     }
 
     // Persist the checkpoint unconditionally on the way out so progress is not lost.
     info!("Shutting down — persisting final checkpoint");
-    if let Err(e) = save_checkpoint(&checkpoint_path, &store, config.deprecated_version_support) {
+    // Read the current (possibly hot-reloaded) config from the cell, not the startup value, so
+    // the final flush honors the latest deprecatedVersionSupport. Poison-tolerant, matching the loop.
+    let deprecated_support = shared_config
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .deprecated_version_support;
+    if let Err(e) = save_checkpoint(&checkpoint_path, &store, deprecated_support) {
         error!("Failed to persist checkpoint on shutdown: {e}");
     }
     info!("Shutdown complete");
 }
 
 /// Resolve the raw config from ordered sources (first non-empty wins):
-/// (1) CLI `--config <inline-json-or-path>`, (2) env `GG_LOG_MANAGER_CONFIG`, (3) `{}` default.
-// TODO: prepend a higher-priority runtime config source ahead of CLI/env once that
-// integration lands; parsing stays agnostic to where the raw config originates.
-fn resolve_raw_config(args: &[String]) -> String {
-    for source in [config_from_cli(args), config_from_env()] {
+/// (1) CLI `--config <inline-json-or-path>`, (2) env `GG_LOG_MANAGER_CONFIG`,
+/// (3) IPC (the component's own configuration read from the Greengrass runtime at startup),
+/// (4) `{}` default. Parsing stays agnostic to where the raw config originates.
+fn resolve_raw_config(args: &[String], ipc_value: Option<String>) -> String {
+    for source in [
+        config_from_cli(args),
+        config_from_env(),
+        config_from_ipc(ipc_value),
+    ] {
         match source {
             Ok(Some(raw)) => return raw,
             Ok(None) => {}
             Err(e) => error!("Config source error: {e}; trying next source"),
         }
     }
-    // (3) DEFAULT: empty object — start with no sources configured.
+    // (4) DEFAULT: empty object — start with no sources configured.
     "{}".to_string()
 }
 
@@ -193,6 +275,46 @@ fn config_from_env() -> Result<Option<String>, ConfigError> {
     Ok(std::env::var("GG_LOG_MANAGER_CONFIG")
         .ok()
         .filter(|s| !s.is_empty()))
+}
+
+/// (3) IPC source: the startup configuration read from the Greengrass runtime, if any. The
+/// value is read once in `main` (single `Sdk::init()`); `None` off-device or when the `gg-ipc`
+/// feature is disabled, so on-device deployments that carry no `--config`/env config still
+/// resolve one.
+fn config_from_ipc(ipc_value: Option<String>) -> Result<Option<String>, ConfigError> {
+    Ok(ipc_value.filter(|s| !s.is_empty()))
+}
+
+/// Parse and validate a config JSON delivered by a live configuration update and, on success,
+/// swap it into the shared cell so the loop picks it up next cycle. Returns `true` when the cell
+/// was updated; on a parse or validation failure it logs and keeps the previous config
+/// (`false`). This is the testable seam for the live-reload path — the loop supplies the JSON it
+/// read on its own thread.
+fn apply_config_update(shared: &Arc<RwLock<Arc<LogManagerConfig>>>, json: &str) -> bool {
+    match load_config(json) {
+        Ok(new_config) => match validate_config(&new_config) {
+            Ok(()) => {
+                // TODO: when a component is dropped from the config on reload, its checkpoint
+                // entries (file_processing_info / last_processed_timestamps for that log group)
+                // are left in place. This is pre-existing (such entries already persist across a
+                // restart via checkpoint.json) and metadata-only: a removed component is no longer
+                // scanned, so nothing re-uploads and no log-file disk space grows. The stale entry
+                // is bounded by the process lifetime. Pruning entries for log groups absent from
+                // the new config is deferred.
+                *shared.write().unwrap_or_else(|e| e.into_inner()) = Arc::new(new_config);
+                info!("Configuration reloaded from update");
+                true
+            }
+            Err(e) => {
+                warn!(error = %e, "Invalid configuration update ignored; keeping previous config");
+                false
+            }
+        },
+        Err(e) => {
+            warn!(error = %e, "Failed to parse configuration update; keeping previous config");
+            false
+        }
+    }
 }
 
 /// Process all configured log sources (component + system) sequentially in one cycle.
@@ -622,7 +744,7 @@ mod tests {
     fn test_resolve_raw_config_cli_wins_over_env() {
         std::env::set_var("GG_LOG_MANAGER_CONFIG", "ENV");
         let args = vec!["bin".to_string(), "--config".to_string(), "CLI".to_string()];
-        assert_eq!(resolve_raw_config(&args), "CLI");
+        assert_eq!(resolve_raw_config(&args, None), "CLI");
         std::env::remove_var("GG_LOG_MANAGER_CONFIG");
     }
 
@@ -631,7 +753,7 @@ mod tests {
     fn test_resolve_raw_config_env_used_without_cli() {
         std::env::set_var("GG_LOG_MANAGER_CONFIG", "ENV");
         let args = vec!["bin".to_string()];
-        assert_eq!(resolve_raw_config(&args), "ENV");
+        assert_eq!(resolve_raw_config(&args, None), "ENV");
         std::env::remove_var("GG_LOG_MANAGER_CONFIG");
     }
 
@@ -640,7 +762,76 @@ mod tests {
     fn test_resolve_raw_config_default_when_no_source() {
         std::env::remove_var("GG_LOG_MANAGER_CONFIG");
         let args = vec!["bin".to_string()];
-        assert_eq!(resolve_raw_config(&args), "{}");
+        assert_eq!(resolve_raw_config(&args, None), "{}");
+    }
+
+    // Default build (no `gg-ipc`): the startup IPC value is `None`, so the IPC source never
+    // contributes and the chain behaves as CLI → env → default.
+    #[cfg(not(feature = "gg-ipc"))]
+    #[test]
+    fn test_config_from_ipc_none_without_feature() {
+        assert_eq!(config_from_ipc(None).unwrap(), None);
+    }
+
+    // A non-empty env value wins over the (last) IPC source even when an IPC value is present.
+    #[test]
+    #[serial]
+    fn test_resolve_raw_config_env_wins_over_ipc_fallback() {
+        std::env::set_var("GG_LOG_MANAGER_CONFIG", "ENV");
+        let args = vec!["bin".to_string()];
+        assert_eq!(resolve_raw_config(&args, Some("IPC".to_string())), "ENV");
+        std::env::remove_var("GG_LOG_MANAGER_CONFIG");
+    }
+
+    // The empty-string env filter routes past env to the IPC source: CLI absent, env empty, and
+    // no IPC value → resolution falls through to the "{}" default.
+    #[test]
+    #[serial]
+    fn test_resolve_raw_config_empty_env_falls_through_to_ipc_fallback() {
+        std::env::set_var("GG_LOG_MANAGER_CONFIG", "");
+        let args = vec!["bin".to_string()];
+        assert_eq!(resolve_raw_config(&args, None), "{}");
+        std::env::remove_var("GG_LOG_MANAGER_CONFIG");
+    }
+
+    // With CLI and env absent, the startup IPC value is used as the last source before default.
+    #[test]
+    #[serial]
+    fn test_resolve_raw_config_uses_ipc_value_when_cli_env_absent() {
+        std::env::remove_var("GG_LOG_MANAGER_CONFIG");
+        let args = vec!["bin".to_string()];
+        assert_eq!(
+            resolve_raw_config(
+                &args,
+                Some(r#"{"periodicUploadIntervalSec":9}"#.to_string())
+            ),
+            r#"{"periodicUploadIntervalSec":9}"#
+        );
+    }
+
+    // apply_config_update swaps the cell on a valid update and keeps the previous config on a bad
+    // one. The live subscribe path (the callback firing, the SDK rejecting a get_config on the
+    // callback thread, and the end-to-end deploy→swap) is device-only and not unit-testable here.
+    #[test]
+    fn test_apply_config_update_good_json_swaps_cell() {
+        let shared = Arc::new(RwLock::new(Arc::new(load_config("{}").unwrap())));
+        let before = shared.read().unwrap().periodic_upload_interval_sec;
+        assert!(apply_config_update(
+            &shared,
+            r#"{"periodicUploadIntervalSec":42}"#
+        ));
+        let after = shared.read().unwrap().periodic_upload_interval_sec;
+        assert_eq!(after, 42);
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn test_apply_config_update_bad_json_keeps_previous() {
+        let shared = Arc::new(RwLock::new(Arc::new(
+            load_config(r#"{"periodicUploadIntervalSec":7}"#).unwrap(),
+        )));
+        assert!(!apply_config_update(&shared, "not valid json {{{"));
+        assert_eq!(shared.read().unwrap().periodic_upload_interval_sec, 7);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Adds an IPC-based configuration source so the component reads its own configuration from the Greengrass runtime — at startup (a fallback after CLI/env) and live via a configuration-update subscription, so config changes apply without a component restart. Works on both Greengrass nucleus and nucleus lite. Behind an opt-in `gg-ipc` feature so the default build stays portable.

## Why
The component's recipe carries no `Setenv`/`--config`, so on-device it would otherwise start on `"{}"` defaults on both runtimes. Reading its own deployment-merged config via IPC `GetConfiguration` gives it configuration at runtime, and subscribing to configuration updates lets it apply later changes live — without the service interruption of restarting the component on a config-only change. (Greengrass Classic does not restart a component for config-only changes; components consume such updates via the IPC configuration-update subscription.) CLI/env remain the primary sources for local/test.

## What changed
- `Cargo.toml`: optional `gg_sdk` (`aws-greengrass-component-sdk` `=1.0.4`) + a `gg-ipc` feature, not in `default`.
- `src/ipc_config.rs`: `connect_ipc()` (single connect) and `read_config()` (own-config `GetConfiguration`), behind `#[cfg(feature = "gg-ipc")]`; an empty module when the feature is off.
- `src/main.rs`:
  - `config_from_ipc()` wired as the last source in `resolve_raw_config` (`CLI → env → IPC → default`).
  - Config held in a shared cell the upload loop reads at the top of each cycle.
  - A configuration-update subscription whose callback signals the loop; the loop (which owns the connection) re-reads via `GetConfiguration`, validates, and swaps the cell — keeping the previous config on a bad update. No restart.

## Behavior notes
- Config changes take effect on the next cycle; a configuration-update notification also triggers an immediate processing cycle.
- If a component's `logGroupName` changes, its previous checkpoint entries are left behind and the new group starts from the beginning (re-uploading already-sent data for that group) — inherent to re-keying on a config change.
- The startup read is the first-load path on both runtimes; the subscription provides restart-free updates.

## How tested
- Default build (no feature): `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — all green; `gg_sdk` is not compiled on the default path.
- Unit tests: resolution order (CLI/env/IPC/default, incl. empty-env fallthrough); `apply_config_update` swaps on a valid update and keeps the previous config on an invalid one.
- Not unit-tested (needs a device or mock socket): the subscription callback firing, and the end-to-end deploy → reload path.

## Notes for reviewers
- Opt-in feature: `gg_sdk`'s build depends on libclang + a C toolchain (edition 2024), so `gg-ipc` is kept out of `default` to keep `cargo build/test/clippy` portable. A dedicated `--features gg-ipc` CI job is recommended.
- Deferred (separate follow-ups): pruning checkpoint entries for components removed from config (pre-existing, metadata-only); resolving `systemLogsConfiguration` `logFileDirectoryPath`/`logFileRegex` from the runtime logging configuration; honoring per-source `uploadIntervalSec`.

## Base
Based directly on `rust/v2` (rebased over the merged orchestrator and checkpoint PRs). The rebase surfaced one interaction: the shutdown checkpoint flush now reads `deprecatedVersionSupport` from the live config cell (not the startup value), so a hot-reloaded setting governs the final write.


