### PR TITLE
feat(disk): enforce disk limits every scan cycle with safe reclamation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ cargo test --target aarch64-unknown-linux-musl
 | `credentials/` | AWS credential retrieval via GG TES |
 | `disk/` | Disk space management and log cleanup |
 
+## Disk space management
+
+Each configured log source is bounded by its `diskSpaceLimit`, enforced on **every scan cycle**
+(not only after a successful upload), so already-uploaded files are reclaimed even during an
+upload outage. In the default mode only fully-uploaded files are reclaimed, so a source that
+cannot upload may still exceed its limit unless `deleteUnuploadedFilesOnDiskPressure` is set. A
+source without its own `diskSpaceLimit` uses the component-level `defaultDiskSpaceLimit` if set;
+when neither is set the source is not bounded.
+
+By default only fully-uploaded files are reclaimed. Setting `deleteUnuploadedFilesOnDiskPressure`
+to `true` on a source additionally sheds its oldest un-uploaded files when it is still over the
+limit after reclaiming uploaded ones. The active (newest) file is never deleted. Files skipped as
+hash-duplicates of a newer file (which may not have been uploaded) are likewise preserved in the
+default mode and only reclaimed under pressure when `deleteUnuploadedFilesOnDiskPressure` is set.
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -79,6 +79,9 @@ pub fn validate_config(config: &LogManagerConfig) -> Result<(), ConfigError> {
         warn_if_upload_interval_unwired(&sys.source, "systemLogsConfiguration");
         validate_log_source(&sys.source)?;
     }
+    if let Some(ref limit) = config.logs_uploader_configuration.default_disk_space_limit {
+        validate_disk_limit(limit)?;
+    }
     tracing::info!("Configuration validation passed");
     Ok(())
 }
@@ -130,6 +133,38 @@ pub fn parse_disk_space_limit(limit: Option<&str>) -> Result<Option<u64>, Config
             Ok(parsed)
         })
         .transpose()
+}
+
+/// Effective disk limit in bytes for a source, or `None` when the source is unbounded.
+///
+/// Resolution: the source's own `diskSpaceLimit`, else the component-level
+/// `defaultDiskSpaceLimit`, else `None` — only ever customer-provided values. A value that
+/// fails to parse is treated as unset (WARN); `validate_config` rejects invalid limits at
+/// load, so the `Err` arms are defensive.
+#[must_use]
+pub fn effective_disk_limit_bytes(
+    source: &LogSourceConfig,
+    uploader_config: &LogsUploaderConfig,
+) -> Option<u64> {
+    match parse_disk_space_limit(source.disk_space_limit.as_deref()) {
+        Ok(Some(limit)) => return Some(source.disk_space_limit_unit.to_bytes(limit)),
+        Ok(None) => {} // unset — fall through to the component default
+        Err(e) => {
+            tracing::warn!(error = %e, "Invalid source diskSpaceLimit; ignoring it and trying the component default");
+        }
+    }
+    match parse_disk_space_limit(uploader_config.default_disk_space_limit.as_deref()) {
+        Ok(Some(limit)) => Some(
+            uploader_config
+                .default_disk_space_limit_unit
+                .to_bytes(limit),
+        ),
+        Ok(None) => None, // neither set — the source is unbounded
+        Err(e) => {
+            tracing::warn!(error = %e, "Invalid defaultDiskSpaceLimit; source is left unbounded");
+            None
+        }
+    }
 }
 
 /// Derive log group name: /aws/greengrass/{componentType}/{region}/{componentName}
