### PR TITLE
fix: eagerly consume CRLF line ending to prevent delete-after-upload failure

### DIFF
--- a/src/main/java/com/aws/greengrass/logmanager/PositionTrackingBufferedReader.java
+++ b/src/main/java/com/aws/greengrass/logmanager/PositionTrackingBufferedReader.java
@@ -164,6 +164,18 @@ public class PositionTrackingBufferedReader extends Reader {
                     nextChar++;
                     if (c == '\r') {
                         skipLF = true;
+                        // Eagerly consume the '\n' if it's available in the buffer.
+                        // This ensures position is accurate before readLine() returns,
+                        // so the caller's position snapshot includes the full line ending.
+                        if (nextChar >= nChars) {
+                            // '\n' may be in the next buffer fill — load it now
+                            fill();
+                        }
+                        if (nextChar < nChars && cb[nextChar] == '\n') {
+                            nextChar++;
+                            position++;
+                        }
+                        skipLF = false;
                     }
                     return str;
                 }

--- a/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
+++ b/src/test/java/com/aws/greengrass/logmanager/CloudWatchAttemptLogsProcessorTest.java
@@ -275,7 +275,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             assertEquals(MAX_NUM_OF_LOG_EVENTS, logEventsForStream1.getLogEvents().size());
             assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
             assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getStartPosition());
-            assertEquals((logEventMessageLength+2)*10000 - 1, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
+            assertEquals((logEventMessageLength+2)*10000, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
             assertEquals("TestComponent", logEventsForStream1.getComponentName());
             LocalDateTime localDateTimeNow = LocalDateTime.now(ZoneOffset.UTC);
             for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {
@@ -340,7 +340,7 @@ class CloudWatchAttemptLogsProcessorTest extends GGServiceTestUtil {
             assertEquals(991, logEventsForStream1.getLogEvents().size());
             assertTrue(logEventsForStream1.getAttemptLogFileInformationMap().containsKey(fileHash));
             assertEquals(0, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getStartPosition());
-            assertEquals(1016765, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
+            assertEquals(1016766, logEventsForStream1.getAttemptLogFileInformationMap().get(fileHash).getBytesRead());
             assertEquals("TestComponent", logEventsForStream1.getComponentName());
             LocalDateTime localDateTimeNow = LocalDateTime.now(ZoneOffset.UTC);
             for (InputLogEvent logEvent: logEventsForStream1.getLogEvents()) {


### PR DESCRIPTION
## Problem

PR #256 changed `PositionTrackingBufferedReader` to count UTF-8 bytes instead of characters. This introduced an off-by-one error for files with `\r\n` line endings.

When `readLine()` encounters `\r`, it returns the line and defers consuming the `\n` to the next `readLine()` call (via the `skipLF` flag). The byte counter increments for that `\n` inside the next call — but `CloudWatchAttemptLogsProcessor` captures `position()` *before* that call. After the last line is read, `bytesUploaded` is always 1 less than `file.length()` for CRLF files.

The deletion condition (`file.length() == bytesUploaded`) never passes. Files with `\r\n` line endings are never deleted after upload, even when `deleteLogFileAfterCloudUpload` is enabled.

**Impact**: All Windows Greengrass devices using LogManager with `deleteLogFileAfterCloudUpload=true` accumulate log files indefinitely. The UAT (LogManager-1-T2) also fails because it hardcodes `\r\n` in test files.

## Solution

Instead of deferring the `\n` consumption, eagerly consume it within the same `readLine()` call that found the `\r`. After seeing `\r`, peek at the next character in the buffer (filling if necessary). If it is `\n`, skip and count it immediately. If it is not `\n` (bare `\r`), do nothing extra.

This correctly handles all line ending styles:
- `\n` (Linux): 1 byte counted
- `\r\n` (Windows): 2 bytes counted within the same `readLine()` call
- `\r` alone (classic Mac): 1 byte counted, no phantom `\n`

## Testing

- **Unit tests**: 18/18 pass (PositionTrackingBufferedReaderTest + CloudWatchAttemptLogsProcessorTest)
- **Comprehensive position tracking test**: 16 cases covering all line ending combinations, mixed endings, buffer boundaries, no-trailing-newline, empty files — all pass on both Linux and Windows JDK
- **Full Greengrass Docker replication**: Ran real Greengrass Nucleus with buggy vs fixed LogManager JAR. Debug logging at the deletion decision point confirms:
  - Buggy: `bytesUploaded=10259, fileLength=10260` (off by 1, file never deleted)
  - Fixed: `bytesUploaded=10260, fileLength=10260` (match, file eligible for deletion)
- **UAT (LogManager-1-T2)**: Confirmed same failure on real Windows device (5 files remaining instead of 1). Fix awaiting QA cycle validation.

## Related

- Root cause: PR #256 (count UTF-8 bytes instead of chars)
- UAT failure: LogManager-1-T2 on both Linux and Windows devices