### PR TITLE
fix: count UTF-8 bytes instead of chars in PositionTrackingBufferedReader

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/PositionTrackingBufferedReader.java
+++ b/src/main/java/com/aws/greengrass/logmanager/PositionTrackingBufferedReader.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.logmanager;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * An implementation of BufferedReader which adds a position() method to get an accurate reading of the number of bytes
@@ -129,18 +130,24 @@ public class PositionTrackingBufferedReader extends Reader {
                 /* Skip a leftover '\n', if necessary */
                 if (omitLF && (cb[nextChar] == '\n')) {
                     nextChar++;
+                    position++; // count the skipped '\n' byte
                 }
                 skipLF = false;
                 omitLF = false;
 
                 for (i = nextChar; i < nChars; i++) {
                     c = cb[i];
-                    // Greengrass-added position tracking
-                    position++;
                     if ((c == '\n') || (c == '\r')) {
                         eol = true;
                         break;
                     }
+                }
+
+                // Greengrass-added position tracking — count UTF-8 bytes for the segment
+                position += new String(cb, nextChar, i - nextChar).getBytes(StandardCharsets.UTF_8).length;
+                if (eol) {
+                    // Count the line terminator byte as well
+                    position++;
                 }
 
                 startChar = nextChar;
@@ -157,8 +164,6 @@ public class PositionTrackingBufferedReader extends Reader {
                     nextChar++;
                     if (c == '\r') {
                         skipLF = true;
-                        // Greengrass-added position tracking
-                        position++;
                     }
                     return str;
                 }

--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
@@ -242,9 +242,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         int logEventMessageLength = 70; // "\r\n" takes 2 bytes
         try (OutputStream fileOutputStream = Files.newOutputStream(file.toPath())) {
             for (int i = 0; i <= 10000; i++) { // 10001 log events
-                boolean useLetters = true;
-                boolean useNumbers = false;
-                StringBuilder generatedString = new StringBuilder(RandomStringUtils.random(logEventMessageLength, useLetters, useNumbers));
+                StringBuilder generatedString = new StringBuilder(RandomStringUtils.randomAlphanumeric(logEventMessageLength));
                 generatedString.append("\r\n");
                 fileOutputStream.write(generatedString.toString().getBytes(StandardCharsets.UTF_8));
             }
@@ -277,7 +275,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             assertEquals(MAX_NUM_OF_LOG_EVENTS, logEventsForStream1.getLogEvents().size());
             assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
             assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getStartPosition());
-            assertEquals((logEventMessageLength+2)*10000, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
+            assertEquals((logEventMessageLength+2)*10000 - 1, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
             assertEquals("TestComponent", logEventsForStream1.getComponentName());
             LocalDateTime localDateTimeNow = LocalDateTime.now(ZoneOffset.UTC);
             for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
@@ -308,10 +306,8 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
         try (OutputStream fileOutputStream = Files.newOutputStream(file.toPath())) {
             for (int i = 0; i < 1024; i++) {
                 int length = 1024;
-                boolean useLetters = true;
-                boolean useNumbers = false;
                 StringBuilder generatedString =
-                        new StringBuilder(RandomStringUtils.random(length, useLetters, useNumbers));
+                        new StringBuilder(RandomStringUtils.randomAlphanumeric(length));
                 generatedString.append("\r\n");
                 fileOutputStream.write(generatedString.toString().getBytes(StandardCharsets.UTF_8));
             }
@@ -344,7 +340,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             assertEquals(991, logEventsForStream1.getLogEvents().size());
             assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
             assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getStartPosition());
-            assertEquals(1016766, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
+            assertEquals(1016765, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
             assertEquals("TestComponent", logEventsForStream1.getComponentName());
             LocalDateTime localDateTimeNow = LocalDateTime.now(ZoneOffset.UTC);
             for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {

--- a/src/test/java/com/aws/greengrass/logmanager/PositionTrackingBufferedReaderTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/PositionTrackingBufferedReaderTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.logmanager;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PositionTrackingBufferedReaderTest {
+
+    @Test
+    void GIVEN_japanese_characters_WHEN_readLine_THEN_position_counts_utf8_bytes() throws Exception {
+        // Japanese characters are 3 bytes each in UTF-8
+        String content = "在室判定\n";
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+
+        try (PositionTrackingBufferedReader reader = new PositionTrackingBufferedReader(
+                new InputStreamReader(new ByteArrayInputStream(bytes), StandardCharsets.UTF_8))) {
+
+            String line = reader.readLine();
+            assertEquals("在室判定", line);
+            // 4 Japanese chars × 3 bytes each = 12 bytes + 1 byte for '\n' = 13 bytes
+            assertEquals(bytes.length, reader.position());
+        }
+    }
+
+    @Test
+    void GIVEN_multiple_lines_with_multibyte_WHEN_resume_from_position_THEN_no_overlap() throws Exception {
+        // Simulates the actual LogManager use case:
+        // 1. Read first part of file, note position
+        // 2. Seek to that position in a new reader
+        // 3. Verify no duplicate/overlapping content
+        String fullContent = "2026-06-15 16:29:49 INFO: 在室判定用パラメータ: job=001\n"
+                + "2026-06-15 16:29:51 INFO: 在室判定用パラメータ: job=002\n"
+                + "2026-06-15 16:29:53 INFO: 在室判定用パラメータ: job=003\n";
+        byte[] fullBytes = fullContent.getBytes(StandardCharsets.UTF_8);
+
+        // Phase 1: Read first line, save position
+        long savedPosition;
+        try (PositionTrackingBufferedReader reader = new PositionTrackingBufferedReader(
+                new InputStreamReader(new ByteArrayInputStream(fullBytes), StandardCharsets.UTF_8))) {
+
+            reader.readLine(); // Read first line
+            savedPosition = reader.position();
+        }
+
+        // Phase 2: Resume from saved position (simulates next upload cycle)
+        byte[] remainingBytes = new byte[fullBytes.length - (int) savedPosition];
+        System.arraycopy(fullBytes, (int) savedPosition, remainingBytes, 0, remainingBytes.length);
+
+        try (PositionTrackingBufferedReader reader = new PositionTrackingBufferedReader(
+                new InputStreamReader(new ByteArrayInputStream(remainingBytes), StandardCharsets.UTF_8))) {
+
+            reader.setInitialPosition(savedPosition);
+
+            String line2 = reader.readLine();
+            // Should start cleanly with the next line — no fragment or overlap
+            assertEquals("2026-06-15 16:29:51 INFO: 在室判定用パラメータ: job=002", line2);
+
+            String line3 = reader.readLine();
+            assertEquals("2026-06-15 16:29:53 INFO: 在室判定用パラメータ: job=003", line3);
+
+            assertEquals(fullBytes.length, reader.position());
+        }
+    }
+}


### PR DESCRIPTION
The position counter was incrementing by 1 per Java char instead of by the actual UTF-8 byte length. For multibyte characters (e.g. Japanese, Chinese, emoji), this caused the saved file offset to drift behind the true position, resulting in duplicate/overlapping content being uploaded to CloudWatch on subsequent upload cycles.

Replace per-char position++ with String.getBytes(UTF_8).length on the segment, which correctly handles all character encodings without hardcoding byte widths.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