@@ -265,6 +300,79 @@ mod tests {
         assert!(parse_disk_space_limit(Some("abc")).is_err());
         assert_eq!(parse_disk_space_limit(None).unwrap(), None);
         assert_eq!(parse_disk_space_limit(Some("")).unwrap(), None);
+    }
+
+    #[test]
+    fn test_effective_disk_limit_none_when_neither_set() {
+        let comp: ComponentSourceConfig =
+            serde_json::from_str(r#"{"logFileDirectoryPath":"/tmp","logFileRegex":".*"}"#).unwrap();
+        let uploader = LogsUploaderConfig::default();
+        assert_eq!(effective_disk_limit_bytes(&comp.source, &uploader), None);
+    }
+
+    #[test]
+    fn test_effective_disk_limit_uses_configured_source_value() {
+        let comp: ComponentSourceConfig = serde_json::from_str(
+            r#"{"logFileDirectoryPath":"/tmp","logFileRegex":".*","diskSpaceLimit":"50","diskSpaceLimitUnit":"MB"}"#,
+        )
+        .unwrap();
+        let uploader = LogsUploaderConfig::default();
+        assert_eq!(
+            effective_disk_limit_bytes(&comp.source, &uploader),
+            Some(50 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn test_effective_disk_limit_falls_back_to_component_default() {
+        let comp: ComponentSourceConfig =
+            serde_json::from_str(r#"{"logFileDirectoryPath":"/tmp","logFileRegex":".*"}"#).unwrap();
+        let uploader = LogsUploaderConfig {
+            default_disk_space_limit: Some("10".into()),
+            default_disk_space_limit_unit: DiskSpaceLimitUnit::MB,
+            ..Default::default()
+        };
+        assert_eq!(
+            effective_disk_limit_bytes(&comp.source, &uploader),
+            Some(10 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn test_effective_disk_limit_source_overrides_component_default() {
+        let comp: ComponentSourceConfig = serde_json::from_str(
+            r#"{"logFileDirectoryPath":"/tmp","logFileRegex":".*","diskSpaceLimit":"5","diskSpaceLimitUnit":"MB"}"#,
+        )
+        .unwrap();
+        let uploader = LogsUploaderConfig {
+            default_disk_space_limit: Some("99".into()),
+            default_disk_space_limit_unit: DiskSpaceLimitUnit::GB,
+            ..Default::default()
+        };
+        // Source limit wins over the component default.
+        assert_eq!(
+            effective_disk_limit_bytes(&comp.source, &uploader),
+            Some(5 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn test_effective_disk_limit_bad_source_falls_to_component_default() {
+        // An unparseable source limit is treated as unset and falls through to the default;
+        // a bound is never invented from a bad value.
+        let comp: ComponentSourceConfig = serde_json::from_str(
+            r#"{"logFileDirectoryPath":"/tmp","logFileRegex":".*","diskSpaceLimit":"not-a-number"}"#,
+        )
+        .unwrap();
+        let uploader = LogsUploaderConfig {
+            default_disk_space_limit: Some("2".into()),
+            default_disk_space_limit_unit: DiskSpaceLimitUnit::MB,
+            ..Default::default()
+        };
+        assert_eq!(
+            effective_disk_limit_bytes(&comp.source, &uploader),
+            Some(2 * 1024 * 1024)
+        );
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -69,6 +69,11 @@ pub struct LogSourceConfig {
     pub disk_space_limit_unit: DiskSpaceLimitUnit,
     #[serde(default, deserialize_with = "deserialize_bool_or_string")]
     pub delete_log_file_after_cloud_upload: bool,
+    /// Opt-in: when still over `diskSpaceLimit` after reclaiming fully-uploaded files, also
+    /// delete the oldest un-uploaded (non-active) files. Default false, so the default
+    /// behavior only ever reclaims already-uploaded files.
+    #[serde(default, deserialize_with = "deserialize_bool_or_string")]
+    pub delete_unuploaded_files_on_disk_pressure: bool,
     pub multi_line_start_pattern: Option<String>,
     /// Per-source upload interval override. Not yet honored — every source currently
     /// uploads on the global `periodicUploadIntervalSec` cadence.
@@ -91,6 +96,13 @@ pub struct LogsUploaderConfig {
     pub component_logs_configuration_map: HashMap<String, ComponentSourceConfig>,
     #[serde(default)]
     pub system_logs_configuration: Option<SystemLogSourceConfig>,
+    /// Optional fallback applied to any source that does not set its own `diskSpaceLimit`.
+    /// When neither is set, the source is not bounded. Uses the same string-or-number form
+    /// and unit field as the per-source `diskSpaceLimit`/`diskSpaceLimitUnit`.
+    #[serde(default, deserialize_with = "deserialize_optional_string_or_number")]
+    pub default_disk_space_limit: Option<String>,
+    #[serde(default)]
+    pub default_disk_space_limit_unit: DiskSpaceLimitUnit,
 }
 
 /// Top-level config struct deserialized from the full recipe configuration tree.
@@ -315,6 +327,19 @@ mod tests {
     }
 
     #[test]
+    fn test_delete_unuploaded_flag_default_and_string() {
+        // Defaults to false when omitted.
+        let json = r#"{"logFileDirectoryPath":"/tmp","logFileRegex":".*"}"#;
+        let comp: ComponentSourceConfig = serde_json::from_str(json).unwrap();
+        assert!(!comp.source.delete_unuploaded_files_on_disk_pressure);
+
+        // Accepts the Greengrass string form "true" (config values arrive as strings).
+        let json = r#"{"logFileDirectoryPath":"/tmp","logFileRegex":".*","deleteUnuploadedFilesOnDiskPressure":"true"}"#;
+        let comp: ComponentSourceConfig = serde_json::from_str(json).unwrap();
+        assert!(comp.source.delete_unuploaded_files_on_disk_pressure);
+    }
+
+    #[test]
     fn test_serde_roundtrip() {
         let mut map = HashMap::new();
         map.insert(
@@ -327,6 +352,7 @@ mod tests {
                     disk_space_limit: Some("50".into()),
                     disk_space_limit_unit: DiskSpaceLimitUnit::GB,
                     delete_log_file_after_cloud_upload: true,
+                    delete_unuploaded_files_on_disk_pressure: false,
                     multi_line_start_pattern: Some("^\\d".into()),
                     upload_interval_sec: Some(120),
                 },
@@ -339,6 +365,8 @@ mod tests {
             logs_uploader_configuration: LogsUploaderConfig {
                 component_logs_configuration_map: map,
                 system_logs_configuration: None,
+                default_disk_space_limit: Some("128".into()),
+                default_disk_space_limit_unit: DiskSpaceLimitUnit::MB,
             },
         };
         let json = serde_json::to_string(&config).unwrap();
@@ -358,6 +386,16 @@ mod tests {
             .unwrap();
         assert_eq!(comp.source.disk_space_limit, Some("50".into()));
         assert_eq!(comp.source.upload_interval_sec, Some(120));
+        assert_eq!(
+            parsed.logs_uploader_configuration.default_disk_space_limit,
+            Some("128".into())
+        );
+        assert_eq!(
+            parsed
+                .logs_uploader_configuration
+                .default_disk_space_limit_unit,
+            DiskSpaceLimitUnit::MB
+        );
     }
 
     #[test]
@@ -493,6 +531,53 @@ mod tests {
     #[test]
     fn test_default_log_level_is_info() {
         assert_eq!(LogLevel::default(), LogLevel::Info);
+    }
+
+    #[test]
+    fn test_default_disk_space_limit_keys_parse() {
+        // Component-level default (nested form) parses like the per-source keys.
+        let json = r#"{
+            "logsUploaderConfiguration": {
+                "defaultDiskSpaceLimit": "512",
+                "defaultDiskSpaceLimitUnit": "MB"
+            }
+        }"#;
+        let config: LogManagerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.logs_uploader_configuration.default_disk_space_limit,
+            Some("512".into())
+        );
+        assert_eq!(
+            config
+                .logs_uploader_configuration
+                .default_disk_space_limit_unit,
+            DiskSpaceLimitUnit::MB
+        );
+
+        // JSON number form is accepted too (config values may arrive as numbers).
+        let json = r#"{
+            "logsUploaderConfiguration": {
+                "defaultDiskSpaceLimit": 512
+            }
+        }"#;
+        let config: LogManagerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.logs_uploader_configuration.default_disk_space_limit,
+            Some("512".into())
+        );
+
+        // Omitted → None (unbounded) with the default unit.
+        let config: LogManagerConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(
+            config.logs_uploader_configuration.default_disk_space_limit,
+            None
+        );
+        assert_eq!(
+            config
+                .logs_uploader_configuration
+                .default_disk_space_limit_unit,
+            DiskSpaceLimitUnit::KB
+        );
     }
 
     #[test]

--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -1,101 +1,198 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Disk space management — per-component log directory size limits.
-//! Deletes oldest already-processed (uploaded) files when total exceeds diskSpaceLimit.
+//! Disk space management — per-source log directory size limits.
+//!
+//! `enforce_disk_limit` runs every scan cycle: it enumerates the directory,
+//! classifies each file (active / uploaded-safe / un-uploaded), and deletes the
+//! oldest eligible files until under `diskSpaceLimit`. Uploaded-safe files are
+//! reclaimed first; un-uploaded files only when the caller opts in. The newest
+//! (active) file is never deleted, and each file is re-stat'd immediately before
+//! unlink so one that has since grown into the active file is left alone.
 
 use regex::Regex;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-/// Calculate total size of regular files matching `pattern` in `dir` (top-level only).
-/// Skips symlinks and subdirectories.
-fn dir_size(dir: &Path, pattern: &Regex) -> u64 {
-    match fs::read_dir(dir) {
-        Ok(entries) => entries
-            .filter_map(|e| e.ok())
-            .filter(|e| e.file_type().is_ok_and(|ft| ft.is_file()))
-            .filter(|e| pattern.is_match(&e.file_name().to_string_lossy()))
-            .filter_map(|e| e.metadata().ok())
-            .map(|m| m.len())
-            .sum(),
+/// Files deleted by [`enforce_disk_limit`], split by upload status.
+#[derive(Debug, Default, PartialEq, Eq)]
+#[must_use = "disk-enforcement outcome records which files were deleted"]
+pub struct EnforceOutcome {
+    /// Fully-uploaded ("uploaded-safe") files that were deleted.
+    pub uploaded_deleted: Vec<PathBuf>,
+    /// Un-uploaded files deleted under disk pressure (only when `allow_unuploaded`).
+    pub unuploaded_deleted: Vec<PathBuf>,
+}
+
+/// A matching regular file found during directory enumeration.
+#[derive(Debug)]
+struct DiskEntry {
+    path: PathBuf,
+    size: u64,
+    mtime: SystemTime,
+}
+
+/// Enumerate top-level regular files in `dir` matching `pattern`.
+/// Skips symlinks and subdirectories (mirrors the scanner).
+fn enumerate_files(dir: &Path, pattern: &Regex) -> Vec<DiskEntry> {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
         Err(e) => {
             tracing::warn!(dir = %dir.display(), error = %e, "Cannot read directory for disk management");
-            0
+            return Vec::new();
+        }
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter_map(|e| {
+            if !e.file_type().ok()?.is_file() {
+                return None;
+            }
+            if !pattern.is_match(&e.file_name().to_string_lossy()) {
+                return None;
+            }
+            let meta = e.metadata().ok()?;
+            Some(DiskEntry {
+                path: e.path(),
+                size: meta.len(),
+                mtime: meta.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+            })
+        })
+        .collect()
+}
+
+fn mtime_ms(t: SystemTime) -> u64 {
+    t.duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Re-stat immediately before unlink (TOCTOU guard) and delete.
+/// Returns freed bytes on success, or `None` if the file has become the
+/// newest/active file, vanished, or could not be removed.
+fn restat_and_unlink(path: &Path, newest: SystemTime) -> Option<u64> {
+    let meta = fs::metadata(path).ok()?;
+    if meta.modified().unwrap_or(SystemTime::UNIX_EPOCH) >= newest {
+        // Grew into the newest/active file since enumeration — do not delete.
+        tracing::debug!(path = %path.display(), "Skipping delete: file is now newest/active");
+        return None;
+    }
+    match fs::remove_file(path) {
+        Ok(()) => Some(meta.len()),
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "Failed to delete file, skipping");
+            None
         }
     }
 }
 
-/// Free disk space by deleting oldest processed files until directory size ≤ limit.
+// Real-filesystem-usage-based enforcement (statvfs) is not supported: enforcement is a
+// per-source quota on each source's own directory, not a check of actual device free space.
+// It therefore does not protect against whole-device disk exhaustion (e.g. another process
+// filling the disk), and this component can only ever delete its own files.
+
+// TODO: apply Bytes/EpochMs (and Duration for sec/ms values) newtypes crate-wide instead of
+// bare u64s. The epoch-ms fields serialize into the backward-compatible checkpoint format, so
+// this needs #[serde(transparent)] plus a wire-format round-trip test against the legacy layout.
+/// Enforce `limit_bytes` on `dir` by deleting the oldest eligible files.
 ///
-/// Only deletes files in `processed_files` — caller must ensure these are safe to delete
-/// (fully uploaded, not actively written to). This function trusts the list it receives.
-///
-/// Returns paths of successfully deleted files.
-pub fn free_disk_space(
+/// Enumerates `dir` directly and classifies each matching file: newest mtime = **active**
+/// (never deleted); `mtime <= last_ts_ms && !is_tracked` = **uploaded-safe**; the rest =
+/// **un-uploaded**. Deletes uploaded-safe oldest-first until under limit, then (only if
+/// `allow_unuploaded`) un-uploaded oldest-first, WARN each. Files are re-stat'd before unlink.
+pub fn enforce_disk_limit(
     dir: &Path,
     pattern: &Regex,
     limit_bytes: u64,
-    processed_files: &[PathBuf],
-) -> Vec<PathBuf> {
-    if processed_files.is_empty() {
-        return Vec::new();
+    last_ts_ms: u64,
+    is_tracked: impl Fn(&Path) -> bool,
+    allow_unuploaded: bool,
+) -> EnforceOutcome {
+    let mut outcome = EnforceOutcome::default();
+
+    let entries = enumerate_files(dir, pattern);
+    let total: u64 = entries.iter().map(|e| e.size).sum();
+    if total <= limit_bytes {
+        return outcome;
     }
 
-    let total_size = dir_size(dir, pattern);
-
-    if total_size <= limit_bytes {
-        return Vec::new();
-    }
-
-    // Cache metadata upfront to avoid double reads (once for sort, once for size).
-    let mut file_info: Vec<_> = processed_files
+    // Active file(s) = newest mtime; never deleted (ties treated as active for safety).
+    let newest = entries
         .iter()
-        .filter_map(|p| {
-            fs::metadata(p).ok().map(|m| {
-                (
-                    p.clone(),
-                    m.len(),
-                    m.modified().unwrap_or(SystemTime::UNIX_EPOCH),
-                )
-            })
-        })
-        .collect();
-    file_info.sort_by_key(|(_, _, mtime)| *mtime); // oldest first
+        .map(|e| e.mtime)
+        .max()
+        .unwrap_or(SystemTime::UNIX_EPOCH);
 
-    let mut bytes_to_free = total_size.saturating_sub(limit_bytes);
-    let mut deleted = Vec::with_capacity(file_info.len());
-    let mut actually_freed: u64 = 0;
+    let mut uploaded_safe: Vec<&DiskEntry> = Vec::new();
+    let mut unuploaded: Vec<&DiskEntry> = Vec::new();
+    for e in &entries {
+        if e.mtime >= newest {
+            continue; // active — never delete
+        }
+        if mtime_ms(e.mtime) <= last_ts_ms && !is_tracked(&e.path) {
+            uploaded_safe.push(e);
+        } else {
+            unuploaded.push(e);
+        }
+    }
+    uploaded_safe.sort_by_key(|e| e.mtime); // oldest first
+    unuploaded.sort_by_key(|e| e.mtime);
 
-    for (path, size, _) in file_info {
-        if bytes_to_free == 0 {
+    let mut remaining = total;
+
+    // Phase 1: reclaim uploaded-safe files first.
+    for e in uploaded_safe {
+        if remaining <= limit_bytes {
             break;
         }
-        if let Err(e) = fs::remove_file(&path) {
-            tracing::warn!(path = %path.display(), error = %e, "Failed to delete processed file, skipping");
-            continue;
+        if let Some(freed) = restat_and_unlink(&e.path, newest) {
+            tracing::info!(path = %e.path.display(), freed_bytes = freed, "Deleted uploaded log file under disk pressure");
+            remaining = remaining.saturating_sub(freed);
+            outcome.uploaded_deleted.push(e.path.clone());
         }
-        tracing::info!(path = %path.display(), freed_bytes = size, "Deleted processed log file");
-        deleted.push(path);
-        actually_freed += size;
-        bytes_to_free = bytes_to_free.saturating_sub(size);
     }
 
-    if !deleted.is_empty() {
-        tracing::info!(
-            total_freed = actually_freed,
-            files_deleted = deleted.len(),
-            "Disk space freed"
+    // Phase 2: reclaim un-uploaded files only when opted in and still over.
+    if allow_unuploaded {
+        for e in unuploaded {
+            if remaining <= limit_bytes {
+                break;
+            }
+            if let Some(freed) = restat_and_unlink(&e.path, newest) {
+                tracing::warn!(
+                    path = %e.path.display(),
+                    freed_bytes = freed,
+                    reason = "disk pressure, not yet uploaded",
+                    "Deleted un-uploaded log file under disk pressure"
+                );
+                remaining = remaining.saturating_sub(freed);
+                outcome.unuploaded_deleted.push(e.path.clone());
+            }
+        }
+    }
+
+    if !outcome.unuploaded_deleted.is_empty() {
+        tracing::warn!(
+            count = outcome.unuploaded_deleted.len(),
+            dir = %dir.display(),
+            "Deleted un-uploaded files under disk pressure"
+        );
+    } else if outcome.uploaded_deleted.is_empty() {
+        // Over limit but nothing eligible to reclaim (e.g. only the active file, or
+        // all remaining files are un-uploaded and un-uploaded shedding is disabled).
+        tracing::warn!(
+            dir = %dir.display(),
+            total_bytes = total,
+            limit_bytes,
+            "Over disk limit but no eligible files to delete"
         );
     }
 
-    deleted
+    outcome
 }
 
-// Single-arg &[x.clone()] kept per review; allow for clippy 1.94.1.
 #[cfg(test)]
-#[allow(clippy::cloned_ref_to_slice_refs)]
 mod tests {
     use super::*;
     use std::fs::File;
@@ -124,114 +221,191 @@ mod tests {
         Regex::new(r"\.log$").expect("invalid test regex")
     }
 
-    #[test]
-    fn no_op_when_under_limit() {
-        let tmp = TempDir::new().unwrap();
-        let f1 = create_file(tmp.path(), "a.log", 100);
-        let f2 = create_file(tmp.path(), "b.log", 100);
-        let processed = vec![f1, f2];
-
-        let deleted = free_disk_space(tmp.path(), &log_pattern(), 500, &processed);
-        assert!(deleted.is_empty());
-        assert!(processed.iter().all(|p| p.exists()));
+    /// Epoch-millis for `secs` seconds ago — matches how `set_mtime` sets mtimes.
+    fn ts_ms_secs_ago(secs: i64) -> u64 {
+        let now = i64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock before UNIX_EPOCH")
+                .as_secs(),
+        )
+        .expect("timestamp overflow");
+        u64::try_from((now - secs) * 1000).expect("negative timestamp")
     }
 
-    #[test]
-    fn deletes_oldest_first_until_under_limit() {
-        let tmp = TempDir::new().unwrap();
-        let old = create_file(tmp.path(), "old.log", 100);
-        let mid = create_file(tmp.path(), "mid.log", 100);
-        let new = create_file(tmp.path(), "new.log", 100);
-        set_mtime(&old, 300);
-        set_mtime(&mid, 200);
-        set_mtime(&new, 100);
-
-        let processed = vec![old.clone(), mid.clone(), new.clone()];
-        // total=300, limit=250 → need to free 50 → delete oldest (100 bytes)
-        let deleted = free_disk_space(tmp.path(), &log_pattern(), 250, &processed);
-        assert_eq!(deleted, vec![old.clone()]);
-        assert!(!old.exists());
-        assert!(mid.exists());
-        assert!(new.exists());
+    fn untracked(_: &Path) -> bool {
+        false
     }
 
+    // T1 (default): over limit, allow_unuploaded=false → deletes only uploaded-safe
+    // oldest-first; never the active file; never un-uploaded files.
     #[test]
-    fn only_deletes_processed_files() {
+    fn enforce_deletes_only_uploaded_safe_oldest_first() {
         let tmp = TempDir::new().unwrap();
-        let active = create_file(tmp.path(), "active.log", 200);
-        let processed = create_file(tmp.path(), "done.log", 200);
-        set_mtime(&processed, 100);
+        let active = create_file(tmp.path(), "active.log", 100);
+        let unup = create_file(tmp.path(), "unup.log", 100);
+        let up_old = create_file(tmp.path(), "up_old.log", 100);
+        let up_mid = create_file(tmp.path(), "up_mid.log", 100);
+        set_mtime(&active, 10);
+        set_mtime(&unup, 50);
+        set_mtime(&up_mid, 200);
+        set_mtime(&up_old, 300);
+        let last_ts = ts_ms_secs_ago(150);
 
-        // total=400, limit=250 → need 150 freed, but only processed is deletable
-        let deleted = free_disk_space(tmp.path(), &log_pattern(), 250, &[processed.clone()]);
-        assert_eq!(deleted, vec![processed]);
-        assert!(active.exists(), "active file must not be deleted");
+        // total=400, limit=250 → reclaim the two uploaded-safe files.
+        let outcome =
+            enforce_disk_limit(tmp.path(), &log_pattern(), 250, last_ts, untracked, false);
+
+        assert_eq!(
+            outcome.uploaded_deleted,
+            vec![up_old.clone(), up_mid.clone()]
+        );
+        assert!(outcome.unuploaded_deleted.is_empty());
+        assert!(!up_old.exists() && !up_mid.exists());
+        assert!(active.exists(), "active file must never be deleted");
+        assert!(
+            unup.exists(),
+            "un-uploaded file must not be deleted by default"
+        );
     }
 
+    // T2 (opt-in): still over after uploaded-safe removed → deletes oldest un-uploaded.
+    // Asserts a file with mtime > last_ts (un-uploaded) is deleted — the differentiator.
     #[test]
-    fn handles_missing_files_gracefully() {
+    fn enforce_deletes_unuploaded_when_still_over_and_opted_in() {
         let tmp = TempDir::new().unwrap();
-        let exists = create_file(tmp.path(), "exists.log", 200);
-        let ghost = tmp.path().join("ghost.log");
-        set_mtime(&exists, 50);
+        let active = create_file(tmp.path(), "active.log", 100);
+        let unup = create_file(tmp.path(), "unup.log", 100);
+        let up_old = create_file(tmp.path(), "up_old.log", 100);
+        let up_mid = create_file(tmp.path(), "up_mid.log", 100);
+        set_mtime(&active, 10);
+        set_mtime(&unup, 50);
+        set_mtime(&up_mid, 200);
+        set_mtime(&up_old, 300);
+        let last_ts = ts_ms_secs_ago(150);
 
-        // total=200, limit=50 → need to free 150
-        let deleted = free_disk_space(tmp.path(), &log_pattern(), 50, &[ghost, exists.clone()]);
-        assert_eq!(deleted, vec![exists]);
+        // total=400, limit=150 → reclaim both uploaded-safe, then the oldest un-uploaded.
+        let outcome = enforce_disk_limit(tmp.path(), &log_pattern(), 150, last_ts, untracked, true);
+
+        assert_eq!(outcome.uploaded_deleted, vec![up_old, up_mid]);
+        assert_eq!(outcome.unuploaded_deleted, vec![unup.clone()]);
+        assert!(
+            !unup.exists(),
+            "un-uploaded (mtime>last_ts) file should be deleted when opted in"
+        );
+        assert!(active.exists(), "active file must never be deleted");
     }
 
+    // T3: a single active file alone exceeds the limit → nothing deleted, no thrash/panic.
     #[test]
-    fn empty_processed_files_is_noop() {
+    fn enforce_single_active_file_over_limit_deletes_nothing() {
         let tmp = TempDir::new().unwrap();
-        create_file(tmp.path(), "a.log", 1000);
+        let active = create_file(tmp.path(), "active.log", 1000);
+        set_mtime(&active, 10);
 
-        let deleted = free_disk_space(tmp.path(), &log_pattern(), 10, &[]);
-        assert!(deleted.is_empty());
+        let outcome = enforce_disk_limit(tmp.path(), &log_pattern(), 100, 0, untracked, true);
+
+        assert!(outcome.uploaded_deleted.is_empty());
+        assert!(outcome.unuploaded_deleted.is_empty());
+        assert!(active.exists());
     }
 
+    // T4 (negative): under limit → no-op regardless of classification.
     #[test]
-    fn all_files_deleted_when_way_over_limit() {
+    fn enforce_noop_when_under_limit() {
         let tmp = TempDir::new().unwrap();
-        let f1 = create_file(tmp.path(), "a.log", 500);
-        let f2 = create_file(tmp.path(), "b.log", 500);
-        let f3 = create_file(tmp.path(), "c.log", 500);
-        set_mtime(&f1, 300);
-        set_mtime(&f2, 200);
-        set_mtime(&f3, 100);
+        let a = create_file(tmp.path(), "a.log", 100);
+        let b = create_file(tmp.path(), "b.log", 100);
+        set_mtime(&a, 200);
+        set_mtime(&b, 100);
 
-        // total=1500, limit=100 → need 1400 freed → all 3 deleted
-        let deleted = free_disk_space(
+        let outcome = enforce_disk_limit(
             tmp.path(),
             &log_pattern(),
-            100,
-            &[f1.clone(), f2.clone(), f3.clone()],
+            1000,
+            ts_ms_secs_ago(50),
+            untracked,
+            true,
         );
-        assert_eq!(deleted.len(), 3);
-        assert!(!f1.exists());
-        assert!(!f2.exists());
-        assert!(!f3.exists());
+
+        assert_eq!(outcome, EnforceOutcome::default());
+        assert!(a.exists() && b.exists());
     }
 
+    // A file with mtime <= last_ts but still tracked in the checkpoint is classified
+    // un-uploaded (in-progress), so the default (uploaded-safe only) pass must not delete it.
     #[test]
-    fn zero_limit_deletes_all_processed() {
+    fn enforce_tracked_file_is_not_uploaded_safe() {
         let tmp = TempDir::new().unwrap();
-        let f1 = create_file(tmp.path(), "a.log", 100);
-        let f2 = create_file(tmp.path(), "b.log", 200);
-        set_mtime(&f1, 200);
-        set_mtime(&f2, 100);
+        let active = create_file(tmp.path(), "active.log", 100);
+        let tracked = create_file(tmp.path(), "tracked.log", 100);
+        let untracked_old = create_file(tmp.path(), "untracked.log", 100);
+        set_mtime(&active, 10);
+        set_mtime(&untracked_old, 250);
+        set_mtime(&tracked, 300);
+        let last_ts = ts_ms_secs_ago(150);
 
-        let deleted = free_disk_space(tmp.path(), &log_pattern(), 0, &[f1.clone(), f2.clone()]);
-        assert_eq!(deleted.len(), 2);
-        assert!(!f1.exists());
-        assert!(!f2.exists());
+        let tracked_path = tracked.clone();
+        // total=300, limit=150, default pass. Only the untracked old file is uploaded-safe.
+        let outcome = enforce_disk_limit(
+            tmp.path(),
+            &log_pattern(),
+            150,
+            last_ts,
+            move |p| p == tracked_path.as_path(),
+            false,
+        );
+
+        assert_eq!(outcome.uploaded_deleted, vec![untracked_old.clone()]);
+        assert!(outcome.unuploaded_deleted.is_empty());
+        assert!(!untracked_old.exists());
+        assert!(
+            tracked.exists(),
+            "tracked (in-progress) file must not be deleted"
+        );
+        assert!(active.exists());
     }
 
+    // Missing directory is a safe no-op (nothing to enumerate).
+    #[test]
+    fn enforce_missing_directory_is_noop() {
+        let missing = Path::new("/nonexistent/path/enforce/12345");
+        let outcome = enforce_disk_limit(missing, &log_pattern(), 0, 0, untracked, true);
+        assert_eq!(outcome, EnforceOutcome::default());
+    }
+
+    // Files matching the pattern total under the limit even though a non-matching file
+    // inflates the directory → no-op (only matching files count toward the limit).
+    #[test]
+    fn enforce_pattern_filter_excludes_non_matching_files() {
+        let tmp = TempDir::new().unwrap();
+        // Non-log file inflates the directory but must not count toward the limit.
+        create_file(tmp.path(), "config.json", 1000);
+        let log_file = create_file(tmp.path(), "app.log", 100);
+        set_mtime(&log_file, 100);
+
+        // Only 100 bytes of .log files → under the 200-byte limit → nothing deleted.
+        let outcome = enforce_disk_limit(
+            tmp.path(),
+            &log_pattern(),
+            200,
+            ts_ms_secs_ago(50),
+            untracked,
+            true,
+        );
+
+        assert_eq!(outcome, EnforceOutcome::default());
+        assert!(log_file.exists());
+    }
+
+    // Undeletable files (read-only directory) are skipped without panicking; the outcome
+    // reports nothing deleted because the unlink failed.
     #[cfg(unix)]
     #[test]
-    fn skips_undeletable_files() {
+    fn enforce_skips_undeletable_files() {
         use std::os::unix::fs::PermissionsExt;
 
-        // Skip if running as root (root ignores permission bits)
+        // Skip if running as root (root ignores permission bits).
         if std::process::Command::new("id")
             .arg("-u")
             .output()
@@ -242,37 +416,30 @@ mod tests {
         }
 
         let tmp = TempDir::new().unwrap();
-        let f1 = create_file(tmp.path(), "a.log", 200);
-        let f2 = create_file(tmp.path(), "b.log", 200);
-        set_mtime(&f1, 200);
-        set_mtime(&f2, 100);
+        let active = create_file(tmp.path(), "active.log", 200);
+        let old = create_file(tmp.path(), "old.log", 200);
+        set_mtime(&active, 10);
+        set_mtime(&old, 200);
 
-        // Make directory read-only so files can't be deleted
-        let dir_perms = fs::Permissions::from_mode(0o555);
-        fs::set_permissions(tmp.path(), dir_perms).unwrap();
+        // Make the directory read-only so files cannot be unlinked.
+        fs::set_permissions(tmp.path(), fs::Permissions::from_mode(0o555)).unwrap();
 
-        // total=400, limit=0 → wants to delete all, but can't
-        let deleted = free_disk_space(tmp.path(), &log_pattern(), 0, &[f1.clone(), f2.clone()]);
-        assert!(deleted.is_empty());
-        assert!(f1.exists());
-        assert!(f2.exists());
+        // total=400, limit=100, opted in → wants to delete `old`, but cannot.
+        let outcome = enforce_disk_limit(
+            tmp.path(),
+            &log_pattern(),
+            100,
+            ts_ms_secs_ago(50),
+            untracked,
+            true,
+        );
 
-        // Restore permissions for cleanup
-        let restore_perms = fs::Permissions::from_mode(0o755);
-        fs::set_permissions(tmp.path(), restore_perms).unwrap();
-    }
+        assert!(outcome.uploaded_deleted.is_empty());
+        assert!(outcome.unuploaded_deleted.is_empty());
+        assert!(old.exists());
+        assert!(active.exists());
 
-    #[test]
-    fn pattern_filter_excludes_non_matching_files() {
-        let tmp = TempDir::new().unwrap();
-        // Non-log file inflates directory but shouldn't count toward limit
-        create_file(tmp.path(), "config.json", 1000);
-        let log_file = create_file(tmp.path(), "app.log", 100);
-        set_mtime(&log_file, 100);
-
-        // dir has 1100 bytes total, but only 100 bytes of .log files → under limit
-        let deleted = free_disk_space(tmp.path(), &log_pattern(), 200, &[log_file.clone()]);
-        assert!(deleted.is_empty());
-        assert!(log_file.exists());
+        // Restore permissions so the TempDir can be cleaned up.
+        fs::set_permissions(tmp.path(), fs::Permissions::from_mode(0o755)).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,15 +7,16 @@
 //! Tails log files and EMF JSON files, uploads to CloudWatch Logs.
 
 use gg_log_manager::config::{
-    derive_log_group_name, load_config, validate_config, ConfigError, LogLevel, LogManagerConfig,
-    LogSourceConfig,
+    derive_log_group_name, effective_disk_limit_bytes, load_config, validate_config, ConfigError,
+    LogLevel, LogManagerConfig, LogSourceConfig, LogsUploaderConfig,
 };
 use gg_log_manager::credentials::resolve_thing_name;
 #[cfg(feature = "gg-ipc")]
 use gg_log_manager::ipc_config::{connect_ipc, read_config};
 use gg_log_manager::scanner::{
     assemble_multiline, load_checkpoint, read_file_from_offset, recover_offsets, save_checkpoint,
-    scan_directory, trim_stale_on_load, CheckpointStore, LogEvent, ScannedFile,
+    scan_directory, trim_stale_on_load, CheckpointStore, LogEvent, ScanDirectoryResult,
+    ScannedFile,
 };
 use gg_log_manager::uploader::{
     advance_checkpoints, complete_file, effective_interval_secs, evict_stale_entries,
@@ -23,6 +24,7 @@ use gg_log_manager::uploader::{
     TTL_24H_MS,
 };
 use regex::Regex;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
@@ -373,7 +375,17 @@ async fn process_all_sources(
                 continue;
             }
         };
-        if process_source(source, &log_group, &pattern, client, store, thing_name, now).await
+        if process_source(
+            source,
+            &config.logs_uploader_configuration,
+            &log_group,
+            &pattern,
+            client,
+            store,
+            thing_name,
+            now,
+        )
+        .await
             == CycleOutcome::StopForAuth
         {
             // Auth failure — stop the cycle so credentials can refresh before the next pass.
@@ -383,11 +395,14 @@ async fn process_all_sources(
     CycleOutcome::Continue
 }
 
-/// Process a single log source: scan → read → batch → upload → checkpoint → disk.
+/// Process a single log source: scan → read → batch → upload → checkpoint, then enforce the
+/// disk limit for the source every cycle.
 // Uses blocking std::fs; safe only on the current_thread runtime (switch to tokio::fs if that changes).
 #[cfg(not(tarpaulin_include))]
+#[allow(clippy::too_many_arguments)]
 async fn process_source(
     source: &LogSourceConfig,
+    uploader_config: &LogsUploaderConfig,
     log_group: &str,
     pattern: &Regex,
     client: &mut CwLogsClient,
@@ -395,40 +410,88 @@ async fn process_source(
     thing_name: &str,
     now: u64,
 ) -> CycleOutcome {
-    let scanned_files = match scan_and_filter_files(source, log_group, pattern, store) {
-        Some(files) => files,
-        None => return CycleOutcome::Continue,
+    // A scan error yields no classification data for this cycle: we cannot tell which on-disk
+    // files were dedup-dropped (and thus un-uploaded), so enforcing the disk limit could delete
+    // never-uploaded data. Skip enforcement entirely this cycle; it resumes on the next good
+    // scan. A successful scan always yields a `ScanOutcome` (possibly with an empty `filtered`
+    // set on an idle/all-completed cycle), so enforcement still runs against the directory it
+    // enumerates itself.
+    let scan_outcome = match scan_and_filter_files(source, log_group, pattern, store) {
+        Some(o) => o,
+        None => {
+            warn!(
+                log_group,
+                "Scan failed — skipping disk enforcement this cycle (no classification data)"
+            );
+            return CycleOutcome::Continue;
+        }
     };
+    let scanned_files = scan_outcome.filtered;
+    let dedup_dropped = scan_outcome.dedup_dropped;
 
-    let file_events = read_file_events(source, log_group, &scanned_files, store);
-    if file_events.is_empty() {
-        return CycleOutcome::Continue;
+    let mut outcome = CycleOutcome::Continue;
+    if !scanned_files.is_empty() {
+        let file_events = read_file_events(source, log_group, &scanned_files, store);
+        if !file_events.is_empty() {
+            // Capture the cycle outcome (e.g. StopForAuth) — it is returned after enforcement,
+            // so a systemic auth failure still halts the rest of the cycle.
+            outcome = upload_and_advance_checkpoints(
+                source,
+                log_group,
+                client,
+                store,
+                thing_name,
+                &scanned_files,
+                file_events,
+                now,
+            )
+            .await;
+        }
     }
 
-    upload_and_advance_checkpoints(
+    // Enforce the disk limit last, every cycle — see `enforce_source_disk_limit` for the
+    // classification/ordering rationale (it runs on the StopForAuth path and idle cycles too).
+    let _ = enforce_source_disk_limit(
         source,
+        uploader_config,
         log_group,
         pattern,
-        client,
         store,
-        thing_name,
         &scanned_files,
-        file_events,
-        now,
-    )
-    .await
+        &dedup_dropped,
+    );
+
+    outcome
+}
+
+/// Result of scanning + filtering a source's directory for one cycle. Returned on every
+/// successful scan (a scan error yields `None`), so the `dedup_dropped` list survives even when
+/// `filtered` is empty — the all-completed/idle cycle (path-3) is exactly when disk enforcement
+/// still runs and must know which files were skipped as hash-duplicates.
+struct ScanOutcome {
+    /// Files to read/upload this cycle (new or mid-upload; already-completed files removed).
+    filtered: Vec<ScannedFile>,
+    /// Paths dropped by content-hash dedup (older files sharing a newer file's first-line hash).
+    /// These are never read or uploaded, so disk enforcement treats them as un-uploaded.
+    dedup_dropped: Vec<PathBuf>,
 }
 
 /// Scan the log directory for matching files, dropping already-completed files (older than the
-/// last uploaded file and not mid-upload).
+/// last uploaded file and not mid-upload). Returns `None` only on a scan error (no classification
+/// data — the caller skips enforcement); every successful scan returns a `ScanOutcome`, even when
+/// the directory is empty or every file is already completed, so the dedup-dropped list is never
+/// lost on the very cycles where enforcement runs.
 fn scan_and_filter_files(
     source: &LogSourceConfig,
     log_group: &str,
     pattern: &Regex,
     store: &CheckpointStore,
-) -> Option<Vec<ScannedFile>> {
-    let scanned_files = match scan_directory(&source.log_file_directory_path, pattern) {
-        Ok(files) => files,
+) -> Option<ScanOutcome> {
+    let ScanDirectoryResult {
+        files: scanned_files,
+        dedup_dropped,
+    } = match scan_directory(&source.log_file_directory_path, pattern) {
+        Ok(res) => res,
         Err(e) => {
             error!(directory = source.log_file_directory_path, error = %e, "Failed to scan directory");
             return None;
@@ -436,7 +499,12 @@ fn scan_and_filter_files(
     };
 
     if scanned_files.is_empty() {
-        return None;
+        // Empty directory (or all files unhashable): a valid, idle cycle. `dedup_dropped` is
+        // empty here but returned uniformly so enforcement still runs.
+        return Some(ScanOutcome {
+            filtered: Vec::new(),
+            dedup_dropped,
+        });
     }
 
     let last_ts = store
@@ -444,7 +512,7 @@ fn scan_and_filter_files(
         .get(log_group)
         .map(|t| t.last_file_processed_time_stamp)
         .unwrap_or(0);
-    let scanned_files: Vec<_> = scanned_files
+    let filtered: Vec<_> = scanned_files
         .into_iter()
         .filter(|f| {
             mtime_to_ms(f.mtime) > last_ts
@@ -455,11 +523,12 @@ fn scan_and_filter_files(
         })
         .collect();
 
-    if scanned_files.is_empty() {
-        return None;
-    }
-
-    Some(scanned_files)
+    // Path-3 (all files filtered out as completed): `filtered` is empty but `dedup_dropped` may
+    // be populated — return it so enforcement can protect the dropped files this cycle.
+    Some(ScanOutcome {
+        filtered,
+        dedup_dropped,
+    })
 }
 
 /// Read new content from each scanned file at its checkpointed offset; assemble multi-line entries.
@@ -549,14 +618,14 @@ fn read_file_events(
     file_events
 }
 
-/// Upload batched events, advance checkpoints for fully-uploaded files, delete completed
-/// files when configured, and enforce the disk-space limit.
+/// Upload batched events, advance checkpoints for fully-uploaded files, and delete completed
+/// files when configured. Disk-space enforcement is handled unconditionally by the caller
+/// (`process_source`) every cycle, so it is not done here.
 #[cfg(not(tarpaulin_include))]
 #[allow(clippy::too_many_arguments)]
 async fn upload_and_advance_checkpoints(
     source: &LogSourceConfig,
     log_group: &str,
-    pattern: &Regex,
     client: &mut CwLogsClient,
     store: &mut CheckpointStore,
     thing_name: &str,
@@ -599,41 +668,6 @@ async fn upload_and_advance_checkpoints(
                 }
             }
         }
-
-        // Disk enforcement runs only after a successful upload and only deletes fully-uploaded files.
-        // TODO: if over the disk limit but the upload did not complete, nothing is freed this
-        // cycle (only uploaded files are deletable); revisiting this trade-off is future work.
-        if let Some(limit_str) = source.disk_space_limit.as_deref() {
-            if let Ok(limit_val) = limit_str.parse::<u64>() {
-                let limit_bytes = source.disk_space_limit_unit.to_bytes(limit_val);
-                let last_ts = store
-                    .last_processed_timestamps
-                    .get(log_group)
-                    .map(|t| t.last_file_processed_time_stamp)
-                    .unwrap_or(0);
-                let all_eligible: Vec<PathBuf> = scanned_files
-                    .iter()
-                    .filter(|f| !f.is_active)
-                    .filter(|f| mtime_to_ms(f.mtime) <= last_ts)
-                    .map(|f| f.path.clone())
-                    .collect();
-                let deleted = gg_log_manager::disk::free_disk_space(
-                    Path::new(&source.log_file_directory_path),
-                    pattern,
-                    limit_bytes,
-                    &all_eligible,
-                );
-                if !deleted.is_empty() {
-                    if let Some(file_map) = store.file_processing_info.get_mut(log_group) {
-                        for del_path in &deleted {
-                            if let Some(sf) = scanned_files.iter().find(|f| f.path == *del_path) {
-                                file_map.remove(&sf.content_hash);
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 
     // Evict stale checkpoint entries each cycle so the checkpoint doesn't grow unbounded as files rotate.
@@ -648,6 +682,79 @@ async fn upload_and_advance_checkpoints(
     }
 
     CycleOutcome::Continue
+}
+
+/// Enforce the source's disk limit and drop checkpoint entries for any deleted files. Single
+/// home for the disk-enforcement rationale; call sites point here instead of repeating it.
+///
+/// Runs unconditionally at the end of every `process_source` cycle — idle cycles, upload
+/// outages, and the `StopForAuth` path included (local filesystem op, no credentials) — and
+/// must run LAST so it observes the freshly advanced `last_processed_timestamps`. The limit
+/// and flag are resolved per cycle (live config changes apply next cycle); `None` means the
+/// source is unbounded by explicit customer choice and enforcement is skipped. Dedup-dropped
+/// files are classified un-uploaded (protected by default), never silently reclaimed by mtime.
+fn enforce_source_disk_limit(
+    source: &LogSourceConfig,
+    uploader_config: &LogsUploaderConfig,
+    log_group: &str,
+    pattern: &Regex,
+    store: &mut CheckpointStore,
+    scanned_files: &[ScannedFile],
+    dedup_dropped: &[PathBuf],
+) -> gg_log_manager::disk::EnforceOutcome {
+    let Some(limit_bytes) = effective_disk_limit_bytes(source, uploader_config) else {
+        // Unbounded — neither the source nor the component-level default set a limit. This is an
+        // explicit customer choice, so do no enforcement (and emit no WARN).
+        return gg_log_manager::disk::EnforceOutcome::default();
+    };
+    let last_ts = store
+        .last_processed_timestamps
+        .get(log_group)
+        .map(|t| t.last_file_processed_time_stamp)
+        .unwrap_or(0);
+
+    // Paths still tracked (mid-upload) for this group, matched by content hashes already in the
+    // checkpoint — no re-hashing.
+    let tracked_paths: HashSet<PathBuf> = store
+        .file_processing_info
+        .get(log_group)
+        .map(|m| {
+            scanned_files
+                .iter()
+                .filter(|f| m.contains_key(&f.content_hash))
+                .map(|f| f.path.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Dedup-skipped files were never read or uploaded — fold them into the `is_tracked` guard so
+    // they classify as un-uploaded (protected by default, sheddable under the opt-in flag). Both
+    // sides derive paths from `entry.path()` on the same directory, so membership checks line up.
+    let dropped_paths: HashSet<PathBuf> = dedup_dropped.iter().cloned().collect();
+
+    let outcome = gg_log_manager::disk::enforce_disk_limit(
+        Path::new(&source.log_file_directory_path),
+        pattern,
+        limit_bytes,
+        last_ts,
+        |p| tracked_paths.contains(p) || dropped_paths.contains(p),
+        source.delete_unuploaded_files_on_disk_pressure,
+    );
+
+    // Drop checkpoint entries for every deleted file (uploaded-safe and un-uploaded).
+    if let Some(file_map) = store.file_processing_info.get_mut(log_group) {
+        for del_path in outcome
+            .uploaded_deleted
+            .iter()
+            .chain(&outcome.unuploaded_deleted)
+        {
+            if let Some(sf) = scanned_files.iter().find(|f| f.path == *del_path) {
+                file_map.remove(&sf.content_hash);
+            }
+        }
+    }
+
+    outcome
 }
 
 fn parse_arg(args: &[String], flag: &str) -> Option<String> {
@@ -868,6 +975,7 @@ mod tests {
             disk_space_limit: None,
             disk_space_limit_unit: DiskSpaceLimitUnit::KB,
             delete_log_file_after_cloud_upload: false,
+            delete_unuploaded_files_on_disk_pressure: false,
             multi_line_start_pattern: None,
             upload_interval_sec: None,
         }
@@ -1124,17 +1232,20 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_and_filter_empty_dir_returns_none() {
+    fn test_scan_and_filter_empty_dir_returns_empty_outcome() {
         let dir = tempfile::tempdir().unwrap();
         let store = CheckpointStore::default();
         let pattern = Regex::new(r".*\.log$").unwrap();
         let result =
             scan_and_filter_files(&mk_source(dir.path(), r".*\.log$"), "grp", &pattern, &store);
-        assert!(result.is_none());
+        // Empty dir is a valid (idle) scan: Some with nothing to upload and nothing dropped.
+        let outcome = result.expect("empty dir is a successful scan, not an error");
+        assert!(outcome.filtered.is_empty());
+        assert!(outcome.dedup_dropped.is_empty());
     }
 
     #[test]
-    fn test_scan_and_filter_all_old_returns_none() {
+    fn test_scan_and_filter_all_old_returns_empty_filtered() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("old.log");
         std::fs::write(&path, "old data\n").unwrap();
@@ -1152,7 +1263,10 @@ mod tests {
         let pattern = Regex::new(r".*\.log$").unwrap();
         let result =
             scan_and_filter_files(&mk_source(dir.path(), r".*\.log$"), "grp", &pattern, &store);
-        assert!(result.is_none());
+        // All files filtered out as completed → Some with empty filtered (path-3), no collisions.
+        let outcome = result.expect("all-completed is a successful scan, not an error");
+        assert!(outcome.filtered.is_empty());
+        assert!(outcome.dedup_dropped.is_empty());
     }
 
     #[test]
@@ -1167,7 +1281,7 @@ mod tests {
         let pattern = Regex::new(r".*\.log$").unwrap();
         let result =
             scan_and_filter_files(&mk_source(dir.path(), r".*\.log$"), "grp", &pattern, &store);
-        let files = result.expect("new file should be kept");
+        let files = result.expect("new file should be kept").filtered;
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, path);
     }
@@ -1204,8 +1318,482 @@ mod tests {
         let pattern = Regex::new(r".*\.log$").unwrap();
         let result =
             scan_and_filter_files(&mk_source(dir.path(), r".*\.log$"), "grp", &pattern, &store);
-        let files = result.expect("checkpointed old file should be kept");
+        let files = result
+            .expect("checkpointed old file should be kept")
+            .filtered;
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].content_hash, hash);
+    }
+
+    // ---- enforce_source_disk_limit (synchronous, client-free) ----
+
+    // Idle cycle: scanned_files is empty (the scan returned None), yet a directory over its
+    // configured limit is still reclaimed. Older files at/below last_ts are uploaded-safe and
+    // deleted by the default pass; the newest (active) file is preserved. This is the headline
+    // behavior — enforcement no longer depends on a successful upload having happened.
+    #[test]
+    fn test_enforce_source_disk_limit_reclaims_on_idle_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let old1 = dir.path().join("old1.log");
+        let old2 = dir.path().join("old2.log");
+        let active = dir.path().join("active.log");
+        std::fs::write(&old1, vec![b'a'; 1000]).unwrap();
+        std::fs::write(&old2, vec![b'b'; 1000]).unwrap();
+        std::fs::write(&active, vec![b'c'; 1000]).unwrap();
+        set_file_mtime_ms(&old1, 1_000);
+        set_file_mtime_ms(&old2, 2_000);
+        set_file_mtime_ms(&active, 9_000);
+
+        let mut source = mk_source(dir.path(), r".*\.log$");
+        source.disk_space_limit = Some("1".to_string()); // 1 KB = 1024 bytes; total is 3000
+
+        // last_ts is after both old files' mtimes → they are uploaded-safe (and untracked).
+        let mut store = CheckpointStore::default();
+        store.last_processed_timestamps.insert(
+            "grp".to_string(),
+            LastFileProcessedTimestamp {
+                last_file_processed_time_stamp: 5_000,
+            },
+        );
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let _ = enforce_source_disk_limit(
+            &source,
+            &LogsUploaderConfig::default(),
+            "grp",
+            &pattern,
+            &mut store,
+            &[],
+            &[],
+        );
+
+        assert!(!old1.exists(), "oldest uploaded-safe file reclaimed");
+        assert!(!old2.exists(), "second uploaded-safe file reclaimed");
+        assert!(active.exists(), "active (newest) file must be preserved");
+    }
+
+    // A source with no own diskSpaceLimit is bounded by the component-level defaultDiskSpaceLimit
+    // when one is set: older uploaded-safe files are reclaimed at the customer's default bound.
+    #[test]
+    fn test_enforce_source_disk_limit_component_default_applies_when_source_unset() {
+        let dir = tempfile::tempdir().unwrap();
+        let old1 = dir.path().join("old1.log");
+        let old2 = dir.path().join("old2.log");
+        let active = dir.path().join("active.log");
+        std::fs::write(&old1, vec![b'a'; 1000]).unwrap();
+        std::fs::write(&old2, vec![b'b'; 1000]).unwrap();
+        std::fs::write(&active, vec![b'c'; 1000]).unwrap();
+        set_file_mtime_ms(&old1, 1_000);
+        set_file_mtime_ms(&old2, 2_000);
+        set_file_mtime_ms(&active, 9_000);
+
+        // Source sets no limit; the component-level default (1 KB) bounds it. Total is 3000.
+        let source = mk_source(dir.path(), r".*\.log$");
+        let uploader = LogsUploaderConfig {
+            default_disk_space_limit: Some("1".to_string()),
+            default_disk_space_limit_unit: DiskSpaceLimitUnit::KB,
+            ..Default::default()
+        };
+
+        // last_ts after the old files' mtimes → they are uploaded-safe.
+        let mut store = CheckpointStore::default();
+        store.last_processed_timestamps.insert(
+            "grp".to_string(),
+            LastFileProcessedTimestamp {
+                last_file_processed_time_stamp: 5_000,
+            },
+        );
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let _ =
+            enforce_source_disk_limit(&source, &uploader, "grp", &pattern, &mut store, &[], &[]);
+
+        assert!(
+            !old1.exists() && !old2.exists(),
+            "component default bounds the unconfigured source"
+        );
+        assert!(active.exists(), "active (newest) file must be preserved");
+    }
+
+    // When neither the source nor the component sets a limit, the source is unbounded: no
+    // enforcement runs and nothing is deleted, even far over any hypothetical limit.
+    #[test]
+    fn test_enforce_source_disk_limit_unbounded_when_neither_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.log");
+        let b = dir.path().join("b.log");
+        std::fs::write(&a, vec![b'a'; 10_000]).unwrap();
+        std::fs::write(&b, vec![b'b'; 10_000]).unwrap();
+        set_file_mtime_ms(&a, 1_000);
+        set_file_mtime_ms(&b, 2_000);
+
+        let source = mk_source(dir.path(), r".*\.log$"); // no diskSpaceLimit
+        let uploader = LogsUploaderConfig::default(); // no defaultDiskSpaceLimit
+
+        let mut store = CheckpointStore::default();
+        store.last_processed_timestamps.insert(
+            "grp".to_string(),
+            LastFileProcessedTimestamp {
+                last_file_processed_time_stamp: 5_000,
+            },
+        );
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let outcome =
+            enforce_source_disk_limit(&source, &uploader, "grp", &pattern, &mut store, &[], &[]);
+
+        assert_eq!(
+            outcome,
+            gg_log_manager::disk::EnforceOutcome::default(),
+            "unbounded source: enforcement is skipped"
+        );
+        assert!(
+            a.exists() && b.exists(),
+            "nothing deleted when neither limit is set"
+        );
+    }
+
+    // A source's own diskSpaceLimit takes precedence over the component default: with a generous
+    // source limit (not exceeded) nothing is deleted, even though the tiny component default would
+    // have triggered a reclaim.
+    #[test]
+    fn test_enforce_source_disk_limit_source_limit_overrides_component_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.log");
+        let b = dir.path().join("b.log");
+        let active = dir.path().join("active.log");
+        std::fs::write(&a, vec![b'a'; 1000]).unwrap();
+        std::fs::write(&b, vec![b'b'; 1000]).unwrap();
+        std::fs::write(&active, vec![b'c'; 1000]).unwrap();
+        set_file_mtime_ms(&a, 1_000);
+        set_file_mtime_ms(&b, 2_000);
+        set_file_mtime_ms(&active, 9_000);
+
+        // Source limit is 1 MB (> 3000 total → not exceeded); the component default is 1 KB
+        // (would delete were it applied). Source limit wins → no deletion.
+        let mut source = mk_source(dir.path(), r".*\.log$");
+        source.disk_space_limit = Some("1".to_string());
+        source.disk_space_limit_unit = DiskSpaceLimitUnit::MB;
+        let uploader = LogsUploaderConfig {
+            default_disk_space_limit: Some("1".to_string()),
+            default_disk_space_limit_unit: DiskSpaceLimitUnit::KB,
+            ..Default::default()
+        };
+
+        let mut store = CheckpointStore::default();
+        store.last_processed_timestamps.insert(
+            "grp".to_string(),
+            LastFileProcessedTimestamp {
+                last_file_processed_time_stamp: 5_000,
+            },
+        );
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let outcome =
+            enforce_source_disk_limit(&source, &uploader, "grp", &pattern, &mut store, &[], &[]);
+
+        assert_eq!(
+            outcome,
+            gg_log_manager::disk::EnforceOutcome::default(),
+            "source limit not exceeded → nothing deleted (source limit overrides the default)"
+        );
+        assert!(a.exists() && b.exists() && active.exists());
+    }
+
+    // Scoping guard: a dedup-dropped file whose mtime is at/below last_ts would classify as
+    // uploaded-safe by mtime alone, but because it is in the dropped set it is routed to the
+    // un-uploaded bucket — preserved by default, and shed only under the opt-in flag. This pins
+    // that the dropped-set term (not just mtime) drives the classification.
+    #[test]
+    fn test_enforce_source_disk_limit_dedup_dropped_protected_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let dropped = dir.path().join("dropped.log");
+        let active = dir.path().join("active.log");
+        std::fs::write(&dropped, vec![b'a'; 1000]).unwrap();
+        std::fs::write(&active, vec![b'b'; 1000]).unwrap();
+        set_file_mtime_ms(&dropped, 1_000); // older
+        set_file_mtime_ms(&active, 9_000); // newest → active
+
+        let mut source = mk_source(dir.path(), r".*\.log$");
+        source.disk_space_limit = Some("1".to_string()); // 1 KB; total is 2000 → over limit
+
+        let mut store = CheckpointStore::default();
+        // last_ts is after the dropped file's mtime → it WOULD be uploaded-safe absent the fix.
+        store.last_processed_timestamps.insert(
+            "grp".to_string(),
+            LastFileProcessedTimestamp {
+                last_file_processed_time_stamp: 5_000,
+            },
+        );
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        // scanned_files empty (the dropped file was deduped away, so it never reaches the scan
+        // set); the dropped path is supplied via the dedup_dropped list.
+        let _ = enforce_source_disk_limit(
+            &source,
+            &LogsUploaderConfig::default(),
+            "grp",
+            &pattern,
+            &mut store,
+            &[],
+            std::slice::from_ref(&dropped),
+        );
+
+        assert!(
+            dropped.exists(),
+            "dedup-dropped file must be preserved by default despite mtime <= last_ts"
+        );
+        assert!(active.exists(), "active (newest) file is always preserved");
+
+        // With the opt-in flag it is shed as un-uploaded (phase 2), not uploaded-safe.
+        source.delete_unuploaded_files_on_disk_pressure = true;
+        let _ = enforce_source_disk_limit(
+            &source,
+            &LogsUploaderConfig::default(),
+            "grp",
+            &pattern,
+            &mut store,
+            &[],
+            std::slice::from_ref(&dropped),
+        );
+        assert!(
+            !dropped.exists(),
+            "dedup-dropped file is sheddable under the opt-in flag"
+        );
+        assert!(active.exists(), "active (newest) file is still preserved");
+    }
+
+    // Create a colliding log file: identical first line (so all share one content hash) plus a
+    // distinct-length filler after the newline (distinct sizes, still hash-equal).
+    fn write_collision_file(
+        dir: &Path,
+        name: &str,
+        filler: u8,
+        filler_len: usize,
+        mtime_ms: u64,
+    ) -> PathBuf {
+        let path = dir.join(name);
+        let mut content = b"shared first line\n".to_vec();
+        content.extend(std::iter::repeat_n(filler, filler_len));
+        std::fs::write(&path, &content).unwrap();
+        set_file_mtime_ms(&path, mtime_ms);
+        path
+    }
+
+    // T-A: five files sharing a first line (→ one content hash), so scan dedup keeps the newest
+    // (active) and drops the other four. Driven end-to-end through scan_and_filter_files (which
+    // produces the real dedup-dropped list) → enforce_source_disk_limit. In DEFAULT mode the four
+    // dropped files are classified un-uploaded and preserved across every cycle even though their
+    // mtimes are <= last_ts (they would be uploaded-safe by mtime alone); the directory stays
+    // over its limit (the documented, WARNed boundedness exception).
+    #[test]
+    fn collision_workload_default_mode_preserves_unuploaded() {
+        let dir = tempfile::tempdir().unwrap();
+        let d1 = write_collision_file(dir.path(), "d1.log", b'a', 982, 1_000); // 1000 bytes
+        let d2 = write_collision_file(dir.path(), "d2.log", b'b', 1082, 2_000); // 1100
+        let d3 = write_collision_file(dir.path(), "d3.log", b'c', 1182, 3_000); // 1200
+        let d4 = write_collision_file(dir.path(), "d4.log", b'd', 1282, 4_000); // 1300
+        let active = write_collision_file(dir.path(), "active.log", b'e', 1382, 9_000); // 1400
+        let dropped_paths = [&d1, &d2, &d3, &d4];
+
+        let mut source = mk_source(dir.path(), r".*\.log$");
+        source.disk_space_limit = Some("3".to_string()); // 3 KiB = 3072; total is 6000 → over limit
+
+        let mut store = CheckpointStore::default();
+        // last_ts after the four dropped files' mtimes → without the dedup-dropped protection they
+        // would classify uploaded-safe and be reclaimed.
+        store.last_processed_timestamps.insert(
+            "grp".to_string(),
+            LastFileProcessedTimestamp {
+                last_file_processed_time_stamp: 5_000,
+            },
+        );
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        for cycle in 0..3 {
+            let outcome = scan_and_filter_files(&source, "grp", &pattern, &store)
+                .expect("successful scan yields a ScanOutcome");
+            // Real plumbing: dedup dropped the four older colliding files.
+            assert_eq!(
+                outcome.dedup_dropped.len(),
+                4,
+                "cycle {cycle}: four older colliding files are dedup-dropped"
+            );
+            let enforce_outcome = enforce_source_disk_limit(
+                &source,
+                &LogsUploaderConfig::default(),
+                "grp",
+                &pattern,
+                &mut store,
+                &outcome.filtered,
+                &outcome.dedup_dropped,
+            );
+            assert!(
+                enforce_outcome.uploaded_deleted.is_empty()
+                    && enforce_outcome.unuploaded_deleted.is_empty(),
+                "cycle {cycle}: default mode deletes nothing (dropped files are un-uploaded)"
+            );
+            for p in dropped_paths {
+                assert!(
+                    p.exists(),
+                    "cycle {cycle}: dropped file {p:?} must be preserved"
+                );
+            }
+            assert!(active.exists(), "cycle {cycle}: active file preserved");
+        }
+    }
+
+    // T-B: same fixture with deleteUnuploadedFilesOnDiskPressure = true. The dedup-dropped files
+    // are shed as UN-UPLOADED (phase 2 — reported in unuploaded_deleted, never uploaded_deleted),
+    // oldest-first only until under the limit, and the active (newest) file survives.
+    #[test]
+    fn collision_workload_flag_on_sheds_oldest_and_bounds_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let d1 = write_collision_file(dir.path(), "d1.log", b'a', 982, 1_000); // 1000
+        let d2 = write_collision_file(dir.path(), "d2.log", b'b', 1082, 2_000); // 1100
+        let d3 = write_collision_file(dir.path(), "d3.log", b'c', 1182, 3_000); // 1200
+        let d4 = write_collision_file(dir.path(), "d4.log", b'd', 1282, 4_000); // 1300
+        let active = write_collision_file(dir.path(), "active.log", b'e', 1382, 9_000); // 1400
+
+        let mut source = mk_source(dir.path(), r".*\.log$");
+        source.disk_space_limit = Some("3".to_string()); // 3072; total 6000
+        source.delete_unuploaded_files_on_disk_pressure = true;
+
+        let mut store = CheckpointStore::default();
+        store.last_processed_timestamps.insert(
+            "grp".to_string(),
+            LastFileProcessedTimestamp {
+                last_file_processed_time_stamp: 5_000,
+            },
+        );
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let outcome = scan_and_filter_files(&source, "grp", &pattern, &store)
+            .expect("successful scan yields a ScanOutcome");
+        assert_eq!(outcome.dedup_dropped.len(), 4);
+        let enforce_outcome = enforce_source_disk_limit(
+            &source,
+            &LogsUploaderConfig::default(),
+            "grp",
+            &pattern,
+            &mut store,
+            &outcome.filtered,
+            &outcome.dedup_dropped,
+        );
+
+        // Shed as un-uploaded, oldest-first, only until under 3072: 6000 - (1000+1100+1200) = 2700.
+        assert_eq!(
+            enforce_outcome.unuploaded_deleted,
+            vec![d1.clone(), d2.clone(), d3.clone()],
+            "oldest un-uploaded dropped files shed first"
+        );
+        assert!(
+            enforce_outcome.uploaded_deleted.is_empty(),
+            "dropped files are shed via the un-uploaded path, never uploaded-safe"
+        );
+        assert!(!d1.exists() && !d2.exists() && !d3.exists());
+        assert!(d4.exists(), "only enough shed to get under the limit");
+        assert!(active.exists(), "active (newest) file is never deleted");
+    }
+
+    // Path-3 (§8.7.1.4): a collision where the SURVIVING (newest) file is itself already
+    // completed — its mtime <= last_ts and it has no in-flight checkpoint entry — so
+    // scan_and_filter_files returns `filtered` EMPTY while `dedup_dropped` is NON-EMPTY. This is
+    // the exact cycle a future re-coupling of enforcement to a non-empty `filtered` set would
+    // break: enforcement must still run and must still protect the dropped file. Driven
+    // end-to-end (scan_and_filter_files → enforce_source_disk_limit), flag=false.
+    #[test]
+    fn path3_empty_filtered_with_dropped_preserves_dropped_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        // Two colliding files (shared first line → one content hash); older is dedup-dropped,
+        // newer survives as active. Sizes total over the limit so enforcement attempts a reclaim.
+        let older = write_collision_file(dir.path(), "older.log", b'a', 982, 1_000); // 1000 bytes
+        let newer = write_collision_file(dir.path(), "newer.log", b'b', 1082, 2_000); // 1100 bytes
+
+        let mut source = mk_source(dir.path(), r".*\.log$");
+        source.disk_space_limit = Some("1".to_string()); // 1 KiB = 1024; total 2100 → over limit
+
+        let mut store = CheckpointStore::default();
+        // last_ts is after BOTH files' mtimes (and there is no file_processing_info entry), so the
+        // surviving newer file is filtered out as completed → `filtered` is empty (path-3).
+        store.last_processed_timestamps.insert(
+            "grp".to_string(),
+            LastFileProcessedTimestamp {
+                last_file_processed_time_stamp: 5_000,
+            },
+        );
+
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let outcome = scan_and_filter_files(&source, "grp", &pattern, &store)
+            .expect("a successful scan yields Some(ScanOutcome), even when everything is filtered");
+        assert!(
+            outcome.filtered.is_empty(),
+            "surviving file is already completed → filtered is empty (path-3)"
+        );
+        assert_eq!(
+            outcome.dedup_dropped,
+            vec![older.clone()],
+            "the older colliding file is dedup-dropped (non-empty) on this same cycle"
+        );
+
+        // Enforcement still runs on path-3 and, in default mode, must protect the dropped file
+        // even though its mtime <= last_ts would otherwise class it uploaded-safe.
+        let enforce_outcome = enforce_source_disk_limit(
+            &source,
+            &LogsUploaderConfig::default(),
+            "grp",
+            &pattern,
+            &mut store,
+            &outcome.filtered,
+            &outcome.dedup_dropped,
+        );
+        assert!(
+            enforce_outcome.uploaded_deleted.is_empty()
+                && enforce_outcome.unuploaded_deleted.is_empty(),
+            "default mode deletes nothing: the dropped file is un-uploaded, not uploaded-safe"
+        );
+        assert!(
+            older.exists(),
+            "dedup-dropped file preserved by default on the path-3 cycle"
+        );
+        assert!(newer.exists(), "active (newest) file is always preserved");
+    }
+
+    // Scan-error cycle: an unreadable directory makes scan_directory return Err, so
+    // scan_and_filter_files returns None — the signal on which process_source SKIPS enforcement
+    // entirely (no classification data ⇒ no deletions). Verifies the skip trigger fires.
+    #[cfg(unix)]
+    #[test]
+    fn test_scan_and_filter_scan_error_returns_none_to_skip_enforcement() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // root ignores permission bits — skip.
+        if std::process::Command::new("id")
+            .arg("-u")
+            .output()
+            .map(|o| o.stdout.starts_with(b"0"))
+            .unwrap_or(false)
+        {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        // A file exists, so a *successful* scan would find something to act on.
+        std::fs::write(dir.path().join("app.log"), vec![b'a'; 5000]).unwrap();
+        // Make the directory unreadable so read_dir fails with a non-NotFound error.
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let source = mk_source(dir.path(), r".*\.log$");
+        let store = CheckpointStore::default();
+        let pattern = Regex::new(r".*\.log$").unwrap();
+        let result = scan_and_filter_files(&source, "grp", &pattern, &store);
+
+        // Restore permissions so the TempDir can be cleaned up.
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            result.is_none(),
+            "a scan error yields None so process_source skips disk enforcement this cycle"
+        );
     }
 }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -29,16 +29,43 @@ pub struct ScannedFile {
     pub is_active: bool,
 }
 
+/// Result of scanning a directory. Named fields (rather than a positional tuple, which this
+/// crate avoids for multi-value returns) so callers read `.files` / `.dedup_dropped` instead of
+/// `.0` / `.1`.
+#[derive(Debug)]
+pub struct ScanDirectoryResult {
+    /// Surviving files, sorted by mtime ascending, with the newest marked active.
+    pub files: Vec<ScannedFile>,
+    /// Paths of older files skipped because they share a content hash with a newer file. Handed
+    /// back (rather than discarded) so disk enforcement can treat them as un-uploaded — the
+    /// pipeline never reads or uploads a deduped-away file, so classifying it uploaded-safe by
+    /// mtime alone would risk deleting never-uploaded data.
+    pub dedup_dropped: Vec<PathBuf>,
+}
+
 /// Scan a directory for log files matching the given regex pattern.
-/// Returns files sorted by mtime ascending, with the newest marked as active.
+/// Returns a [`ScanDirectoryResult`]: `files` sorted by mtime ascending with the newest marked
+/// active, and `dedup_dropped` — paths of older files skipped for sharing a content hash with a
+/// newer file (consumed by disk enforcement, which matches on the same `entry.path()` form).
 /// TODO: Optimize to skip hashing files that haven't changed since last scan (cache by path+mtime)
-pub fn scan_directory(directory: &str, pattern: &Regex) -> std::io::Result<Vec<ScannedFile>> {
+pub fn scan_directory(directory: &str, pattern: &Regex) -> std::io::Result<ScanDirectoryResult> {
     tracing::info!(directory = %directory, "Starting directory scan");
     let dir_entries = match fs::read_dir(directory) {
         Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // A not-yet-created directory is a benign idle cycle, not an error.
+            tracing::debug!(directory = %directory, "Directory does not exist yet; treating as empty");
+            return Ok(ScanDirectoryResult {
+                files: vec![],
+                dedup_dropped: vec![],
+            });
+        }
         Err(e) => {
-            tracing::debug!(directory = %directory, error = %e, "Unable to read the directory");
-            return Ok(vec![]);
+            // A genuine read error (e.g. permission denied) means we have no reliable view of the
+            // directory this cycle; surface it so the caller can skip disk enforcement rather than
+            // act on incomplete classification data.
+            tracing::warn!(directory = %directory, error = %e, "Failed to read directory");
+            return Err(e);
         }
     };
     let mut files: Vec<(PathBuf, SystemTime)> = dir_entries
@@ -91,6 +118,7 @@ pub fn scan_directory(directory: &str, pattern: &Regex) -> std::io::Result<Vec<S
         .enumerate()
         .map(|(i, f)| (f.content_hash.clone(), i))
         .collect();
+    let mut dedup_dropped: Vec<PathBuf> = Vec::new();
     if newest_index.len() != result.len() {
         let survivor_paths: HashMap<String, PathBuf> = newest_index
             .iter()
@@ -106,6 +134,7 @@ pub fn scan_directory(directory: &str, pattern: &Regex) -> std::io::Result<Vec<S
                     kept = %kept.display(),
                     "file shares content hash with a newer file; skipping"
                 );
+                dedup_dropped.push(file.path);
             }
         }
         result = deduped;
@@ -117,7 +146,10 @@ pub fn scan_directory(directory: &str, pattern: &Regex) -> std::io::Result<Vec<S
     }
 
     tracing::info!(file_count = result.len(), "Directory scan complete");
-    Ok(result)
+    Ok(ScanDirectoryResult {
+        files: result,
+        dedup_dropped,
+    })
 }
 
 #[cfg(test)]
@@ -139,7 +171,9 @@ mod tests {
     fn test_scan_directory_empty() {
         let dir = tempfile::tempdir().unwrap();
         let pattern = Regex::new(r".*\.log$").unwrap();
-        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+        let result = scan_directory(dir.path().to_str().unwrap(), &pattern)
+            .unwrap()
+            .files;
         assert!(result.is_empty());
     }
 
@@ -151,7 +185,9 @@ mod tests {
         create_test_file(dir.path(), "other.log", b"other log");
 
         let pattern = Regex::new(r".*\.log$").unwrap();
-        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+        let result = scan_directory(dir.path().to_str().unwrap(), &pattern)
+            .unwrap()
+            .files;
 
         assert_eq!(result.len(), 2);
         assert!(result.iter().all(|f| f.path.extension().unwrap() == "log"));
@@ -168,7 +204,9 @@ mod tests {
         create_test_file(dir.path(), "new.log", b"new");
 
         let pattern = Regex::new(r".*\.log$").unwrap();
-        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+        let result = scan_directory(dir.path().to_str().unwrap(), &pattern)
+            .unwrap()
+            .files;
 
         assert_eq!(result.len(), 3);
         // Sorted by mtime ascending
@@ -186,7 +224,9 @@ mod tests {
         create_test_file(dir.path(), "only.log", b"content");
 
         let pattern = Regex::new(r".*\.log$").unwrap();
-        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+        let result = scan_directory(dir.path().to_str().unwrap(), &pattern)
+            .unwrap()
+            .files;
 
         assert_eq!(result.len(), 1);
         assert!(result[0].is_active);
@@ -198,7 +238,9 @@ mod tests {
         create_test_file(dir.path(), "test.log", b"test content");
 
         let pattern = Regex::new(r".*\.log$").unwrap();
-        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+        let result = scan_directory(dir.path().to_str().unwrap(), &pattern)
+            .unwrap()
+            .files;
 
         assert_eq!(result.len(), 1);
         assert!(!result[0].content_hash.is_empty());
@@ -208,7 +250,9 @@ mod tests {
     #[test]
     fn test_scan_directory_nonexistent_returns_empty() {
         let pattern = Regex::new(r".*\.log$").unwrap();
-        let result = scan_directory("/nonexistent/path/12345", &pattern).unwrap();
+        let result = scan_directory("/nonexistent/path/12345", &pattern)
+            .unwrap()
+            .files;
         assert!(result.is_empty());
     }
 
@@ -229,11 +273,17 @@ mod tests {
         );
 
         let pattern = Regex::new(r".*\.log$").unwrap();
-        let result = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+        let ScanDirectoryResult {
+            files: result,
+            dedup_dropped: dropped,
+        } = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
 
         // Only the newest of the two colliding files survives, and it is the active file.
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].path.file_name().unwrap(), "new.log");
         assert!(result[0].is_active);
+        // The older colliding file is reported as dedup-dropped (not silently discarded).
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(dropped[0].file_name().unwrap(), "old.log");
     }
 }

--- a/tests/checkpoint_integration_test.rs
+++ b/tests/checkpoint_integration_test.rs
@@ -24,7 +24,9 @@ fn test_scan_checkpoint_restart_resume() {
 
     // First scan
     let pattern = Regex::new(r".*\.log$").unwrap();
-    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern)
+        .unwrap()
+        .files;
     assert_eq!(files.len(), 3);
 
     // Simulate partial upload: checkpoint 2 files with offsets
@@ -49,7 +51,9 @@ fn test_scan_checkpoint_restart_resume() {
     let mut loaded = load_checkpoint(&checkpoint_path, true).unwrap();
 
     // Re-scan and recover offsets
-    let files_after_restart = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    let files_after_restart = scan_directory(dir.path().to_str().unwrap(), &pattern)
+        .unwrap()
+        .files;
     let offsets = recover_offsets(&mut loaded, "test-group", &files_after_restart);
 
     // Assert: 2 files resume from checkpointed offsets, 1 starts at 0
@@ -73,7 +77,9 @@ fn test_checkpoint_stale_entry_removed_after_file_deleted() {
 
     // Scan and checkpoint both
     let pattern = Regex::new(r".*\.log$").unwrap();
-    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern)
+        .unwrap()
+        .files;
     assert_eq!(files.len(), 2);
 
     let mut store = CheckpointStore::default();
@@ -94,7 +100,9 @@ fn test_checkpoint_stale_entry_removed_after_file_deleted() {
 
     // Re-scan (now only 1 file) and recover
     let mut loaded = load_checkpoint(&checkpoint_path, true).unwrap();
-    let files_after = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    let files_after = scan_directory(dir.path().to_str().unwrap(), &pattern)
+        .unwrap()
+        .files;
     assert_eq!(files_after.len(), 1);
 
     let offsets = recover_offsets(&mut loaded, "test-group", &files_after);

--- a/tests/scanner_test.rs
+++ b/tests/scanner_test.rs
@@ -47,7 +47,9 @@ fn test_scan_with_rotation_active_file_detection() {
     create_file_with_content(dir.path(), "c.emf.json", &[b'c'; 50]);
     // No offset needed - it's the newest
 
-    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern)
+        .unwrap()
+        .files;
 
     assert_eq!(files.len(), 3);
 
@@ -102,7 +104,9 @@ fn test_scan_rotation_renamed_file_still_scannable() {
 
     // First scan with pattern matching .emf.json
     let pattern1 = Regex::new(r".*\.emf\.json$").unwrap();
-    let files_before = scan_directory(dir.path().to_str().unwrap(), &pattern1).unwrap();
+    let files_before = scan_directory(dir.path().to_str().unwrap(), &pattern1)
+        .unwrap()
+        .files;
     assert_eq!(files_before.len(), 3);
 
     // Get hash of b before rename
@@ -118,7 +122,9 @@ fn test_scan_rotation_renamed_file_still_scannable() {
 
     // Re-scan with pattern that includes .old files
     let pattern2 = Regex::new(r".*\.emf\.json$|.*\.old$").unwrap();
-    let files_after = scan_directory(dir.path().to_str().unwrap(), &pattern2).unwrap();
+    let files_after = scan_directory(dir.path().to_str().unwrap(), &pattern2)
+        .unwrap()
+        .files;
 
     // Should still find 3 files (a.emf.json, b.old, c.emf.json)
     assert_eq!(files_after.len(), 3);
@@ -141,7 +147,9 @@ fn test_scan_content_hash_is_sha256() {
     create_file_with_content(dir.path(), "test.emf.json", b"test content");
 
     let pattern = Regex::new(r".*\.emf\.json$").unwrap();
-    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern)
+        .unwrap()
+        .files;
 
     assert_eq!(files.len(), 1);
     // SHA-256 produces 64 hex characters
@@ -158,7 +166,9 @@ fn test_scan_empty_directory() {
     let dir = TempDir::new().unwrap();
     let pattern = Regex::new(r".*\.emf\.json$").unwrap();
 
-    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern)
+        .unwrap()
+        .files;
     assert!(files.is_empty());
 }
 
@@ -168,7 +178,9 @@ fn test_scan_single_file_is_active() {
     create_file_with_content(dir.path(), "only.emf.json", b"content");
 
     let pattern = Regex::new(r".*\.emf\.json$").unwrap();
-    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern)
+        .unwrap()
+        .files;
 
     assert_eq!(files.len(), 1);
     assert!(files[0].is_active, "Single file should be marked as active");
@@ -182,7 +194,9 @@ fn test_scan_filters_by_regex() {
     create_file_with_content(dir.path(), "another.log", b"content");
 
     let pattern = Regex::new(r".*\.emf\.json$").unwrap();
-    let files = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    let files = scan_directory(dir.path().to_str().unwrap(), &pattern)
+        .unwrap()
+        .files;
 
     assert_eq!(files.len(), 1);
     assert!(files[0].path.ends_with("match.emf.json"));
@@ -200,8 +214,9 @@ fn test_scan_directory_skips_symlinks() {
         std::os::unix::fs::symlink(&real_path, dir.path().join("link.log")).unwrap();
     }
     let pattern = regex::Regex::new(r".*\.log$").unwrap();
-    let result =
-        gg_log_manager::scanner::scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    let result = gg_log_manager::scanner::scan_directory(dir.path().to_str().unwrap(), &pattern)
+        .unwrap()
+        .files;
     // Should only find the real file, not the symlink
     assert_eq!(result.len(), 1);
     assert!(result[0].path.ends_with("real.log"));

--- a/tests/upload_pipeline_test.rs
+++ b/tests/upload_pipeline_test.rs
@@ -1,0 +1,189 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for per-cycle disk enforcement over the real scan → read path.
+//!
+//! These drive the actual scanner and checkpoint types into `enforce_disk_limit`, covering
+//! the reclaim path that the (now unconditional, every-cycle) disk enforcement enables — i.e.
+//! reclaiming disk on a cycle where nothing was uploaded. The CloudWatch upload leg itself is
+//! covered by the uploader unit tests and `sdk_retry_test.rs`; here nothing is uploaded (so no
+//! checkpoint advances), which is exactly the outage/idle case.
+
+use gg_log_manager::disk::enforce_disk_limit;
+use gg_log_manager::scanner::{
+    compute_content_hash, read_file_from_offset, recover_offsets, scan_directory, CheckpointStore,
+    LogEvent, ScanDirectoryResult, ScannedFile,
+};
+use regex::Regex;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64
+}
+
+/// Write a file of exactly `size` bytes filled with `byte` (distinct fill bytes give distinct
+/// content hashes).
+fn write_sized(dir: &std::path::Path, name: &str, byte: u8, size: usize) -> PathBuf {
+    let path = dir.join(name);
+    let mut f = File::create(&path).unwrap();
+    f.write_all(&vec![byte; size]).unwrap();
+    path
+}
+
+fn set_mtime_ms(path: &std::path::Path, ms: u64) {
+    filetime::set_file_mtime(
+        path,
+        filetime::FileTime::from_unix_time((ms / 1000) as i64, ((ms % 1000) * 1_000_000) as u32),
+    )
+    .unwrap();
+}
+
+/// Build the tracked-paths set exactly as `enforce_source_disk_limit` does: scanned files whose
+/// content hash currently has a checkpoint entry for the group.
+fn tracked_paths(
+    store: &CheckpointStore,
+    group: &str,
+    scanned: &[ScannedFile],
+) -> HashSet<PathBuf> {
+    store
+        .file_processing_info
+        .get(group)
+        .map(|m| {
+            scanned
+                .iter()
+                .filter(|f| m.contains_key(&f.content_hash))
+                .map(|f| f.path.clone())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Full scan → read → enforce path with no upload (the outage / empty-`succeeded` case): a
+/// directory over its limit is still reclaimed, oldest-first, and the active (newest) file is
+/// preserved. With `last_ts = 0` every non-active file is un-uploaded, so this exercises the
+/// opt-in `deleteUnuploadedFilesOnDiskPressure` phase.
+#[test]
+fn enforcement_reclaims_over_limit_dir_without_upload() {
+    let dir = TempDir::new().unwrap();
+    let old1 = write_sized(dir.path(), "old1.log", b'a', 1000);
+    let old2 = write_sized(dir.path(), "old2.log", b'b', 1000);
+    let active = write_sized(dir.path(), "active.log", b'c', 100);
+    set_mtime_ms(&old1, 1_000);
+    set_mtime_ms(&old2, 2_000);
+    set_mtime_ms(&active, 9_000);
+
+    let pattern = Regex::new(r".*\.log$").unwrap();
+
+    // Scan → read (mirrors scan_and_filter_files + read_file_events); no CW upload occurs, so
+    // nothing is "succeeded" and no checkpoint advances — the outage scenario.
+    let scanned = scan_directory(dir.path().to_str().unwrap(), &pattern)
+        .unwrap()
+        .files;
+    assert!(!scanned.is_empty(), "scan must find files");
+    let mut store = CheckpointStore::default();
+    let offsets = recover_offsets(&mut store, "grp", &scanned);
+    for (path, offset) in &offsets {
+        let _read: (Vec<LogEvent>, u64) = read_file_from_offset(path, *offset, now_ms()).unwrap();
+    }
+
+    let tracked = tracked_paths(&store, "grp", &scanned);
+    // total = 2100 bytes, limit = 1500 → reclaim the oldest un-uploaded file only.
+    let outcome = enforce_disk_limit(dir.path(), &pattern, 1500, 0, |p| tracked.contains(p), true);
+
+    assert!(
+        outcome.unuploaded_deleted.contains(&old1),
+        "oldest file reclaimed first even though nothing was uploaded"
+    );
+    assert!(!old1.exists());
+    assert!(old2.exists(), "only enough deleted to get under the limit");
+    assert!(
+        active.exists(),
+        "active (newest) file must never be deleted"
+    );
+}
+
+/// Content-hash dedup drops older files that share a first line with a newer file. Disk
+/// enforcement must classify those dropped files as UN-UPLOADED and never reclaim them by mtime
+/// alone: the pipeline never reads or uploads a deduped-away file, so treating it as
+/// uploaded-safe could delete data that was never sent. `enforce_source_disk_limit` routes the
+/// scan's dedup-dropped set into the enforcement guard, so a dropped file stays protected in
+/// default mode even when its mtime is `<= last_ts` (i.e. when it would otherwise look
+/// uploaded-safe). It is reclaimable only when the source opts into
+/// `deleteUnuploadedFilesOnDiskPressure`, where it is shed as un-uploaded. This pins the
+/// (best-effort) contract that, by default, only files known to be uploaded are reclaimed. The
+/// active (newest) file is always preserved.
+#[test]
+fn dedup_collision_older_file_is_protected_by_default() {
+    let dir = TempDir::new().unwrap();
+
+    // Identical first line → identical content hash; distinct fill after the newline keeps the
+    // files byte-distinct but hash-equal.
+    let older = dir.path().join("older.log");
+    let newer = dir.path().join("newer.log");
+    {
+        let mut f = File::create(&older).unwrap();
+        f.write_all(b"shared first line\n").unwrap();
+        f.write_all(&vec![b'a'; 982]).unwrap(); // 1000 bytes total
+    }
+    {
+        let mut f = File::create(&newer).unwrap();
+        f.write_all(b"shared first line\n").unwrap();
+        f.write_all(&vec![b'b'; 982]).unwrap();
+    }
+    set_mtime_ms(&older, 1_000);
+    set_mtime_ms(&newer, 2_000);
+    assert_eq!(
+        compute_content_hash(&older).unwrap(),
+        compute_content_hash(&newer).unwrap(),
+        "same first line must collide on content hash"
+    );
+
+    let pattern = Regex::new(r".*\.log$").unwrap();
+    // Real plumbing: the scanner keeps the newest of the colliding pair and reports the older one
+    // as dedup-dropped (no hand-built dropped set).
+    let ScanDirectoryResult {
+        files: scanned,
+        dedup_dropped: dropped,
+    } = scan_directory(dir.path().to_str().unwrap(), &pattern).unwrap();
+    assert_eq!(scanned.len(), 1, "collision deduped to the newest file");
+    assert_eq!(scanned[0].path, newer);
+    assert_eq!(
+        dropped,
+        vec![older.clone()],
+        "older colliding file is reported dedup-dropped"
+    );
+
+    // No checkpoint entries → tracked set is empty; the dropped set carries the older file.
+    let store = CheckpointStore::default();
+    let tracked = tracked_paths(&store, "grp", &scanned);
+    let dropped_set: HashSet<PathBuf> = dropped.iter().cloned().collect();
+
+    // total = 2000, limit = 1500, last_ts = 1500 (>= older mtime). Default pass. By mtime alone
+    // the older file would be uploaded-safe; routing the dedup-dropped set into the guard (as
+    // enforce_source_disk_limit does) reclassifies it as un-uploaded, so it is protected.
+    let outcome = enforce_disk_limit(
+        dir.path(),
+        &pattern,
+        1500,
+        1_500,
+        |p| tracked.contains(p) || dropped_set.contains(p),
+        false,
+    );
+
+    assert!(
+        outcome.uploaded_deleted.is_empty() && outcome.unuploaded_deleted.is_empty(),
+        "dedup-dropped file is protected in default mode (not reclaimed as uploaded-safe)"
+    );
+    assert!(
+        older.exists(),
+        "deduped-away, never-uploaded file must not be reclaimed by default"
+    );
+    assert!(newer.exists(), "newest (active) file is always preserved");
+}


### PR DESCRIPTION
## Summary
Enforces each source's `diskSpaceLimit` on **every scan cycle** (not only after a successful upload), so already-uploaded files are reclaimed even during an upload outage. A source without its own limit can be bounded by an optional, customer-provided component-level `defaultDiskSpaceLimit`; when neither is set the source is not bounded. By default only fully-uploaded files are deleted; an opt-in `deleteUnuploadedFilesOnDiskPressure` (default `false`) additionally sheds the oldest un-uploaded files when a source is still over its limit.

## Why
Today the disk limit is only enforced after a successful upload, so during an upload outage or on idle cycles a source's directory can grow past its configured limit. On runtimes without a nucleus-managed log store (e.g. nucleus lite, where the component tails application-written `.emf`/log files that nothing else rotates), this component may be the only thing bounding those directories — an upload outage must not be able to fill the disk.

## Relationship to the Java component
The **default deletion policy is unchanged from `aws.greengrass.LogManager`**: only fully-uploaded, non-active files are ever deleted by default (`DiskSpaceManagementService` semantics — never un-uploaded data, never the active file). Three things intentionally go further, on runtime merits rather than parity: enforcement runs every cycle instead of only after a successful upload; operators can set a single component-level `defaultDiskSpaceLimit` that applies to sources without their own limit (unset everywhere = unbounded, as in the Java component); and the opt-in flag allows shedding un-uploaded files under pressure (off by default = Java behavior).

## What changed
- `src/disk/mod.rs`: new `enforce_disk_limit` — enumerates the directory itself, classifies each file (active / uploaded-safe / un-uploaded), deletes uploaded-safe oldest-first, then (opt-in) un-uploaded oldest-first, each logged at WARN. The active (newest) file is never deleted; every file is re-stat'd immediately before unlink. Replaces the list-driven `free_disk_space`.
- `src/main.rs`: enforcement runs unconditionally at the end of every `process_source` cycle — including cycles halted for credential refresh (it is a local filesystem operation). Cycles whose directory scan **failed** skip enforcement (no classification data). The upload cycle outcome is preserved.
- Files skipped by the scanner as hash-duplicates of a newer file are classified **un-uploaded** (they may not have been uploaded) and preserved by default; `scan_directory` now returns those skipped paths for this classification.
- `src/config/`: `deleteUnuploadedFilesOnDiskPressure` (accepts bool or string, like the other flags), the optional component-level `defaultDiskSpaceLimit`/`defaultDiskSpaceLimitUnit`, and `effective_disk_limit_bytes` resolving source limit → component default → unbounded (parse errors never invent a bound).
- README: disk space management section.

## Behavior notes
- **`defaultDiskSpaceLimit` applies per source** (each source without its own limit is bounded to that value individually). Leaving both unset keeps a source unbounded — matching the Java component.
- **Known edge (documented):** a directory whose files all share a first line (identical banner) dedups to one processed file; the skipped duplicates are preserved in default mode, so such a source is not bounded by default — it WARNs each cycle, and `deleteUnuploadedFilesOnDiskPressure` restores a hard bound. Recommended for high-volume or collision-prone producers.
- **Known edge (documented):** with `deleteLogFileAfterCloudUpload`, once the newer twin of a hash-duplicate is uploaded and deleted, the remaining duplicate is treated as completed on the next cycle and becomes reclaimable without having been uploaded itself — inherent to first-line content identity; strengthening that identity is tracked as follow-up work.
- Config changes to the limit or flag (including via live reload) take effect on the next cycle.
- The guarantee is best-effort: only files known to be uploaded are reclaimed by default, and enforcement pauses on cycles where the scan itself fails.

## How tested
- Unit suite for `enforce_disk_limit` (ordering, opt-in shedding, active protection, tracked/in-flight protection, pattern filter, undeletable files, missing dir); idle-cycle reclamation; the `defaultDiskSpaceLimit` resolution (component default applies when a source sets no limit, a source limit overrides it, neither set = unbounded, string and number forms); multi-cycle collision-workload tests (default preserves / flag sheds); the all-completed-scan case; scan-error skip; and integration tests driving the real scan→enforce path.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — all green.


